### PR TITLE
ci: add CONTEXT7_API_KEY to test workflow

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -47,3 +47,4 @@ jobs:
         run: task test
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          CONTEXT7_API_KEY: ${{ secrets.CONTEXT7_API_KEY }}


### PR DESCRIPTION
Tests require the CONTEXT7_API_KEY environment variable to run. This adds it to the CI workflow, pulling from the repository secrets.

The secret needs to be configured in the repository settings.