### PR TITLE
Extract DeepSeek test helpers to openaicompattest package

### DIFF
--- a/providers/openaicompat/deepseek_conformance_test.go
+++ b/providers/openaicompat/deepseek_conformance_test.go
@@ -1,7 +1,6 @@
 package openaicompat_test
 
 import (
-	"os"
 	"testing"
 	"time"
 
@@ -10,6 +9,7 @@ import (
 	"github.com/redpanda-data/ai-sdk-go/llm"
 	"github.com/redpanda-data/ai-sdk-go/providers/conformance"
 	"github.com/redpanda-data/ai-sdk-go/providers/openaicompat"
+	"github.com/redpanda-data/ai-sdk-go/providers/openaicompat/openaicompattest"
 )
 
 // DeepSeekFixture implements the conformance.Fixture interface for DeepSeek API.
@@ -24,15 +24,8 @@ type DeepSeekFixture struct {
 func NewDeepSeekFixture(t *testing.T) *DeepSeekFixture {
 	t.Helper()
 
-	apiKey := os.Getenv("DEEPSEEK_API_KEY")
-	if apiKey == "" {
-		t.Skip("DEEPSEEK_API_KEY not set, skipping DeepSeek conformance tests")
-	}
-
-	baseURL := os.Getenv("DEEPSEEK_BASE_URL")
-	if baseURL == "" {
-		baseURL = "https://api.deepseek.com"
-	}
+	apiKey := openaicompattest.GetDeepSeekAPIKeyOrSkipTest(t)
+	baseURL := openaicompattest.GetDeepSeekBaseURL()
 
 	// Create provider with DeepSeek base URL and extended timeout for reasoning
 	provider, err := openaicompat.NewProvider(
@@ -59,7 +52,8 @@ func NewDeepSeekFixture(t *testing.T) *DeepSeekFixture {
 	}
 
 	// Standard model (non-reasoning)
-	standardModel, err := provider.NewModel("deepseek-chat",
+	standardModel, err := provider.NewModel(
+		openaicompattest.DeepSeekDefaultStandardModel,
 		openaicompat.WithCapabilities(deepseekCaps),
 	)
 	if err != nil {
@@ -71,7 +65,7 @@ func NewDeepSeekFixture(t *testing.T) *DeepSeekFixture {
 	reasoningCaps.Reasoning = true
 
 	reasoningModel, err := provider.NewModel(
-		"deepseek-reasoner",
+		openaicompattest.DeepSeekDefaultReasoningModel,
 		openaicompat.WithCapabilities(reasoningCaps),
 	)
 	if err != nil {
@@ -94,7 +88,6 @@ func (f *DeepSeekFixture) StandardModel() llm.Model {
 }
 
 func (f *DeepSeekFixture) ReasoningModel() llm.Model {
-	// Unlike OpenAI, DeepSeek exposes reasoning traces in the Chat Completions API
 	return f.reasoningModel
 }
 

--- a/providers/openaicompat/deepseek_integration_test.go
+++ b/providers/openaicompat/deepseek_integration_test.go
@@ -2,7 +2,6 @@ package openaicompat_test
 
 import (
 	"context"
-	"os"
 	"testing"
 	"time"
 
@@ -11,6 +10,7 @@ import (
 
 	"github.com/redpanda-data/ai-sdk-go/llm"
 	"github.com/redpanda-data/ai-sdk-go/providers/openaicompat"
+	"github.com/redpanda-data/ai-sdk-go/providers/openaicompat/openaicompattest"
 )
 
 // TestDeepSeekMultiTurnReasoning verifies that reasoning traces work correctly
@@ -27,20 +27,9 @@ import (
 func TestDeepSeekMultiTurnReasoning(t *testing.T) {
 	t.Parallel()
 
-	apiKey := os.Getenv("DEEPSEEK_API_KEY")
-	if apiKey == "" {
-		t.Skip("DEEPSEEK_API_KEY not set, skipping integration test")
-	}
-
-	baseURL := os.Getenv("DEEPSEEK_BASE_URL")
-	if baseURL == "" {
-		baseURL = "https://api.deepseek.com"
-	}
-
-	modelName := os.Getenv("DEEPSEEK_MODEL")
-	if modelName == "" {
-		modelName = "deepseek-reasoner"
-	}
+	apiKey := openaicompattest.GetDeepSeekAPIKeyOrSkipTest(t)
+	baseURL := openaicompattest.GetDeepSeekBaseURL()
+	modelName := openaicompattest.GetDeepSeekModel(openaicompattest.DeepSeekDefaultReasoningModel)
 
 	// Create provider
 	provider, err := openaicompat.NewProvider(

--- a/providers/openaicompat/openaicompattest/constants.go
+++ b/providers/openaicompat/openaicompattest/constants.go
@@ -5,4 +5,11 @@ const (
 	TestModelName = "gpt-4o-mini"
 	// TestReasoningModelName is the model for reasoning tests.
 	TestReasoningModelName = "o1"
+
+	// DeepSeekDefaultBaseURL is the default API base URL for DeepSeek.
+	DeepSeekDefaultBaseURL = "https://api.deepseek.com"
+	// DeepSeekDefaultStandardModel is the default standard chat model.
+	DeepSeekDefaultStandardModel = "deepseek-chat"
+	// DeepSeekDefaultReasoningModel is the default reasoning model.
+	DeepSeekDefaultReasoningModel = "deepseek-reasoner"
 )

--- a/providers/openaicompat/openaicompattest/env.go
+++ b/providers/openaicompat/openaicompattest/env.go
@@ -17,3 +17,34 @@ func GetAPIKeyOrSkipTest(t *testing.T) string {
 
 	return key
 }
+
+// GetDeepSeekAPIKeyOrSkipTest returns the DeepSeek API key if present,
+// otherwise it skips the test.
+func GetDeepSeekAPIKeyOrSkipTest(t *testing.T) string {
+	t.Helper()
+
+	key := os.Getenv("DEEPSEEK_API_KEY")
+	if key == "" {
+		t.Skip("DEEPSEEK_API_KEY not set, skipping DeepSeek test")
+	}
+
+	return key
+}
+
+// GetDeepSeekBaseURL returns the DeepSeek base URL from environment or the default.
+func GetDeepSeekBaseURL() string {
+	if baseURL := os.Getenv("DEEPSEEK_BASE_URL"); baseURL != "" {
+		return baseURL
+	}
+
+	return DeepSeekDefaultBaseURL
+}
+
+// GetDeepSeekModel returns the DeepSeek model name from environment or the default.
+func GetDeepSeekModel(defaultModel string) string {
+	if model := os.Getenv("DEEPSEEK_MODEL"); model != "" {
+		return model
+	}
+
+	return defaultModel
+}


### PR DESCRIPTION
Move DeepSeek-specific constants and environment variable handling into the openaicompattest package to improve code reuse and maintainability across test files.

Changes:
- Add DeepSeek default constants (base URL, model names)
- Add GetDeepSeekAPIKeyOrSkipTest helper
- Add GetDeepSeekBaseURL and GetDeepSeekModel helpers
- Refactor deepseek_conformance_test.go to use new helpers
- Refactor deepseek_integration_test.go to use new helpers

This consolidation makes it easier to maintain consistent test configuration and reduces code duplication.