### PR TITLE
refactor: consolidate tool responses into RoleUser & RoleAssistant

### DIFF
--- a/agent/llmagent/llmagent.go
+++ b/agent/llmagent/llmagent.go
@@ -471,7 +471,7 @@ func (a *LLMAgent) executeTools(
 				Name:  result.name,
 				Error: result.err.Error(),
 			}
-			msg = llm.NewMessage(llm.RoleTool, llm.NewToolResponsePart(errResp))
+			msg = llm.NewMessage(llm.RoleUser, llm.NewToolResponsePart(errResp))
 
 			// Yield error tool result event
 			if !yield(agent.ToolResultEvent{
@@ -482,7 +482,7 @@ func (a *LLMAgent) executeTools(
 			}
 		} else {
 			// Tool execution succeeded
-			msg = llm.NewMessage(llm.RoleTool, llm.NewToolResponsePart(result.response))
+			msg = llm.NewMessage(llm.RoleUser, llm.NewToolResponsePart(result.response))
 
 			// Yield tool result event
 			if !yield(agent.ToolResultEvent{

--- a/llm/fakellm/fake_test.go
+++ b/llm/fakellm/fake_test.go
@@ -273,7 +273,7 @@ func TestFakeModel_Scenario_ToolCalling(t *testing.T) {
 			{Role: llm.RoleUser, Content: []*llm.Part{llm.NewTextPart("What's the weather in SF?")}},
 			resp1.Message, // Include tool request
 			{
-				Role: llm.RoleTool,
+				Role: llm.RoleUser,
 				Content: []*llm.Part{
 					llm.NewToolResponsePart(&llm.ToolResponse{
 						ID:     resp1.ToolRequests()[0].ID,
@@ -504,7 +504,7 @@ func TestFakeModel_ToolCallingLoop(t *testing.T) {
 		Messages: []llm.Message{
 			{Role: llm.RoleUser, Content: []*llm.Part{llm.NewTextPart("What is 2 + 2?")}},
 			resp1.Message,
-			{Role: llm.RoleTool, Content: []*llm.Part{llm.NewToolResponsePart(&llm.ToolResponse{
+			{Role: llm.RoleUser, Content: []*llm.Part{llm.NewToolResponsePart(&llm.ToolResponse{
 				ID:     resp1.ToolRequests()[0].ID,
 				Name:   "calculate",
 				Result: []byte(`{"result": 4}`),

--- a/llm/fakellm/matchers.go
+++ b/llm/fakellm/matchers.go
@@ -297,7 +297,7 @@ func LastMessageHasToolResponse(toolName string) Matcher {
 		}
 
 		lastMsg := req.Messages[len(req.Messages)-1]
-		if lastMsg.Role != llm.RoleTool {
+		if lastMsg.Role != llm.RoleUser {
 			return fmt.Errorf("last message is not a tool response (role: %s)", lastMsg.Role)
 		}
 

--- a/llm/message.go
+++ b/llm/message.go
@@ -24,10 +24,6 @@ const (
 	// RoleSystem indicates the message provides system-level context or instructions.
 	// Only used if the model supports system prompts (check Capabilities.SystemPrompts).
 	RoleSystem MessageRole = "system"
-
-	// RoleTool indicates the message contains the result of a tool execution.
-	// These messages are responses to tool requests from the assistant.
-	RoleTool MessageRole = "tool"
 )
 
 // NewMessage creates a message with the specified role and parts.
@@ -44,9 +40,9 @@ const (
 //	    llm.NewToolRequestPart(toolReq),
 //	)
 //
-// For tool responses, use the tool role:
+// For tool responses, use the user role:
 //
-//	msg := llm.NewMessage(llm.RoleTool, llm.NewToolResponsePart(resp))
+//	msg := llm.NewMessage(llm.RoleUser, llm.NewToolResponsePart(resp))
 func NewMessage(role MessageRole, parts ...*Part) Message {
 	return Message{
 		Role:    role,

--- a/llm/message_test.go
+++ b/llm/message_test.go
@@ -57,7 +57,7 @@ func TestNewMessage(t *testing.T) {
 		},
 		{
 			name:      "tool response message",
-			role:      llm.RoleTool,
+			role:      llm.RoleUser,
 			parts:     []*llm.Part{llm.NewToolResponsePart(toolResp)},
 			wantParts: 1,
 			wantText:  "",

--- a/providers/anthropic/request_mapper.go
+++ b/providers/anthropic/request_mapper.go
@@ -146,30 +146,6 @@ func (rm *RequestMapper) mapMessages(messages []llm.Message) ([]anthropic.BetaMe
 
 			apiMessages = append(apiMessages, apiMsg)
 
-		case llm.RoleTool:
-			// Tool responses are embedded in the content of user messages in Anthropic's format
-			// We need to append them to the previous user message or create a new user message
-			if len(apiMessages) == 0 || apiMessages[len(apiMessages)-1].Role != anthropic.BetaMessageParamRoleUser {
-				// Create a new user message for tool results
-				apiMessages = append(apiMessages, anthropic.BetaMessageParam{
-					Role: anthropic.BetaMessageParamRoleUser,
-				})
-			}
-
-			// Append tool result blocks to the last user message
-			lastMsg := &apiMessages[len(apiMessages)-1]
-
-			for _, part := range msg.Content {
-				if part.IsToolResponse() {
-					block, err := rm.mapToolResultBlock(part)
-					if err != nil {
-						return nil, nil, err
-					}
-
-					lastMsg.Content = append(lastMsg.Content, block)
-				}
-			}
-
 		default:
 			return nil, nil, fmt.Errorf("unsupported message role: %s", msg.Role)
 		}
@@ -192,6 +168,13 @@ func (rm *RequestMapper) mapUserMessage(msg llm.Message) (anthropic.BetaMessageP
 					Text: part.Text,
 				},
 			})
+		} else if part.IsToolResponse() {
+			block, err := rm.mapToolResultBlock(part)
+			if err != nil {
+				return apiMsg, err
+			}
+
+			apiMsg.Content = append(apiMsg.Content, block)
 		} else {
 			return apiMsg, fmt.Errorf("unsupported part type in user message: %s", part.Kind)
 		}

--- a/providers/conformance/suite.go
+++ b/providers/conformance/suite.go
@@ -972,7 +972,7 @@ func (s *Suite) TestToolExecutionLoop() {
 				},
 				response.Message, // Add the assistant's tool call message
 				{
-					Role: llm.RoleTool,
+					Role: llm.RoleUser,
 					Content: []*llm.Part{
 						llm.NewToolResponsePart(&llm.ToolResponse{
 							ID:     toolRequests[0].ID,
@@ -1078,7 +1078,7 @@ func (s *Suite) TestToolExecutionLoop() {
 				},
 				assistantMessage,
 				{
-					Role: llm.RoleTool,
+					Role: llm.RoleUser,
 					Content: []*llm.Part{
 						llm.NewToolResponsePart(&llm.ToolResponse{
 							ID:     toolRequests[0].ID,
@@ -1184,7 +1184,7 @@ func (s *Suite) TestToolExecutionLoop() {
 				},
 				response1.Message,
 				{
-					Role: llm.RoleTool,
+					Role: llm.RoleUser,
 					Content: []*llm.Part{
 						llm.NewToolResponsePart(&llm.ToolResponse{
 							ID:     toolRequests1[0].ID,
@@ -1239,7 +1239,7 @@ func (s *Suite) TestToolExecutionLoop() {
 				},
 				response1.Message,
 				{
-					Role: llm.RoleTool,
+					Role: llm.RoleUser,
 					Content: []*llm.Part{
 						llm.NewToolResponsePart(&llm.ToolResponse{
 							ID:     toolRequests1[0].ID,
@@ -1250,7 +1250,7 @@ func (s *Suite) TestToolExecutionLoop() {
 				},
 				response2.Message,
 				{
-					Role: llm.RoleTool,
+					Role: llm.RoleUser,
 					Content: []*llm.Part{
 						llm.NewToolResponsePart(&llm.ToolResponse{
 							ID:     toolRequests2[0].ID,

--- a/providers/openai/openai_conformance_test.go
+++ b/providers/openai/openai_conformance_test.go
@@ -26,7 +26,7 @@ func NewOpenAIFixture(t *testing.T) *OpenAIFixture {
 	// Check for API key (skips test if not set)
 	apiKey := openaitest.GetAPIKeyOrSkipTest(t)
 
-	// Create provider
+	// Create provider with standard timeout for regular models
 	provider, err := openai.NewProvider(apiKey, openai.WithTimeout(time.Minute*2))
 	if err != nil {
 		t.Fatalf("Failed to create provider: %v", err)
@@ -38,8 +38,13 @@ func NewOpenAIFixture(t *testing.T) *OpenAIFixture {
 		t.Fatalf("Failed to create standard model: %v", err)
 	}
 
-	// Create reasoning model
-	reasoningModel, err := provider.NewModel(openaitest.TestReasoningModelName,
+	// Create reasoning model with extended timeout since reasoning can take longer
+	reasoningProvider, err := openai.NewProvider(apiKey, openai.WithTimeout(time.Minute*5))
+	if err != nil {
+		t.Fatalf("Failed to create reasoning provider: %v", err)
+	}
+
+	reasoningModel, err := reasoningProvider.NewModel(openaitest.TestReasoningModelName,
 		openai.WithReasoningEffort(openai.ReasoningEffortHigh),
 		openai.WithReasoningSummary(openai.ReasoningSummaryDetailed),
 	)

--- a/providers/openai/openai_test.go
+++ b/providers/openai/openai_test.go
@@ -490,7 +490,7 @@ func TestMessageMappingWithToolParts(t *testing.T) {
 			name: "tool response message",
 			messages: []llm.Message{
 				{
-					Role: llm.RoleTool,
+					Role: llm.RoleUser,
 					Content: []*llm.Part{
 						llm.NewToolResponsePart(&llm.ToolResponse{
 							ID:     "call_123",
@@ -513,7 +513,7 @@ func TestMessageMappingWithToolParts(t *testing.T) {
 			name: "tool response with error",
 			messages: []llm.Message{
 				{
-					Role: llm.RoleTool,
+					Role: llm.RoleUser,
 					Content: []*llm.Part{
 						llm.NewToolResponsePart(&llm.ToolResponse{
 							ID:    "call_123",
@@ -575,7 +575,7 @@ func TestMessageMappingWithToolParts(t *testing.T) {
 					},
 				},
 				{
-					Role: llm.RoleTool,
+					Role: llm.RoleUser,
 					Content: []*llm.Part{
 						llm.NewToolResponsePart(&llm.ToolResponse{
 							ID:     "call_456",
@@ -646,23 +646,6 @@ func TestMessageRoleValidation(t *testing.T) {
 		errContains string
 	}{
 		{
-			name: "tool response with wrong role (RoleUser)",
-			messages: []llm.Message{
-				{
-					Role: llm.RoleUser,
-					Content: []*llm.Part{
-						llm.NewToolResponsePart(&llm.ToolResponse{
-							ID:     "call_123",
-							Name:   "get_weather",
-							Result: json.RawMessage(`{"temp": 72}`),
-						}),
-					},
-				},
-			},
-			wantErr:     true,
-			errContains: "tool response parts require RoleTool",
-		},
-		{
 			name: "tool response with wrong role (RoleAssistant)",
 			messages: []llm.Message{
 				{
@@ -677,20 +660,7 @@ func TestMessageRoleValidation(t *testing.T) {
 				},
 			},
 			wantErr:     true,
-			errContains: "tool response parts require RoleTool",
-		},
-		{
-			name: "text part in RoleTool message",
-			messages: []llm.Message{
-				{
-					Role: llm.RoleTool,
-					Content: []*llm.Part{
-						llm.NewTextPart("Here's the result"),
-					},
-				},
-			},
-			wantErr:     true,
-			errContains: "RoleTool messages cannot contain text parts",
+			errContains: "tool response parts require RoleUser",
 		},
 		{
 			name: "tool request with wrong role (RoleUser)",
@@ -710,10 +680,10 @@ func TestMessageRoleValidation(t *testing.T) {
 			errContains: "tool request parts require RoleAssistant",
 		},
 		{
-			name: "multiple tool responses in RoleTool message (valid)",
+			name: "multiple tool responses in RoleUser message (valid)",
 			messages: []llm.Message{
 				{
-					Role: llm.RoleTool,
+					Role: llm.RoleUser,
 					Content: []*llm.Part{
 						llm.NewToolResponsePart(&llm.ToolResponse{
 							ID:     "call_123",
@@ -734,7 +704,7 @@ func TestMessageRoleValidation(t *testing.T) {
 			name: "tool response in correct role (valid)",
 			messages: []llm.Message{
 				{
-					Role: llm.RoleTool,
+					Role: llm.RoleUser,
 					Content: []*llm.Part{
 						llm.NewToolResponsePart(&llm.ToolResponse{
 							ID:     "call_123",

--- a/providers/openai/request_mapper.go
+++ b/providers/openai/request_mapper.go
@@ -115,11 +115,6 @@ func (rm *RequestMapper) mapMessagesToInputItems(messages []llm.Message) ([]resp
 		for _, part := range msg.Content {
 			switch {
 			case part.IsText():
-				// Text parts cannot be in RoleTool messages
-				if msg.Role == llm.RoleTool {
-					return nil, fmt.Errorf("%w: RoleTool messages cannot contain text parts", llm.ErrRequestMapping)
-				}
-
 				item, err := rm.mapTextMessage(part, msg.Role)
 				if err != nil {
 					return nil, err
@@ -141,9 +136,9 @@ func (rm *RequestMapper) mapMessagesToInputItems(messages []llm.Message) ([]resp
 				items = append(items, item)
 
 			case part.IsToolResponse():
-				// Tool responses must be in RoleTool messages
-				if msg.Role != llm.RoleTool {
-					return nil, fmt.Errorf("%w: tool response parts require RoleTool, got %s", llm.ErrRequestMapping, msg.Role)
+				// Tool responses must be in RoleUser messages
+				if msg.Role != llm.RoleUser {
+					return nil, fmt.Errorf("%w: tool response parts require RoleUser, got %s", llm.ErrRequestMapping, msg.Role)
 				}
 
 				item, err := rm.mapToolResponseMessage(part)
@@ -331,10 +326,6 @@ func (*RequestMapper) mapRoleToAPI(role llm.MessageRole) (responses.EasyInputMes
 		return responses.EasyInputMessageRoleAssistant, nil
 	case llm.RoleSystem:
 		return responses.EasyInputMessageRoleSystem, nil
-	case llm.RoleTool:
-		// RoleTool is not a direct input message role in the same way.
-		// Tool responses are handled via specific tool output items.
-		return "", fmt.Errorf("unsupported message role for OpenAI Responses API: %s", role)
 	default:
 		return "", fmt.Errorf("unsupported message role for OpenAI Responses API: %s", role)
 	}

--- a/providers/openaicompat/openaicompat_test.go
+++ b/providers/openaicompat/openaicompat_test.go
@@ -457,7 +457,7 @@ func TestMessageMappingWithToolParts(t *testing.T) {
 			name: "tool response message",
 			messages: []llm.Message{
 				{
-					Role: llm.RoleTool,
+					Role: llm.RoleUser,
 					Content: []*llm.Part{
 						llm.NewToolResponsePart(&llm.ToolResponse{
 							ID:     "call_123",
@@ -480,7 +480,7 @@ func TestMessageMappingWithToolParts(t *testing.T) {
 			name: "tool response with error",
 			messages: []llm.Message{
 				{
-					Role: llm.RoleTool,
+					Role: llm.RoleUser,
 					Content: []*llm.Part{
 						llm.NewToolResponsePart(&llm.ToolResponse{
 							ID:    "call_123",
@@ -540,7 +540,7 @@ func TestMessageMappingWithToolParts(t *testing.T) {
 					},
 				},
 				{
-					Role: llm.RoleTool,
+					Role: llm.RoleUser,
 					Content: []*llm.Part{
 						llm.NewToolResponsePart(&llm.ToolResponse{
 							ID:     "call_456",

--- a/providers/openaicompat/request_mapper.go
+++ b/providers/openaicompat/request_mapper.go
@@ -183,17 +183,6 @@ func (rm *RequestMapper) mapMessages(messages []llm.Message) ([]openai.ChatCompl
 				apiMessages = append(apiMessages, apiMsg)
 			}
 
-		case llm.RoleTool:
-			// Tool responses become separate tool messages
-			for _, part := range toolResponses {
-				apiMsg, err := rm.mapToolMessage(&part)
-				if err != nil {
-					return nil, err
-				}
-
-				apiMessages = append(apiMessages, apiMsg)
-			}
-
 		default:
 			return nil, fmt.Errorf("unsupported message role: %q", msg.Role)
 		}

--- a/tool/builtin/todo/todo_integration_test.go
+++ b/tool/builtin/todo/todo_integration_test.go
@@ -221,7 +221,7 @@ func TestTodoTools_Integration(t *testing.T) {
 		conversationHistory = append(conversationHistory, addResponse.Message)
 		if lastToolResponse != nil {
 			conversationHistory = append(conversationHistory, llm.Message{
-				Role: llm.RoleTool,
+				Role: llm.RoleUser,
 				Content: []*llm.Part{
 					llm.NewToolResponsePart(lastToolResponse),
 				},
@@ -265,7 +265,7 @@ func TestTodoTools_Integration(t *testing.T) {
 					// Continue conversation after tool execution to get final response
 					conversationHistory = append(conversationHistory, updateResponse.Message)
 					conversationHistory = append(conversationHistory, llm.Message{
-						Role: llm.RoleTool,
+						Role: llm.RoleUser,
 						Content: []*llm.Part{
 							llm.NewToolResponsePart(toolResp),
 						},

--- a/tool/builtin/webfetch/tool_integration_test.go
+++ b/tool/builtin/webfetch/tool_integration_test.go
@@ -211,7 +211,7 @@ func TestWebFetch_PromptInjectionFencing_Integration(t *testing.T) {
 					Content: response.Message.Content,
 				},
 				{
-					Role: llm.RoleTool,
+					Role: llm.RoleUser,
 					Content: []*llm.Part{
 						llm.NewToolResponsePart(toolResponse),
 					},
@@ -347,7 +347,7 @@ func TestWebFetch_PromptInjectionFencing_Integration(t *testing.T) {
 					Content: response.Message.Content,
 				},
 				{
-					Role: llm.RoleTool,
+					Role: llm.RoleUser,
 					Content: []*llm.Part{
 						llm.NewToolResponsePart(toolResponse),
 					},

--- a/tool/mcp/context7_integration_test.go
+++ b/tool/mcp/context7_integration_test.go
@@ -153,7 +153,7 @@ func TestContext7Integration_EndToEnd(t *testing.T) { //nolint:paralleltest // c
 
 		// Add tool results to conversation
 		messages = append(messages, llm.Message{
-			Role:    llm.RoleTool,
+			Role:    llm.RoleUser,
 			Content: toolResults,
 		})
 	}

--- a/tool/registry_integration_test.go
+++ b/tool/registry_integration_test.go
@@ -456,7 +456,7 @@ func TestRegistry_WebfetchToolWithLLM_Integration(t *testing.T) {
 				Content: response.Message.Content, // Include the original tool requests
 			},
 			{
-				Role: llm.RoleTool,
+				Role: llm.RoleUser,
 				Content: []*llm.Part{
 					llm.NewToolResponsePart(toolResponse),
 				},


### PR DESCRIPTION
## Summary

Removes `llm.RoleTool` and consolidates tool response handling to use `RoleUser`. This simplifies the message role system while maintaining full compatibility with provider APIs.

**Message role mapping:**
- Tool requests (from assistant) → `RoleAssistant`
- Tool responses (from user) → `RoleUser` (previously `RoleTool`)

## Changes

- Remove `RoleTool` constant and update all provider request mappers to validate tool responses in `RoleUser` messages
- Update test expectations to reflect new role validation behavior (error messages now say "tool response parts require RoleUser")
- Configure extended timeout (5min) for reasoning models vs 2min for standard models in OpenAI conformance tests
- Update fakellm matchers and integration tests to work with tool responses in `RoleUser`

## Breaking Change

⚠️ Tool responses must now use `llm.RoleUser` instead of the removed `llm.RoleTool`.