### PR TITLE
Rename tool events for consistency with llm package

### DIFF
--- a/agent/event.go
+++ b/agent/event.go
@@ -106,27 +106,27 @@ func (AssistantDeltaEvent) isEvent() {}
 // GetEnvelope returns the event envelope containing observability metadata.
 func (e AssistantDeltaEvent) GetEnvelope() EventEnvelope { return e.Envelope }
 
-// ToolCallEvent represents a tool invocation request from the LLM.
-type ToolCallEvent struct {
+// ToolRequestEvent represents a tool invocation request from the LLM.
+type ToolRequestEvent struct {
 	Envelope EventEnvelope   `json:"envelope"`
 	Request  llm.ToolRequest `json:"request"`
 }
 
-func (ToolCallEvent) isEvent() {}
+func (ToolRequestEvent) isEvent() {}
 
 // GetEnvelope returns the event envelope containing observability metadata.
-func (e ToolCallEvent) GetEnvelope() EventEnvelope { return e.Envelope }
+func (e ToolRequestEvent) GetEnvelope() EventEnvelope { return e.Envelope }
 
-// ToolResultEvent carries the result of a tool execution.
-type ToolResultEvent struct {
+// ToolResponseEvent carries the result of a tool execution.
+type ToolResponseEvent struct {
 	Envelope EventEnvelope    `json:"envelope"`
 	Response llm.ToolResponse `json:"response"`
 }
 
-func (ToolResultEvent) isEvent() {}
+func (ToolResponseEvent) isEvent() {}
 
 // GetEnvelope returns the event envelope containing observability metadata.
-func (e ToolResultEvent) GetEnvelope() EventEnvelope { return e.Envelope }
+func (e ToolResponseEvent) GetEnvelope() EventEnvelope { return e.Envelope }
 
 // ErrorEvent is NON-TERMINAL at the runtime layer.
 // It reports a recoverable or fatal problem, but the stream only ends
@@ -166,7 +166,7 @@ type InvocationEndEvent struct {
 	Usage *llm.TokenUsage `json:"usage,omitempty"`
 	// InputRequiredToolIDs lists tool call IDs that require external input.
 	// Only populated when FinishReason is FinishReasonInputRequired.
-	// These IDs correspond to ToolCallEvent.Request.ID from earlier in the stream.
+	// These IDs correspond to ToolRequestEvent.Request.ID from earlier in the stream.
 	InputRequiredToolIDs []string `json:"input_required_tool_ids,omitempty"`
 }
 

--- a/agent/llmagent/llmagent.go
+++ b/agent/llmagent/llmagent.go
@@ -236,7 +236,7 @@ func (a *LLMAgent) Run(invCtx *agent.InvocationContext) iter.Seq2[agent.Event, e
 
 			// Emit tool call events
 			for _, toolReq := range toolReqs {
-				if !yield(agent.ToolCallEvent{
+				if !yield(agent.ToolRequestEvent{
 					Envelope: makeEnvelope(),
 					Request:  *toolReq,
 				}, nil) {
@@ -403,7 +403,7 @@ func (a *LLMAgent) generateWithStreaming(
 // This follows the pattern from ADK and other SDKs: tool errors are NEVER
 // terminal - they're always sent to the LLM as part of the conversation.
 //
-// ToolResultEvents are yielded as tools complete.
+// ToolResponseEvents are yielded as tools complete.
 //
 // Returns tool result messages to be added to the conversation.
 //
@@ -474,7 +474,7 @@ func (a *LLMAgent) executeTools(
 			msg = llm.NewMessage(llm.RoleUser, llm.NewToolResponsePart(errResp))
 
 			// Yield error tool result event
-			if !yield(agent.ToolResultEvent{
+			if !yield(agent.ToolResponseEvent{
 				Envelope: makeEnvelope(),
 				Response: *errResp,
 			}, nil) {
@@ -485,7 +485,7 @@ func (a *LLMAgent) executeTools(
 			msg = llm.NewMessage(llm.RoleUser, llm.NewToolResponsePart(result.response))
 
 			// Yield tool result event
-			if !yield(agent.ToolResultEvent{
+			if !yield(agent.ToolResponseEvent{
 				Envelope: makeEnvelope(),
 				Response: *result.response,
 			}, nil) {

--- a/agent/llmagent/llmagent_integration_test.go
+++ b/agent/llmagent/llmagent_integration_test.go
@@ -115,8 +115,8 @@ func TestLLMAgent_Integration_ToolCalling(t *testing.T) {
 	events := collectEvents(t, ag.Run(invCtx))
 
 	// Collect different event types
-	toolCallEvents := filterEvents[agent.ToolCallEvent](events)
-	toolResultEvents := filterEvents[agent.ToolResultEvent](events)
+	toolCallEvents := filterEvents[agent.ToolRequestEvent](events)
+	toolResultEvents := filterEvents[agent.ToolResponseEvent](events)
 	messageEvents := filterEvents[agent.MessageEvent](events)
 	endEvent := findInvocationEndEvent(events)
 

--- a/agent/llmagent/llmagent_test.go
+++ b/agent/llmagent/llmagent_test.go
@@ -312,8 +312,8 @@ func TestRun_MultiTurnWithTools(t *testing.T) {
 	assert.Equal(t, 1, maxTurn, "expected 2 turns (0 and 1)")
 
 	// Assert: Should have tool call and tool result events
-	toolCallEvents := filterEvents[agent.ToolCallEvent](events)
-	toolResultEvents := filterEvents[agent.ToolResultEvent](events)
+	toolCallEvents := filterEvents[agent.ToolRequestEvent](events)
+	toolResultEvents := filterEvents[agent.ToolResponseEvent](events)
 
 	assert.Len(t, toolCallEvents, 1)
 	assert.Len(t, toolResultEvents, 1)
@@ -468,7 +468,7 @@ func TestExecuteTools_ToolError(t *testing.T) {
 	events := collectEvents(t, ag.Run(invCtx))
 
 	// Assert: Should have tool result with error
-	toolResultEvents := filterEvents[agent.ToolResultEvent](events)
+	toolResultEvents := filterEvents[agent.ToolResponseEvent](events)
 	require.Len(t, toolResultEvents, 1)
 	assert.NotEmpty(t, toolResultEvents[0].Response.Error)
 	assert.Contains(t, toolResultEvents[0].Response.Error, "tool execution failed")
@@ -832,7 +832,7 @@ func TestRun_EventOrdering(t *testing.T) {
 		events := collectEvents(t, ag.Run(invCtx))
 
 		// Verify canonical sequence:
-		// StatusEvent → MessageEvent (tool calls) → ToolCallEvent → ToolResultEvent → MessageEvent (final) → InvocationEndEvent
+		// StatusEvent → MessageEvent (tool calls) → ToolRequestEvent → ToolResponseEvent → MessageEvent (final) → InvocationEndEvent
 		require.GreaterOrEqual(t, len(events), 6, "should have status, message, tool call, tool result, message, and end events")
 
 		// Find event indices
@@ -850,11 +850,11 @@ func TestRun_EventOrdering(t *testing.T) {
 				}
 
 				finalMessageIdx = i // Keep updating to get last message
-			case agent.ToolCallEvent:
+			case agent.ToolRequestEvent:
 				if toolCallIdx == -1 {
 					toolCallIdx = i
 				}
-			case agent.ToolResultEvent:
+			case agent.ToolResponseEvent:
 				if toolResultIdx == -1 {
 					toolResultIdx = i
 				}
@@ -866,16 +866,16 @@ func TestRun_EventOrdering(t *testing.T) {
 		// Assert all events present
 		require.NotEqual(t, -1, statusIdx, "should have StatusEvent")
 		require.NotEqual(t, -1, firstMessageIdx, "should have first MessageEvent")
-		require.NotEqual(t, -1, toolCallIdx, "should have ToolCallEvent")
-		require.NotEqual(t, -1, toolResultIdx, "should have ToolResultEvent")
+		require.NotEqual(t, -1, toolCallIdx, "should have ToolRequestEvent")
+		require.NotEqual(t, -1, toolResultIdx, "should have ToolResponseEvent")
 		require.NotEqual(t, -1, finalMessageIdx, "should have final MessageEvent")
 		require.NotEqual(t, -1, endIdx, "should have InvocationEndEvent")
 
 		// Assert canonical ordering
 		assert.Less(t, statusIdx, firstMessageIdx, "StatusEvent should come before first MessageEvent")
-		assert.Less(t, firstMessageIdx, toolCallIdx, "MessageEvent should come before ToolCallEvent")
-		assert.Less(t, toolCallIdx, toolResultIdx, "ToolCallEvent should come before ToolResultEvent")
-		assert.Less(t, toolResultIdx, finalMessageIdx, "ToolResultEvent should come before final MessageEvent")
+		assert.Less(t, firstMessageIdx, toolCallIdx, "MessageEvent should come before ToolRequestEvent")
+		assert.Less(t, toolCallIdx, toolResultIdx, "ToolRequestEvent should come before ToolResponseEvent")
+		assert.Less(t, toolResultIdx, finalMessageIdx, "ToolResponseEvent should come before final MessageEvent")
 		assert.Less(t, finalMessageIdx, endIdx, "Final MessageEvent should come before InvocationEndEvent")
 	})
 }

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -85,7 +85,7 @@ func New(ag agent.Agent, sessionStore session.Store, opts ...Option) (*Runner, e
 //   - StatusEvent (turn started, model call, tool exec, etc.)
 //   - MessageEvent (assistant responses)
 //   - AssistantDeltaEvent (streaming tokens, if supported)
-//   - ToolCallEvent, ToolResultEvent (tool execution)
+//   - ToolRequestEvent, ToolResponseEvent (tool execution)
 //   - ErrorEvent (recoverable errors)
 //   - InvocationEndEvent (terminal event)
 //

--- a/runner/runner_integration_test.go
+++ b/runner/runner_integration_test.go
@@ -115,10 +115,10 @@ func TestRunner_Integration_WithTools(t *testing.T) {
 	events := collectEventsIntegration(t, r.Run(ctx, "", "test-session-tools", userMsg))
 
 	// Verify tool was called
-	toolCallEvents := filterEventsIntegration[agent.ToolCallEvent](events)
+	toolCallEvents := filterEventsIntegration[agent.ToolRequestEvent](events)
 	require.NotEmpty(t, toolCallEvents, "should have called the calculator tool")
 
-	toolResultEvents := filterEventsIntegration[agent.ToolResultEvent](events)
+	toolResultEvents := filterEventsIntegration[agent.ToolResponseEvent](events)
 	require.NotEmpty(t, toolResultEvents, "should have tool result")
 
 	// Verify completion


### PR DESCRIPTION
## What

Rename agent event types for consistency:
- `ToolCallEvent` -> `ToolRequestEvent`
- `ToolResultEvent` -> `ToolResponseEvent`

## Why

The `llm.Part` types use `ToolRequest` and `ToolResponse` naming, but agent events used `ToolCallEvent` and `ToolResultEvent`. This inconsistency is confusing for developers working across both packages.

"Request/Response" is a clearer paired concept than "Call/Result", and aligns with the A2A protocol which also uses "tool_request" and "tool_response" in data parts.

## Implementation details

Simple find-and-replace across 6 files:
- agent/event.go
- agent/llmagent/llmagent.go
- agent/llmagent/llmagent_integration_test.go
- agent/llmagent/llmagent_test.go
- runner/runner.go
- runner/runner_integration_test.go

All references updated, tests remain passing.