### PR TITLE
Add support for Gemini 3 Pro Preview

### DIFF
--- a/providers/gemini/models.go
+++ b/providers/gemini/models.go
@@ -4,6 +4,7 @@ import "github.com/redpanda-data/ai-sdk-go/llm"
 
 // Model ID constants for Google Gemini models.
 const (
+	ModelGemini3ProPreview = "gemini-3-pro-preview"
 	ModelGemini25Pro       = "gemini-2.5-pro"
 	ModelGemini25Flash     = "gemini-2.5-flash"
 	ModelGemini25FlashLite = "gemini-2.5-flash-lite"
@@ -21,6 +22,26 @@ type ModelDefinition struct {
 // supportedModels defines all Gemini models with their capabilities and constraints.
 // Based on https://ai.google.dev/gemini-api/docs/models
 var supportedModels = map[string]ModelDefinition{
+	ModelGemini3ProPreview: {
+		Name:  ModelGemini3ProPreview,
+		Label: "Gemini 3 Pro Preview",
+		Capabilities: llm.ModelCapabilities{
+			Streaming:        true,
+			Tools:            true,
+			JSONMode:         true,
+			StructuredOutput: true,
+			Vision:           true,
+			MultiTurn:        true,
+			SystemPrompts:    true,
+			Reasoning:        true, // Gemini 3 has thinking support
+		},
+		Constraints: llm.ModelConstraints{
+			TemperatureRange:  [2]float64{0.0, 2.0},
+			MaxTokensLimit:    1048576, // 1M input tokens
+			SupportedParams:   []string{"temperature", "top_p", "top_k", "max_tokens", "stop", "presence_penalty", "frequency_penalty"},
+			MutuallyExclusive: [][]string{},
+		},
+	},
 	ModelGemini25Pro: {
 		Name:  ModelGemini25Pro,
 		Label: "Gemini 2.5 Pro",


### PR DESCRIPTION
## What
Add support for Google's `gemini-3-pro-preview` model to the SDK.

## Why
Gemini 3 Pro is Google's latest and most advanced model, released November 18, 2025. It provides:
- Best-in-class multimodal understanding
- Enhanced reasoning and thinking capabilities  
- Improved agentic behavior
- State-of-the-art coding assistance

Supporting this model keeps the SDK current with Google's latest offerings.

## Implementation details
- Added `ModelGemini3ProPreview` constant with value `gemini-3-pro-preview`
- Defined model capabilities: streaming, tools, JSON mode, structured output, vision, multi-turn, system prompts, and reasoning
- Set constraints: 1M input token limit, temperature range 0.0-2.0
- Uses existing `ThinkingConfig` mechanism compatible with Gemini 2.5

All conformance tests pass including the new model.

## References
https://ai.google.dev/gemini-api/docs/models