### PR TITLE
a2a: add timeout to background context for canceled task status writes

### DIFF
--- a/adapter/a2a/executor.go
+++ b/adapter/a2a/executor.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"iter"
 	"log/slog"
+	"time"
 
 	"github.com/a2aproject/a2a-go/a2a"
 	"github.com/a2aproject/a2a-go/a2asrv"
@@ -116,8 +117,9 @@ func (e *Executor) processEvents(
 			// Check if the error is a cancellation error
 			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 				// Emit canceled status with error message
-				// Use background context since the original context is likely canceled
-				bgCtx := context.Background()
+				// Use background context with timeout since the original context is likely canceled
+				bgCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+				defer cancel()
 				errMsg := a2a.NewMessage(a2a.MessageRoleAgent, a2a.TextPart{Text: err.Error()})
 				statusEvent := a2a.NewStatusUpdateEvent(reqCtx, a2a.TaskStateCanceled, errMsg)
 				statusEvent.Final = true


### PR DESCRIPTION
## What

Add a 30-second timeout to the background context used for writing canceled task status events.

## Why

When the executor detects a cancellation error (context.Canceled or context.DeadlineExceeded), it emits a canceled status event using a background context since the original context is canceled. Previously, this used a bare `context.Background()` which could theoretically hang forever if the write operation blocks.

## Implementation details

- Changed `context.Background()` to `context.WithTimeout(context.Background(), 30*time.Second)`
- Added proper cleanup with `defer cancel()`

The 30-second timeout provides sufficient time for the status write to complete while preventing indefinite hangs.

## References

Addresses review comment: https://github.com/redpanda-data/ai-sdk-go/pull/29/files#r2564599593