### PR TITLE
Add unit tests for Gemini provider

### DIFF
--- a/providers/gemini/gemini_test.go
+++ b/providers/gemini/gemini_test.go
@@ -10,6 +10,7 @@ import (
 
 func TestProviderCreation(t *testing.T) {
 	t.Parallel()
+
 	ctx := context.Background()
 
 	// Valid provider creation with API key
@@ -26,6 +27,7 @@ func TestProviderCreation(t *testing.T) {
 
 func TestProviderModels(t *testing.T) {
 	t.Parallel()
+
 	ctx := context.Background()
 
 	provider, err := NewProvider(ctx, "test-api-key")
@@ -58,6 +60,7 @@ func TestProviderModels(t *testing.T) {
 
 func TestModelCreation(t *testing.T) {
 	t.Parallel()
+
 	ctx := context.Background()
 
 	provider, err := NewProvider(ctx, "test-api-key")
@@ -88,6 +91,7 @@ func TestModelCreation(t *testing.T) {
 
 func TestModelConstraints(t *testing.T) {
 	t.Parallel()
+
 	ctx := context.Background()
 
 	provider, err := NewProvider(ctx, "test-api-key")
@@ -113,6 +117,7 @@ func TestModelConstraints(t *testing.T) {
 
 func TestModelCapabilities(t *testing.T) {
 	t.Parallel()
+
 	ctx := context.Background()
 
 	provider, err := NewProvider(ctx, "test-api-key")
@@ -159,34 +164,34 @@ func TestModelTokenLimits(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name            string
-		model           string
-		expectedMaxIn   int
-		expectedMaxOut  int
+		name           string
+		model          string
+		expectedMaxIn  int
+		expectedMaxOut int
 	}{
 		{
-			name:            "Gemini 3 Pro Preview",
-			model:           ModelGemini3ProPreview,
-			expectedMaxIn:   1048576, // 1M
-			expectedMaxOut:  65535,   // 65K
+			name:           "Gemini 3 Pro Preview",
+			model:          ModelGemini3ProPreview,
+			expectedMaxIn:  1048576, // 1M
+			expectedMaxOut: 65535,   // 65K
 		},
 		{
-			name:            "Gemini 2.5 Pro",
-			model:           ModelGemini25Pro,
-			expectedMaxIn:   1048576, // 1M
-			expectedMaxOut:  65535,   // 65K
+			name:           "Gemini 2.5 Pro",
+			model:          ModelGemini25Pro,
+			expectedMaxIn:  1048576, // 1M
+			expectedMaxOut: 65535,   // 65K
 		},
 		{
-			name:            "Gemini 2.5 Flash",
-			model:           ModelGemini25Flash,
-			expectedMaxIn:   1048576, // 1M
-			expectedMaxOut:  65535,   // 65K
+			name:           "Gemini 2.5 Flash",
+			model:          ModelGemini25Flash,
+			expectedMaxIn:  1048576, // 1M
+			expectedMaxOut: 65535,   // 65K
 		},
 		{
-			name:            "Gemini 2.0 Flash",
-			model:           ModelGemini20Flash,
-			expectedMaxIn:   1048576, // 1M
-			expectedMaxOut:  8192,    // 8K
+			name:           "Gemini 2.0 Flash",
+			model:          ModelGemini20Flash,
+			expectedMaxIn:  1048576, // 1M
+			expectedMaxOut: 8192,    // 8K
 		},
 	}
 


### PR DESCRIPTION
## What

Add comprehensive unit tests for the Gemini provider to validate model definitions, capabilities, and constraints without requiring actual API calls.

## Why

The Gemini provider lacked basic unit tests similar to the OpenAI provider. This made it harder to validate model definitions and catch configuration errors early.

The OpenAI provider has `TestProviderCreation`, `TestProviderModels`, `TestModelCreation`, etc. The Gemini provider had none of these, only conformance tests that hit the actual API.

## Implementation details

Added `providers/gemini/gemini_test.go` with test coverage for:

- **TestProviderCreation**: Validates provider initialization and API key requirements
- **TestProviderModels**: Verifies all models are discoverable and properly configured (gemini-3-pro-preview, gemini-2.5-pro, gemini-2.5-flash, gemini-2.5-flash-lite, gemini-2.0-flash)
- **TestModelCreation**: Validates model instantiation with options
- **TestModelConstraints**: Tests temperature and parameter validation
- **TestModelCapabilities**: Verifies capabilities flags (Streaming, Tools, Vision, Reasoning, etc.)
- **TestModelTokenLimits**: Validates input/output token limits for each model

All tests pass. Conformance test confirms gemini-3-pro-preview works with Tier 2+ API keys (requires paid tier, not available in free tier).