### PR TITLE
feat: add agent as a tool

### DIFF
--- a/examples/agent_as_tool/main.go
+++ b/examples/agent_as_tool/main.go
@@ -1,0 +1,251 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"iter"
+	"log"
+	"os"
+	"time"
+
+	"github.com/redpanda-data/ai-sdk-go/agent"
+	"github.com/redpanda-data/ai-sdk-go/agent/llmagent"
+	"github.com/redpanda-data/ai-sdk-go/llm"
+	"github.com/redpanda-data/ai-sdk-go/providers/openai"
+	"github.com/redpanda-data/ai-sdk-go/store/session"
+	"github.com/redpanda-data/ai-sdk-go/tool"
+	"github.com/redpanda-data/ai-sdk-go/tool/agenttool"
+	"github.com/redpanda-data/ai-sdk-go/tool/builtin/webfetch"
+)
+
+// usageTracker tracks token usage for an agent.
+type usageTracker struct {
+	name        string
+	totalTokens int
+}
+
+// InterceptModel implements agent.ModelInterceptor to track token usage.
+func (u *usageTracker) InterceptModel(
+	ctx context.Context,
+	info *agent.ModelCallInfo,
+	next agent.ModelCallHandler,
+) agent.ModelCallHandler {
+	return &usageModelHandler{
+		tracker: u,
+		next:    next,
+	}
+}
+
+type usageModelHandler struct {
+	tracker *usageTracker
+	next    agent.ModelCallHandler
+}
+
+func (h *usageModelHandler) Generate(ctx context.Context, req *llm.Request) (*llm.Response, error) {
+	resp, err := h.next.Generate(ctx, req)
+	if err == nil && resp.Usage != nil {
+		h.tracker.totalTokens += resp.Usage.TotalTokens
+		fmt.Printf("  [%s Usage] +%d tokens (cumulative: %d)\n",
+			h.tracker.name, resp.Usage.TotalTokens, h.tracker.totalTokens)
+	}
+	return resp, err
+}
+
+func (h *usageModelHandler) GenerateEvents(ctx context.Context, req *llm.Request) iter.Seq2[llm.Event, error] {
+	return func(yield func(llm.Event, error) bool) {
+		var turnUsage int
+		for evt, err := range h.next.GenerateEvents(ctx, req) {
+			if endEvt, ok := evt.(llm.StreamEndEvent); ok && endEvt.Response != nil && endEvt.Response.Usage != nil {
+				turnUsage = endEvt.Response.Usage.TotalTokens
+			}
+			if !yield(evt, err) {
+				return
+			}
+		}
+		if turnUsage > 0 {
+			h.tracker.totalTokens += turnUsage
+			fmt.Printf("  [%s Usage] +%d tokens (cumulative: %d)\n",
+				h.tracker.name, turnUsage, h.tracker.totalTokens)
+		}
+	}
+}
+
+// assistantToolLogger logs tool calls made by the nested assistant agent.
+type assistantToolLogger struct{}
+
+// InterceptToolExecution implements agent.ToolInterceptor.
+func (a *assistantToolLogger) InterceptToolExecution(
+	ctx context.Context,
+	info *agent.ToolCallInfo,
+	next agent.ToolExecutionNext,
+) (*llm.ToolResponse, error) {
+	fmt.Printf("  [Assistant Tool Call] %s\n", info.Req.Name)
+	if len(info.Req.Arguments) > 0 && len(info.Req.Arguments) < 200 {
+		fmt.Printf("  [Assistant Tool Args] %s\n", string(info.Req.Arguments))
+	}
+
+	resp, err := next(ctx, info)
+
+	if err != nil {
+		fmt.Printf("  [Assistant Tool Error] %v\n", err)
+	} else if resp.Error != "" {
+		fmt.Printf("  [Assistant Tool Error] %s\n", resp.Error)
+	} else {
+		fmt.Printf("  [Assistant Tool Success] %s\n", info.Req.Name)
+	}
+
+	return resp, err
+}
+
+func main() {
+	ctx := context.Background()
+
+	// Get API key from environment
+	apiKey := os.Getenv("OPENAI_API_KEY")
+	if apiKey == "" {
+		log.Fatal("OPENAI_API_KEY environment variable not set")
+	}
+
+	// Create OpenAI provider
+	provider, err := openai.NewProvider(apiKey)
+	if err != nil {
+		log.Fatalf("failed to create provider: %v", err)
+	}
+
+	// Create model
+	model, err := provider.NewModel(openai.ModelGPT5_1)
+	if err != nil {
+		log.Fatalf("failed to create model: %v", err)
+	}
+
+	// Create a general-purpose assistant agent with tools
+	// This agent can be delegated subtasks for better context management
+	assistantTools := tool.NewRegistry(tool.RegistryConfig{})
+	if err := assistantTools.Register(webfetch.New()); err != nil {
+		log.Fatalf("failed to register webfetch tool: %v", err)
+	}
+
+	// Track token usage for assistant agent
+	assistantUsage := &usageTracker{name: "Assistant"}
+	toolLogger := &assistantToolLogger{}
+
+	assistantAgent, err := llmagent.New(
+		"assistant",
+		`You are a helpful assistant that can use tools to complete tasks.
+When given a task, use available tools as needed and provide a clear, concise response.`,
+		model,
+		llmagent.WithTools(assistantTools),
+		llmagent.WithInterceptors(assistantUsage, toolLogger),
+	)
+	if err != nil {
+		log.Fatalf("failed to create assistant agent: %v", err)
+	}
+
+	// Create main agent that can delegate to the assistant for context isolation
+	// This enables the main agent to offload subtasks without polluting its context
+	mainTools := tool.NewRegistry(tool.RegistryConfig{})
+	// Configure a longer timeout (8 minutes) since agent execution can include:
+	// - Multiple LLM calls for reasoning and response formatting
+	// - Multiple tool calls (like webfetch) with their own timeouts
+	// - Complex research or data gathering tasks
+	if err := mainTools.Register(agenttool.New(assistantAgent), tool.WithTimeout(8*time.Minute)); err != nil {
+		log.Fatalf("failed to register assistant agent: %v", err)
+	}
+
+	// Track token usage for main agent
+	mainUsage := &usageTracker{name: "Main"}
+
+	mainAgent, err := llmagent.New(
+		"main",
+		`You are a helpful assistant that can delegate subtasks to a specialized assistant.
+
+When you need to:
+- Fetch information from the web
+- Perform a complex subtask that would clutter your context
+- Isolate work that doesn't need your full conversation history
+
+Use the 'assistant' tool by passing it a clear task description in JSON format like:
+{"task": "search for X and summarize the key points"}
+
+The assistant has access to web search and will return a focused response.
+This helps keep your context clean and focused on the main task.`,
+		model,
+		llmagent.WithTools(mainTools),
+		llmagent.WithInterceptors(mainUsage),
+	)
+	if err != nil {
+		log.Fatalf("failed to create main agent: %v", err)
+	}
+
+	// Create a session for the conversation
+	sess := &session.State{
+		ID:       "example-session",
+		Messages: []llm.Message{},
+		Metadata: map[string]any{},
+	}
+
+	// Add a user message that requires web research
+	userMessage := llm.NewMessage(
+		llm.RoleUser,
+		llm.NewTextPart("What are the latest developments at Redpanda Data? I need a brief summary."),
+	)
+	sess.Messages = append(sess.Messages, userMessage)
+
+	// Create invocation metadata
+	inv := agent.NewInvocationMetadata(sess, agent.Info{
+		Name:        mainAgent.Name(),
+		Description: mainAgent.Description(),
+	})
+
+	// Run the main agent
+	fmt.Println("Agent-as-Tool Example: Context Management Pattern")
+	fmt.Println("=================================================")
+	fmt.Println()
+	fmt.Println("User:", userMessage.TextContent())
+	fmt.Println()
+
+	for evt, err := range mainAgent.Run(ctx, inv) {
+		if err != nil {
+			log.Fatalf("agent error: %v", err)
+		}
+
+		switch e := evt.(type) {
+		case agent.StatusEvent:
+			fmt.Printf("[Status] %s\n", e.Stage)
+
+		case agent.ToolRequestEvent:
+			if e.Request.Name == "assistant" {
+				fmt.Printf("[Delegating to assistant] Sub-task isolated in fresh context\n")
+			} else {
+				fmt.Printf("[Tool Call] %s\n", e.Request.Name)
+			}
+
+		case agent.ToolResponseEvent:
+			if e.Response.Error != "" {
+				fmt.Printf("[Error] %s\n", e.Response.Error)
+			}
+
+		case agent.MessageEvent:
+			fmt.Printf("\nAssistant: %s\n", e.Response.Message.TextContent())
+
+		case agent.InvocationEndEvent:
+			fmt.Printf("\n[Done] Finish reason: %s\n", e.FinishReason)
+			if e.Usage != nil {
+				fmt.Printf("Total tokens used: %d\n", e.Usage.TotalTokens)
+			}
+		}
+	}
+
+	// Print token usage summary
+	fmt.Println()
+	fmt.Println("=================================================")
+	fmt.Println("Token Usage Summary:")
+	fmt.Printf("  Main Agent:      %d tokens\n", mainUsage.totalTokens)
+	fmt.Printf("  Assistant Agent: %d tokens\n", assistantUsage.totalTokens)
+	fmt.Printf("  Total:           %d tokens\n", mainUsage.totalTokens+assistantUsage.totalTokens)
+	fmt.Println()
+	fmt.Println("Context Isolation Benefit:")
+	fmt.Println("  The assistant agent ran with a fresh context,")
+	fmt.Println("  keeping the main agent's context clean and focused.")
+	fmt.Printf("  Assistant handled %d tokens of work independently.\n", assistantUsage.totalTokens)
+}

--- a/tool/agenttool/agenttool.go
+++ b/tool/agenttool/agenttool.go
@@ -1,0 +1,132 @@
+// Package agenttool wraps agents as tools for hierarchical composition and context isolation.
+//
+// AgentTool enables parent agents to delegate subtasks to child agents with fresh sessions.
+// Each invocation creates an isolated context, useful for:
+//   - Context management: offload subtasks without polluting main agent context
+//   - Tool access: child agents can have different tools than parent
+//   - Focused execution: each subtask gets clean context
+//
+// Usage:
+//
+//	// Create assistant with tools
+//	assistant := llmagent.New("assistant", "You are helpful...", model,
+//	    llmagent.WithTools(toolRegistry))
+//
+//	// Main agent delegates via agenttool
+//	mainTools := tool.NewRegistry(tool.RegistryConfig{})
+//	mainTools.Register(agenttool.New(assistant))
+package agenttool
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/redpanda-data/ai-sdk-go/agent"
+	"github.com/redpanda-data/ai-sdk-go/llm"
+	"github.com/redpanda-data/ai-sdk-go/store/session"
+	"github.com/redpanda-data/ai-sdk-go/tool"
+)
+
+// AgentTool wraps an Agent as a Tool, enabling hierarchical agent composition.
+// Each invocation creates a fresh session for the agent.
+type AgentTool struct {
+	agent agent.Agent
+}
+
+// New creates a new AgentTool that wraps the given agent as a tool.
+func New(a agent.Agent) tool.Tool {
+	return &AgentTool{agent: a}
+}
+
+// Definition implements tool.Tool by using the agent's existing metadata.
+func (at *AgentTool) Definition() llm.ToolDefinition {
+	schema := at.agent.InputSchema()
+
+	schemaJSON, err := json.Marshal(schema)
+	if err != nil {
+		// Programming error: agent's InputSchema contains unmarshalable types (channels, funcs, etc.)
+		// This is caught at tool registration time, not by user input or parent agent calls.
+		return llm.ToolDefinition{
+			Name:        at.agent.Name(),
+			Description: fmt.Sprintf("[SCHEMA ERROR] %s - Invalid InputSchema implementation: %v", at.agent.Description(), err),
+			Parameters:  json.RawMessage(`{"type":"object"}`),
+		}
+	}
+
+	return llm.ToolDefinition{
+		Name:        at.agent.Name(),
+		Description: at.agent.Description(),
+		Parameters:  schemaJSON,
+	}
+}
+
+// Result represents the output from an agent tool execution.
+type Result struct {
+	Result string `json:"result"`
+}
+
+// Execute implements tool.Tool by running the agent with a fresh session.
+//
+// Input Handling:
+//   - Args are passed as JSON in a user message (e.g., {"query": "search X"})
+//   - The child agent receives this as text and parses it naturally
+//   - Modern LLMs reliably handle JSON parsing from text
+//   - Alternative approaches (text wrapping, schema validation) add complexity
+//     without proven value - the LLM handles malformed inputs by asking for clarification
+//
+// Output Structure:
+//   - Returns {"result": "<text>"}
+//   - Only the last assistant message is captured as the result
+//   - Token usage is tracked separately via interceptors on the agent
+//
+// Session Isolation:
+//   - Each invocation creates a fresh session (no context sharing)
+//   - This prevents context pollution and keeps parent/child boundaries clear
+//   - For context sharing, pass relevant information explicitly in args
+func (at *AgentTool) Execute(ctx context.Context, args json.RawMessage) (json.RawMessage, error) {
+	// 1. Create fresh session with unique ID to prevent collisions in state stores
+	sess := &session.State{
+		ID:       fmt.Sprintf("agent-tool-%s-%d", at.agent.Name(), time.Now().UnixNano()),
+		Messages: []llm.Message{},
+		Metadata: map[string]any{},
+	}
+
+	// 2. Convert args to user message
+	// Args are passed as JSON text (e.g., {"query": "..."})
+	// Child agent receives this in a user message and parses it naturally
+	userMsg := llm.NewMessage(llm.RoleUser, llm.NewTextPart(string(args)))
+	sess.Messages = append(sess.Messages, userMsg)
+
+	// 3. Create invocation metadata
+	inv := agent.NewInvocationMetadata(sess, agent.Info{
+		Name:        at.agent.Name(),
+		Description: at.agent.Description(),
+	})
+
+	// 4. Run agent and collect response
+	var result string
+
+	for evt, err := range at.agent.Run(ctx, inv) {
+		if err != nil {
+			return nil, fmt.Errorf("agent execution failed: %w", err)
+		}
+
+		// Capture last assistant message as result
+		if msgEvt, ok := evt.(agent.MessageEvent); ok {
+			result = msgEvt.Response.Message.TextContent()
+		}
+	}
+
+	// 5. Return result
+	if result == "" {
+		result = "Task completed with no text output."
+	}
+
+	output := Result{
+		Result: result,
+	}
+
+	return json.Marshal(output)
+}

--- a/tool/agenttool/agenttool_test.go
+++ b/tool/agenttool/agenttool_test.go
@@ -1,0 +1,232 @@
+package agenttool_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"iter"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/redpanda-data/ai-sdk-go/agent"
+	"github.com/redpanda-data/ai-sdk-go/llm"
+	"github.com/redpanda-data/ai-sdk-go/tool"
+	"github.com/redpanda-data/ai-sdk-go/tool/agenttool"
+)
+
+// mockAgent is a simple test agent that returns a predefined response.
+type mockAgent struct {
+	name        string
+	description string
+	inputSchema map[string]any
+	response    string
+	shouldError bool
+}
+
+func (m *mockAgent) Name() string {
+	return m.name
+}
+
+func (m *mockAgent) Description() string {
+	return m.description
+}
+
+func (m *mockAgent) InputSchema() map[string]any {
+	return m.inputSchema
+}
+
+func (m *mockAgent) Run(_ context.Context, _ *agent.InvocationMetadata) iter.Seq2[agent.Event, error] {
+	return func(yield func(agent.Event, error) bool) {
+		if m.shouldError {
+			yield(nil, errors.New("mock agent error"))
+			return
+		}
+
+		// Emit a message event
+		msg := llm.NewMessage(llm.RoleAssistant, llm.NewTextPart(m.response))
+		evt := agent.MessageEvent{
+			Response: llm.Response{
+				Message: msg,
+			},
+		}
+
+		yield(evt, nil)
+
+		// Emit end event
+		endEvt := agent.InvocationEndEvent{
+			FinishReason: agent.FinishReasonStop,
+		}
+		yield(endEvt, nil)
+	}
+}
+
+// blockingMockAgent simulates an agent that blocks until context is cancelled.
+type blockingMockAgent struct {
+	mockAgent
+}
+
+func (m *blockingMockAgent) Run(ctx context.Context, _ *agent.InvocationMetadata) iter.Seq2[agent.Event, error] {
+	return func(yield func(agent.Event, error) bool) {
+		// Block until context is cancelled
+		<-ctx.Done()
+		yield(nil, ctx.Err())
+	}
+}
+
+func TestNew(t *testing.T) {
+	t.Parallel()
+
+	mockAgent := &mockAgent{
+		name:        "test-agent",
+		description: "A test agent",
+		response:    "test response",
+	}
+
+	agentTool := agenttool.New(mockAgent)
+
+	require.NotNil(t, agentTool)
+	assert.Implements(t, (*tool.Tool)(nil), agentTool)
+}
+
+func TestDefinition(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		agentName   string
+		description string
+		schema      map[string]any
+	}{
+		{
+			name:        "basic agent",
+			agentName:   "search-agent",
+			description: "Searches for information",
+			schema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"query": map[string]any{
+						"type":        "string",
+						"description": "The search query",
+					},
+				},
+			},
+		},
+		{
+			name:        "nil schema",
+			agentName:   "simple-agent",
+			description: "Simple agent",
+			schema:      nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			mockAgent := &mockAgent{
+				name:        tt.agentName,
+				description: tt.description,
+				inputSchema: tt.schema,
+				response:    "test",
+			}
+
+			agentTool := agenttool.New(mockAgent)
+			def := agentTool.Definition()
+
+			assert.Equal(t, tt.agentName, def.Name)
+			assert.Equal(t, tt.description, def.Description)
+
+			// Parameters is json.RawMessage, so unmarshal to compare
+			var actualSchema map[string]any
+			if def.Parameters != nil {
+				err := json.Unmarshal(def.Parameters, &actualSchema)
+				require.NoError(t, err)
+			}
+
+			assert.Equal(t, tt.schema, actualSchema)
+		})
+	}
+}
+
+func TestExecute(t *testing.T) {
+	t.Parallel()
+
+	t.Run("successful execution", func(t *testing.T) {
+		t.Parallel()
+
+		mockAgent := &mockAgent{
+			name:     "test-agent",
+			response: "This is the agent response",
+		}
+
+		agentTool := agenttool.New(mockAgent)
+
+		args, _ := json.Marshal(map[string]string{"query": "test query"})
+		result, err := agentTool.Execute(context.Background(), args)
+
+		require.NoError(t, err)
+
+		var output agenttool.Result
+		err = json.Unmarshal(result, &output)
+		require.NoError(t, err)
+		assert.Equal(t, "This is the agent response", output.Result)
+	})
+
+	t.Run("empty args", func(t *testing.T) {
+		t.Parallel()
+
+		mockAgent := &mockAgent{
+			name:     "test-agent",
+			response: "Response without input",
+		}
+
+		agentTool := agenttool.New(mockAgent)
+
+		result, err := agentTool.Execute(context.Background(), json.RawMessage("{}"))
+
+		require.NoError(t, err)
+
+		var output agenttool.Result
+		err = json.Unmarshal(result, &output)
+		require.NoError(t, err)
+		assert.Equal(t, "Response without input", output.Result)
+	})
+
+	t.Run("agent error propagation", func(t *testing.T) {
+		t.Parallel()
+
+		mockAgent := &mockAgent{
+			name:        "failing-agent",
+			shouldError: true,
+		}
+
+		agentTool := agenttool.New(mockAgent)
+
+		_, err := agentTool.Execute(context.Background(), json.RawMessage("{}"))
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "agent execution failed")
+	})
+
+	t.Run("context cancellation", func(t *testing.T) {
+		t.Parallel()
+
+		blockingAgent := &blockingMockAgent{
+			mockAgent: mockAgent{name: "blocking-agent"},
+		}
+
+		agentTool := agenttool.New(blockingAgent)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+		defer cancel()
+
+		_, err := agentTool.Execute(ctx, json.RawMessage("{}"))
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "agent execution failed")
+		assert.ErrorIs(t, err, context.DeadlineExceeded)
+	})
+}


### PR DESCRIPTION
This PR adds a new agent tool. This allows you to provide any agent that satisfies the agent interface to be used as a tool. This helps for context management or also consult more specialized agents with different toolsets. This is primarily intended for more efficient context management e.g. to spin up some sub agents to do a bunch of research work and then only hand back the most important findings to the parent agent.