### PR TITLE
Add CompositeRegistry for tool aggregation

### DIFF
--- a/tool/registry.go
+++ b/tool/registry.go
@@ -227,16 +227,24 @@ func (r *registry) Execute(ctx context.Context, req *llm.ToolRequest) (*llm.Tool
 	}, nil
 }
 
-// ExecuteAll implements Registry.ExecuteAll.
-// All errors are encoded in ToolResponse.Error fields, including:
-// - Per-tool execution failures
-// - Individual tool timeouts
-// - Context cancellation (for tasks that never started or were interrupted)
+// executeAllConcurrent is a shared helper for concurrent tool execution.
+// It implements the best-effort pattern: all errors are encoded in ToolResponse.Error,
+// never as top-level errors. Always returns len(reqs) responses.
 //
-// This "best-effort" pattern ensures callers always get a predictable response
-// structure with len(reqs) entries, making it simpler to process results without
-// checking for top-level errors.
-func (r *registry) ExecuteAll(ctx context.Context, reqs []*llm.ToolRequest, opts ...BatchOption) []*llm.ToolResponse {
+// This helper enables code reuse between registry and CompositeRegistry implementations,
+// ensuring consistent concurrency behavior across all registry types.
+//
+// Parameters:
+//   - ctx: context for cancellation
+//   - reqs: slice of tool requests to execute
+//   - opts: batch options (concurrency control, etc.)
+//   - execOne: function to execute a single request (registry-specific)
+func executeAllConcurrent(
+	ctx context.Context,
+	reqs []*llm.ToolRequest,
+	opts []BatchOption,
+	execOne func(context.Context, *llm.ToolRequest) (*llm.ToolResponse, error),
+) []*llm.ToolResponse {
 	n := len(reqs)
 	if n == 0 {
 		return []*llm.ToolResponse{}
@@ -260,7 +268,7 @@ func (r *registry) ExecuteAll(ctx context.Context, reqs []*llm.ToolRequest, opts
 		g.Go(func() error {
 			// Per-tool errors are encoded in resp.Error, never propagated to errgroup.
 			// This prevents one tool failure from canceling other concurrent executions.
-			resp, _ := r.executeOne(gctx, req)
+			resp, _ := execOne(gctx, req)
 			results[i] = resp
 
 			return nil
@@ -282,6 +290,19 @@ func (r *registry) ExecuteAll(ctx context.Context, reqs []*llm.ToolRequest, opts
 	}
 
 	return results
+}
+
+// ExecuteAll implements Registry.ExecuteAll.
+// All errors are encoded in ToolResponse.Error fields, including:
+// - Per-tool execution failures
+// - Individual tool timeouts
+// - Context cancellation (for tasks that never started or were interrupted)
+//
+// This "best-effort" pattern ensures callers always get a predictable response
+// structure with len(reqs) entries, making it simpler to process results without
+// checking for top-level errors.
+func (r *registry) ExecuteAll(ctx context.Context, reqs []*llm.ToolRequest, opts ...BatchOption) []*llm.ToolResponse {
+	return executeAllConcurrent(ctx, reqs, opts, r.executeOne)
 }
 
 // enforceResponseSizeLimit checks response size and applies limits/fallbacks.

--- a/tool/registry_composite.go
+++ b/tool/registry_composite.go
@@ -104,23 +104,28 @@ func (c *CompositeRegistry) Execute(ctx context.Context, req *llm.ToolRequest) (
 	return nil, ErrToolNotFound
 }
 
-// ExecuteAll runs multiple tool requests, routing each to the appropriate child registry.
-func (c *CompositeRegistry) ExecuteAll(ctx context.Context, reqs []*llm.ToolRequest, _ ...BatchOption) []*llm.ToolResponse {
-	responses := make([]*llm.ToolResponse, len(reqs))
-
-	for i, req := range reqs {
-		resp, err := c.Execute(ctx, req)
-		if err != nil {
-			// Convert error to ToolResponse format
-			responses[i] = &llm.ToolResponse{
-				ID:    req.ID,
-				Name:  req.Name,
-				Error: err.Error(),
-			}
-		} else {
-			responses[i] = resp
+// ExecuteAll runs multiple tool requests concurrently, routing each to the appropriate child registry.
+// Respects batch options like WithMaxConcurrency() for controlled concurrency.
+//
+// Like the normal registry, this uses the best-effort pattern: all errors are encoded in
+// ToolResponse.Error fields, and len(reqs) responses are always returned in the same order.
+func (c *CompositeRegistry) ExecuteAll(ctx context.Context, reqs []*llm.ToolRequest, opts ...BatchOption) []*llm.ToolResponse {
+	// Use the shared concurrent execution helper with our Execute method
+	// which routes each request to the appropriate child registry
+	return executeAllConcurrent(ctx, reqs, opts, func(ctx context.Context, req *llm.ToolRequest) (*llm.ToolResponse, error) {
+		if req == nil {
+			return &llm.ToolResponse{Error: ErrToolRequestNil.Error()}, ErrToolRequestNil
 		}
-	}
 
-	return responses
+		resp, err := c.Execute(ctx, req)
+		if resp == nil {
+			resp = &llm.ToolResponse{ID: req.ID, Name: req.Name}
+		}
+
+		if err != nil {
+			resp.Error = err.Error()
+		}
+
+		return resp, err
+	})
 }

--- a/tool/registry_composite_test.go
+++ b/tool/registry_composite_test.go
@@ -3,7 +3,10 @@ package tool
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -480,5 +483,286 @@ func TestCompositeRegistry_MCPUseCase(t *testing.T) {
 		names := []string{defs[0].Name, defs[1].Name}
 		assert.Contains(t, names, "mcp_tool")
 		assert.Contains(t, names, "agent2_custom")
+	})
+}
+
+// mockConcurrentTool tracks concurrent execution for testing.
+type mockConcurrentTool struct {
+	name             string
+	delay            time.Duration
+	currentCounter   *atomic.Int32
+	maxCounter       *atomic.Int32
+	executionCounter *atomic.Int32
+}
+
+func (t *mockConcurrentTool) Definition() llm.ToolDefinition {
+	return llm.ToolDefinition{
+		Name:        t.name,
+		Description: "Mock tool for concurrency testing",
+		Parameters:  json.RawMessage(`{"type":"object","properties":{}}`),
+	}
+}
+
+func (t *mockConcurrentTool) Execute(ctx context.Context, _ json.RawMessage) (json.RawMessage, error) {
+	// Track execution count
+	if t.executionCounter != nil {
+		t.executionCounter.Add(1)
+	}
+
+	// Track concurrent execution
+	current := t.currentCounter.Add(1)
+	defer t.currentCounter.Add(-1)
+
+	// Update max concurrent if needed
+	for {
+		maxVal := t.maxCounter.Load()
+		if current <= maxVal || t.maxCounter.CompareAndSwap(maxVal, current) {
+			break
+		}
+	}
+
+	// Simulate work with context cancellation support
+	select {
+	case <-time.After(t.delay):
+		return json.Marshal(map[string]string{"result": "success"})
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
+func TestCompositeRegistry_Concurrency(t *testing.T) {
+	t.Parallel()
+
+	t.Run("respects concurrency limit", func(t *testing.T) {
+		t.Parallel()
+
+		var currentConcurrent, maxConcurrent atomic.Int32
+
+		mockTool := &mockConcurrentTool{
+			name:           "test-tool",
+			delay:          50 * time.Millisecond,
+			currentCounter: &currentConcurrent,
+			maxCounter:     &maxConcurrent,
+		}
+
+		reg1 := NewRegistry(RegistryConfig{})
+		require.NoError(t, reg1.Register(mockTool))
+
+		composite := NewCompositeRegistry(reg1)
+
+		// Create 10 requests
+		requests := make([]*llm.ToolRequest, 10)
+		for i := range requests {
+			requests[i] = &llm.ToolRequest{
+				ID:        fmt.Sprintf("req-%d", i),
+				Name:      "test-tool",
+				Arguments: json.RawMessage(`{}`),
+			}
+		}
+
+		results := composite.ExecuteAll(
+			context.Background(),
+			requests,
+			WithMaxConcurrency(3),
+		)
+
+		require.Len(t, results, 10)
+		assert.LessOrEqual(t, maxConcurrent.Load(), int32(3), "Should respect concurrency limit of 3")
+		assert.GreaterOrEqual(t, maxConcurrent.Load(), int32(1), "At least one tool should have run concurrently")
+
+		// Verify all succeeded
+		for i, resp := range results {
+			assert.Empty(t, resp.Error, "Request %d should succeed", i)
+			assert.NotEmpty(t, resp.Result)
+		}
+	})
+
+	t.Run("default full parallelism", func(t *testing.T) {
+		t.Parallel()
+
+		var currentConcurrent, maxConcurrent atomic.Int32
+
+		mockTool := &mockConcurrentTool{
+			name:           "test-tool",
+			delay:          50 * time.Millisecond,
+			currentCounter: &currentConcurrent,
+			maxCounter:     &maxConcurrent,
+		}
+
+		reg1 := NewRegistry(RegistryConfig{})
+		require.NoError(t, reg1.Register(mockTool))
+
+		composite := NewCompositeRegistry(reg1)
+
+		// Create 5 requests
+		requests := make([]*llm.ToolRequest, 5)
+		for i := range requests {
+			requests[i] = &llm.ToolRequest{
+				ID:        fmt.Sprintf("req-%d", i),
+				Name:      "test-tool",
+				Arguments: json.RawMessage(`{}`),
+			}
+		}
+
+		// No concurrency limit specified - should run all in parallel
+		results := composite.ExecuteAll(context.Background(), requests)
+
+		require.Len(t, results, 5)
+		// All 5 should have run concurrently (or close to it due to timing)
+		assert.GreaterOrEqual(t, maxConcurrent.Load(), int32(3), "Should run multiple tools concurrently by default")
+
+		for i, resp := range results {
+			assert.Empty(t, resp.Error, "Request %d should succeed", i)
+		}
+	})
+
+	t.Run("context cancellation", func(t *testing.T) {
+		t.Parallel()
+
+		var executionCount atomic.Int32
+		mockTool := &mockConcurrentTool{
+			name:             "test-tool",
+			delay:            500 * time.Millisecond, // Longer delay to ensure cancellation happens
+			currentCounter:   &atomic.Int32{},
+			maxCounter:       &atomic.Int32{},
+			executionCounter: &executionCount,
+		}
+
+		reg1 := NewRegistry(RegistryConfig{})
+		require.NoError(t, reg1.Register(mockTool))
+
+		composite := NewCompositeRegistry(reg1)
+
+		// Create 5 requests
+		requests := make([]*llm.ToolRequest, 5)
+		for i := range requests {
+			requests[i] = &llm.ToolRequest{
+				ID:        fmt.Sprintf("req-%d", i),
+				Name:      "test-tool",
+				Arguments: json.RawMessage(`{}`),
+			}
+		}
+
+		// Cancel context after 50ms (before tools can complete their 500ms delay)
+		ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+		defer cancel()
+
+		results := composite.ExecuteAll(ctx, requests)
+
+		// ExecuteAll always returns len(reqs) responses, even on cancellation
+		require.Len(t, results, 5)
+
+		// At least some results should have errors due to cancellation
+		// (some may have started and been cancelled, others may never have started)
+		errorCount := 0
+
+		for _, result := range results {
+			if result.Error != "" {
+				errorCount++
+			}
+		}
+
+		assert.Positive(t, errorCount, "At least some requests should have errors due to cancellation")
+	})
+
+	t.Run("mixed registries concurrent execution", func(t *testing.T) {
+		t.Parallel()
+
+		var currentConcurrent, maxConcurrent atomic.Int32
+
+		mockTool1 := &mockConcurrentTool{
+			name:           "tool1",
+			delay:          50 * time.Millisecond,
+			currentCounter: &currentConcurrent,
+			maxCounter:     &maxConcurrent,
+		}
+
+		mockTool2 := &mockConcurrentTool{
+			name:           "tool2",
+			delay:          50 * time.Millisecond,
+			currentCounter: &currentConcurrent,
+			maxCounter:     &maxConcurrent,
+		}
+
+		reg1 := NewRegistry(RegistryConfig{})
+		require.NoError(t, reg1.Register(mockTool1))
+
+		reg2 := NewRegistry(RegistryConfig{})
+		require.NoError(t, reg2.Register(mockTool2))
+
+		composite := NewCompositeRegistry(reg1, reg2)
+
+		// Create mixed requests from both registries
+		requests := []*llm.ToolRequest{
+			{ID: "req-1", Name: "tool1", Arguments: json.RawMessage(`{}`)},
+			{ID: "req-2", Name: "tool2", Arguments: json.RawMessage(`{}`)},
+			{ID: "req-3", Name: "tool1", Arguments: json.RawMessage(`{}`)},
+			{ID: "req-4", Name: "tool2", Arguments: json.RawMessage(`{}`)},
+		}
+
+		results := composite.ExecuteAll(
+			context.Background(),
+			requests,
+			WithMaxConcurrency(2),
+		)
+
+		require.Len(t, results, 4)
+		assert.LessOrEqual(t, maxConcurrent.Load(), int32(2), "Should respect concurrency limit")
+
+		// Verify correct tool execution and order preservation
+		assert.Equal(t, "req-1", results[0].ID)
+		assert.Equal(t, "tool1", results[0].Name)
+		assert.Equal(t, "req-2", results[1].ID)
+		assert.Equal(t, "tool2", results[1].Name)
+		assert.Equal(t, "req-3", results[2].ID)
+		assert.Equal(t, "tool1", results[2].Name)
+		assert.Equal(t, "req-4", results[3].ID)
+		assert.Equal(t, "tool2", results[3].Name)
+
+		// All should succeed
+		for i, resp := range results {
+			assert.Empty(t, resp.Error, "Request %d should succeed", i)
+		}
+	})
+
+	t.Run("sequential execution with concurrency 1", func(t *testing.T) {
+		t.Parallel()
+
+		var currentConcurrent, maxConcurrent atomic.Int32
+
+		mockTool := &mockConcurrentTool{
+			name:           "test-tool",
+			delay:          30 * time.Millisecond,
+			currentCounter: &currentConcurrent,
+			maxCounter:     &maxConcurrent,
+		}
+
+		reg1 := NewRegistry(RegistryConfig{})
+		require.NoError(t, reg1.Register(mockTool))
+
+		composite := NewCompositeRegistry(reg1)
+
+		requests := make([]*llm.ToolRequest, 5)
+		for i := range requests {
+			requests[i] = &llm.ToolRequest{
+				ID:        fmt.Sprintf("req-%d", i),
+				Name:      "test-tool",
+				Arguments: json.RawMessage(`{}`),
+			}
+		}
+
+		// Force sequential execution
+		results := composite.ExecuteAll(
+			context.Background(),
+			requests,
+			WithMaxConcurrency(1),
+		)
+
+		require.Len(t, results, 5)
+		assert.Equal(t, int32(1), maxConcurrent.Load(), "Should execute sequentially with concurrency limit 1")
+
+		for i, resp := range results {
+			assert.Empty(t, resp.Error, "Request %d should succeed", i)
+		}
 	})
 }


### PR DESCRIPTION
## What

CompositeRegistry implementation for aggregating multiple tool registries into a single interface.

## Why

MCP client deduplication requires sharing tools across multiple agents. Current single-registry-per-agent model forces duplicate connections for shared toolsets. Wrong architectural choice when multiple agents need the same MCP server tools.

## Implementation details

Registry-of-registries pattern with transparent delegation:

**Lookup strategy**: First registry with matching tool name wins. Straightforward linear search with early exit.

**Read operations**: Get/Execute/ExecuteAll delegate to child registries. List() merges all tools, deduplicating by name.

**Write operations**: Register/Unregister blocked on composite - callers modify child registries directly. Prevents confusion about which registry owns the tool.

**Concurrent execution**: Added shared executeAllConcurrent helper used by both standard and composite registries. Removes code duplication while respecting batch options like WithMaxConcurrency.

**Use case pattern**:
```go
// Server creates one MCP client with leaf registry
mcpRegistry := tool.NewRegistry(tool.RegistryConfig{})
mcp.NewClient("serverID", transport, mcp.WithRegistry(mcpRegistry))

// Each agent gets composite of shared MCP + agent-specific tools
agent1 := tool.NewCompositeRegistry(mcpRegistry, agent1Custom)
agent2 := tool.NewCompositeRegistry(mcpRegistry, agent2Custom)
```

Both agents share the same MCP connection/tools while maintaining isolated custom registries.