### PR TITLE
Make API key optional for openaicompat provider

### DIFF
--- a/providers/openaicompat/openaicompat_test.go
+++ b/providers/openaicompat/openaicompat_test.go
@@ -14,16 +14,17 @@ import (
 
 func TestProviderCreation(t *testing.T) {
 	t.Parallel()
-	// Valid provider creation
+	// Valid provider creation with API key
 	provider, err := NewProvider("sk-test-key-123")
 	require.NoError(t, err)
 	assert.NotNil(t, provider)
 	assert.NotNil(t, provider.client)
 
-	// Empty API key should fail
-	_, err = NewProvider("")
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "API key is required")
+	// Empty API key should be allowed (for providers that don't require authentication)
+	provider, err = NewProvider("")
+	require.NoError(t, err)
+	assert.NotNil(t, provider)
+	assert.NotNil(t, provider.client)
 
 	// Invalid options should fail
 	_, err = NewProvider("sk-test", WithTimeout(-1*time.Second))

--- a/providers/openaicompat/provider.go
+++ b/providers/openaicompat/provider.go
@@ -35,12 +35,9 @@ func (p *Provider) Name() string {
 // ProviderOption configures a Provider instance using functional options.
 type ProviderOption func(*Provider) error
 
-// NewProvider creates a new OpenAI-compatible provider with the required API key and optional configuration.
+// NewProvider creates a new OpenAI-compatible provider with optional configuration.
+// The API key is optional to support providers that don't require authentication.
 func NewProvider(apiKey string, opts ...ProviderOption) (*Provider, error) {
-	if apiKey == "" {
-		return nil, errors.New("API key is required")
-	}
-
 	timeout := 10 * time.Minute
 	p := &Provider{
 		APIKey:  apiKey,
@@ -60,10 +57,15 @@ func NewProvider(apiKey string, opts ...ProviderOption) (*Provider, error) {
 
 	// Initialize OpenAI client with provider configuration
 	clientOpts := []option.RequestOption{
-		option.WithAPIKey(p.APIKey),
 		option.WithBaseURL(p.BaseURL),
 		option.WithHTTPClient(p.HTTPClient),
 	}
+
+	// Only add API key if provided
+	if p.APIKey != "" {
+		clientOpts = append(clientOpts, option.WithAPIKey(p.APIKey))
+	}
+
 	client := openai.NewClient(clientOpts...)
 	p.client = &client
 


### PR DESCRIPTION
E.g. out api-gateway is open-ai compat api but does not require the key