### PR TITLE
otel: add tool type and description tracking

### DIFF
--- a/agent/interceptors.go
+++ b/agent/interceptors.go
@@ -180,6 +180,11 @@ type ToolCallInfo struct {
 
 	// Req is the tool request from the LLM.
 	Req *llm.ToolRequest
+
+	// Definition is the full tool definition including description and type.
+	// Used by interceptors for observability (e.g., OpenTelemetry attributes).
+	// May be nil if tool definition is not available.
+	Definition *llm.ToolDefinition
 }
 
 // ToolExecutionNext is the continuation function for tool execution interception.

--- a/agent/llmagent/llmagent.go
+++ b/agent/llmagent/llmagent.go
@@ -321,7 +321,7 @@ func (a *LLMAgent) executeSingleTurn(
 		return "", agent.ErrToolRegistry
 	}
 
-	toolParts := a.executeTools(ctx, inv, toolReqs, makeEnvelope, yield)
+	toolParts := a.executeTools(ctx, inv, toolReqs, req.Tools, makeEnvelope, yield)
 
 	// Build single message with all tool response parts
 	toolMsg := llm.NewMessage(llm.RoleUser, toolParts...)
@@ -458,6 +458,7 @@ func (a *LLMAgent) executeTools(
 	ctx context.Context,
 	inv *agent.InvocationMetadata,
 	toolReqs []*llm.ToolRequest,
+	toolDefs []llm.ToolDefinition,
 	makeEnvelope func() agent.EventEnvelope,
 	yield func(agent.Event, error) bool,
 ) []*llm.Part {
@@ -484,10 +485,20 @@ func (a *LLMAgent) executeTools(
 	// Apply tool interceptors
 	executor := agent.ApplyToolInterceptors(a.config.interceptors, baseExecutor)
 
+	// Build tool definition lookup map for interceptors from provided definitions
+	toolDefMap := make(map[string]*llm.ToolDefinition, len(toolDefs))
+	for i := range toolDefs {
+		toolDefMap[toolDefs[i].Name] = &toolDefs[i]
+	}
+
 	// Launch tool executions
 	for i, req := range toolReqs {
 		g.Go(func() error {
-			toolInfo := &agent.ToolCallInfo{Inv: inv, Req: req}
+			toolInfo := &agent.ToolCallInfo{
+				Inv:        inv,
+				Req:        req,
+				Definition: toolDefMap[req.Name], // Add tool definition
+			}
 
 			resp, err := executor(gctx, toolInfo)
 			results <- toolResult{

--- a/llm/request.go
+++ b/llm/request.go
@@ -49,6 +49,11 @@ type ToolDefinition struct {
 	// Metadata provides additional information about the tool.
 	// This can include provider-specific configuration or documentation.
 	Metadata map[string]any `json:"metadata,omitempty"`
+
+	// Type specifies the tool category for observability.
+	// Values: "function" (default), "extension", "datastore"
+	// Used for OpenTelemetry gen_ai.tool.type attribute.
+	Type string `json:"type,omitempty"`
 }
 
 // ToolChoice controls how the model should interact with available tools.
@@ -68,6 +73,22 @@ const (
 	ToolChoiceNone     = "none"     // Model should not use any tools
 	ToolChoiceRequired = "required" // Model must use at least one tool
 	ToolChoiceSpecific = "specific" // Model must use the tool specified in Name
+)
+
+// Tool type constants for OpenTelemetry semantic conventions.
+// These describe where/how the tool executes.
+const (
+	// ToolTypeFunction: Local execution - agent generates parameters,
+	// local code executes the logic (built-in tools, user-provided functions).
+	ToolTypeFunction = "function"
+
+	// ToolTypeExtension: Agent-side remote execution - agent calls
+	// external APIs or services (e.g., MCP server tools).
+	ToolTypeExtension = "extension"
+
+	// ToolTypeDatastore: Specialized data retrieval tools
+	// (e.g., vector databases, knowledge bases).
+	ToolTypeDatastore = "datastore"
 )
 
 // ResponseFormat controls the structure of the model's output.

--- a/plugins/otel/attributes.go
+++ b/plugins/otel/attributes.go
@@ -37,6 +37,8 @@ const (
 	attrGenAIToolCallID            = "gen_ai.tool.call.id"
 	attrGenAIToolCallArguments     = "gen_ai.tool.call.arguments"
 	attrGenAIToolCallResult        = "gen_ai.tool.call.result"
+	attrGenAIToolType              = "gen_ai.tool.type"
+	attrGenAIToolDescription       = "gen_ai.tool.description"
 	attrToolArgumentsSize          = "redpanda.tool.arguments.size"
 	attrToolResultSize             = "redpanda.tool.result.size"
 	attrToolExecutionDuration      = "redpanda.tool.execution.duration"
@@ -193,6 +195,14 @@ func genAIToolCallArguments(args string) attribute.KeyValue {
 
 func genAIToolCallResult(result string) attribute.KeyValue {
 	return attribute.String(attrGenAIToolCallResult, result)
+}
+
+func genAIToolType(toolType string) attribute.KeyValue {
+	return attribute.String(attrGenAIToolType, toolType)
+}
+
+func genAIToolDescription(description string) attribute.KeyValue {
+	return attribute.String(attrGenAIToolDescription, description)
 }
 
 func genAIInputMessages(json string) attribute.KeyValue {

--- a/plugins/otel/otel_test.go
+++ b/plugins/otel/otel_test.go
@@ -714,6 +714,339 @@ func TestTracingInterceptor_ContextPropagation(t *testing.T) {
 	assert.NotEmpty(t, spans)
 }
 
+func TestTracingInterceptor_InterceptToolExecution_WithToolTypeAndDescription(t *testing.T) {
+	t.Parallel()
+
+	exporter, tp := setupTracer()
+	defer tp.Shutdown(t.Context()) //nolint:errcheck // Test cleanup
+
+	interceptor := pluginotel.New(
+		pluginotel.WithTracerProvider(tp),
+	)
+
+	inv := agent.NewInvocationMetadata(&session.State{ID: "sess-123"}, agent.Info{
+		Name:        "test-agent",
+		Description: "Test agent for OpenTelemetry tracing",
+	})
+	ctx := t.Context()
+
+	_, _ = interceptor.InterceptTurn(ctx, &agent.TurnInfo{Inv: inv}, func(ctx context.Context, _ *agent.TurnInfo) (agent.FinishReason, error) {
+		req := &llm.ToolRequest{
+			Name:      "get_weather",
+			ID:        "tool-call-123",
+			Arguments: json.RawMessage(`{"city": "Seattle"}`),
+		}
+
+		// Create a tool definition with type and description
+		toolDef := &llm.ToolDefinition{
+			Name:        "get_weather",
+			Description: "Gets the current weather for a location",
+			Type:        llm.ToolTypeFunction,
+		}
+
+		toolInfo := &agent.ToolCallInfo{
+			Inv:        inv,
+			Req:        req,
+			Definition: toolDef,
+		}
+
+		resp, err := interceptor.InterceptToolExecution(ctx, toolInfo,
+			func(_ context.Context, _ *agent.ToolCallInfo) (*llm.ToolResponse, error) {
+				return &llm.ToolResponse{Result: json.RawMessage(`"Sunny, 72F"`)}, nil
+			})
+		require.NoError(t, err)
+		assert.NotNil(t, resp)
+
+		return agent.FinishReasonStop, nil
+	})
+
+	// Find the tool span
+	spans := exporter.GetSpans()
+	var toolSpan *tracetest.SpanStub
+
+	for i := range spans {
+		if strings.HasPrefix(spans[i].Name, "execute_tool") {
+			toolSpan = &spans[i]
+			break
+		}
+	}
+
+	require.NotNil(t, toolSpan, "Expected execute_tool span")
+
+	// Check that tool type and description attributes are set
+	assertHasAttribute(t, toolSpan.Attributes, "gen_ai.tool.type", "function")
+	assertHasAttribute(t, toolSpan.Attributes, "gen_ai.tool.description", "Gets the current weather for a location")
+}
+
+func TestTracingInterceptor_InterceptToolExecution_ToolTypeDefaultsToFunction(t *testing.T) {
+	t.Parallel()
+
+	exporter, tp := setupTracer()
+	defer tp.Shutdown(t.Context()) //nolint:errcheck // Test cleanup
+
+	interceptor := pluginotel.New(
+		pluginotel.WithTracerProvider(tp),
+	)
+
+	inv := agent.NewInvocationMetadata(&session.State{ID: "sess-123"}, agent.Info{
+		Name:        "test-agent",
+		Description: "Test agent for OpenTelemetry tracing",
+	})
+	ctx := t.Context()
+
+	_, _ = interceptor.InterceptTurn(ctx, &agent.TurnInfo{Inv: inv}, func(ctx context.Context, _ *agent.TurnInfo) (agent.FinishReason, error) {
+		req := &llm.ToolRequest{
+			Name:      "custom_tool",
+			ID:        "tool-call-456",
+			Arguments: json.RawMessage(`{}`),
+		}
+
+		// Create a tool definition without specifying Type (should default to "function")
+		toolDef := &llm.ToolDefinition{
+			Name:        "custom_tool",
+			Description: "A custom tool",
+		}
+
+		toolInfo := &agent.ToolCallInfo{
+			Inv:        inv,
+			Req:        req,
+			Definition: toolDef,
+		}
+
+		_, _ = interceptor.InterceptToolExecution(ctx, toolInfo,
+			func(_ context.Context, _ *agent.ToolCallInfo) (*llm.ToolResponse, error) {
+				return &llm.ToolResponse{Result: json.RawMessage(`{}`)}, nil
+			})
+
+		return agent.FinishReasonStop, nil
+	})
+
+	// Find the tool span
+	spans := exporter.GetSpans()
+	var toolSpan *tracetest.SpanStub
+
+	for i := range spans {
+		if strings.HasPrefix(spans[i].Name, "execute_tool") {
+			toolSpan = &spans[i]
+			break
+		}
+	}
+
+	require.NotNil(t, toolSpan, "Expected execute_tool span")
+
+	// Check that tool type defaults to "function"
+	assertHasAttribute(t, toolSpan.Attributes, "gen_ai.tool.type", "function")
+}
+
+func TestTracingInterceptor_InterceptToolExecution_WithDifferentToolTypes(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name     string
+		toolType string
+	}{
+		{name: "function type", toolType: llm.ToolTypeFunction},
+		{name: "extension type", toolType: llm.ToolTypeExtension},
+		{name: "datastore type", toolType: llm.ToolTypeDatastore},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			exporter, tp := setupTracer()
+			defer tp.Shutdown(t.Context()) //nolint:errcheck // Test cleanup
+
+			interceptor := pluginotel.New(
+				pluginotel.WithTracerProvider(tp),
+			)
+
+			inv := agent.NewInvocationMetadata(&session.State{ID: "sess-123"}, agent.Info{
+				Name:        "test-agent",
+				Description: "Test agent for OpenTelemetry tracing",
+			})
+			ctx := t.Context()
+
+			_, _ = interceptor.InterceptTurn(ctx, &agent.TurnInfo{Inv: inv}, func(ctx context.Context, _ *agent.TurnInfo) (agent.FinishReason, error) {
+				req := &llm.ToolRequest{
+					Name:      "test_tool",
+					ID:        "tool-call-789",
+					Arguments: json.RawMessage(`{}`),
+				}
+
+				toolDef := &llm.ToolDefinition{
+					Name:        "test_tool",
+					Description: "A test tool",
+					Type:        tc.toolType,
+				}
+
+				toolInfo := &agent.ToolCallInfo{
+					Inv:        inv,
+					Req:        req,
+					Definition: toolDef,
+				}
+
+				_, _ = interceptor.InterceptToolExecution(ctx, toolInfo,
+					func(_ context.Context, _ *agent.ToolCallInfo) (*llm.ToolResponse, error) {
+						return &llm.ToolResponse{Result: json.RawMessage(`{}`)}, nil
+					})
+
+				return agent.FinishReasonStop, nil
+			})
+
+			// Find the tool span
+			spans := exporter.GetSpans()
+			var toolSpan *tracetest.SpanStub
+
+			for i := range spans {
+				if strings.HasPrefix(spans[i].Name, "execute_tool") {
+					toolSpan = &spans[i]
+					break
+				}
+			}
+
+			require.NotNil(t, toolSpan, "Expected execute_tool span")
+
+			// Check that the correct tool type is set
+			assertHasAttribute(t, toolSpan.Attributes, "gen_ai.tool.type", tc.toolType)
+		})
+	}
+}
+
+func TestTracingInterceptor_InterceptToolExecution_WithoutDefinition(t *testing.T) {
+	t.Parallel()
+
+	exporter, tp := setupTracer()
+	defer tp.Shutdown(t.Context()) //nolint:errcheck // Test cleanup
+
+	interceptor := pluginotel.New(
+		pluginotel.WithTracerProvider(tp),
+	)
+
+	inv := agent.NewInvocationMetadata(&session.State{ID: "sess-123"}, agent.Info{
+		Name:        "test-agent",
+		Description: "Test agent for OpenTelemetry tracing",
+	})
+	ctx := t.Context()
+
+	_, _ = interceptor.InterceptTurn(ctx, &agent.TurnInfo{Inv: inv}, func(ctx context.Context, _ *agent.TurnInfo) (agent.FinishReason, error) {
+		req := &llm.ToolRequest{
+			Name:      "unknown_tool",
+			ID:        "tool-call-999",
+			Arguments: json.RawMessage(`{}`),
+		}
+
+		// ToolCallInfo without Definition (simulates tool not found in registry)
+		toolInfo := &agent.ToolCallInfo{
+			Inv:        inv,
+			Req:        req,
+			Definition: nil, // No definition available
+		}
+
+		_, _ = interceptor.InterceptToolExecution(ctx, toolInfo,
+			func(_ context.Context, _ *agent.ToolCallInfo) (*llm.ToolResponse, error) {
+				return &llm.ToolResponse{Result: json.RawMessage(`{}`)}, nil
+			})
+
+		return agent.FinishReasonStop, nil
+	})
+
+	// Find the tool span
+	spans := exporter.GetSpans()
+	var toolSpan *tracetest.SpanStub
+
+	for i := range spans {
+		if strings.HasPrefix(spans[i].Name, "execute_tool") {
+			toolSpan = &spans[i]
+			break
+		}
+	}
+
+	require.NotNil(t, toolSpan, "Expected execute_tool span")
+
+	// Should still have basic attributes
+	assertHasAttribute(t, toolSpan.Attributes, "gen_ai.tool.name", "unknown_tool")
+	assertHasAttribute(t, toolSpan.Attributes, "gen_ai.tool.call.id", "tool-call-999")
+
+	// Should NOT have type or description attributes when Definition is nil
+	hasType := false
+	hasDescription := false
+
+	for _, attr := range toolSpan.Attributes {
+		if string(attr.Key) == "gen_ai.tool.type" {
+			hasType = true
+		}
+
+		if string(attr.Key) == "gen_ai.tool.description" {
+			hasDescription = true
+		}
+	}
+
+	assert.False(t, hasType, "Should not have gen_ai.tool.type when Definition is nil")
+	assert.False(t, hasDescription, "Should not have gen_ai.tool.description when Definition is nil")
+}
+
+func TestTracingInterceptor_InterceptToolExecution_InvalidToolTypeDefaultsToFunction(t *testing.T) {
+	t.Parallel()
+
+	exporter, tp := setupTracer()
+	defer tp.Shutdown(t.Context()) //nolint:errcheck // Test cleanup
+
+	interceptor := pluginotel.New(
+		pluginotel.WithTracerProvider(tp),
+	)
+
+	inv := agent.NewInvocationMetadata(&session.State{ID: "sess-123"}, agent.Info{
+		Name:        "test-agent",
+		Description: "Test agent for OpenTelemetry tracing",
+	})
+	ctx := t.Context()
+
+	_, _ = interceptor.InterceptTurn(ctx, &agent.TurnInfo{Inv: inv}, func(ctx context.Context, _ *agent.TurnInfo) (agent.FinishReason, error) {
+		req := &llm.ToolRequest{
+			Name:      "invalid_type_tool",
+			ID:        "tool-call-invalid",
+			Arguments: json.RawMessage(`{}`),
+		}
+
+		// Create a tool definition with an invalid Type value
+		toolDef := &llm.ToolDefinition{
+			Name:        "invalid_type_tool",
+			Description: "Tool with invalid type",
+			Type:        "invalid_type_value", // Invalid - should default to "function"
+		}
+
+		toolInfo := &agent.ToolCallInfo{
+			Inv:        inv,
+			Req:        req,
+			Definition: toolDef,
+		}
+
+		_, _ = interceptor.InterceptToolExecution(ctx, toolInfo,
+			func(_ context.Context, _ *agent.ToolCallInfo) (*llm.ToolResponse, error) {
+				return &llm.ToolResponse{Result: json.RawMessage(`{}`)}, nil
+			})
+
+		return agent.FinishReasonStop, nil
+	})
+
+	// Find the tool span
+	spans := exporter.GetSpans()
+	var toolSpan *tracetest.SpanStub
+
+	for i := range spans {
+		if strings.HasPrefix(spans[i].Name, "execute_tool") {
+			toolSpan = &spans[i]
+			break
+		}
+	}
+
+	require.NotNil(t, toolSpan, "Expected execute_tool span")
+
+	// Check that invalid tool type defaults to "function" for OTel compliance
+	assertHasAttribute(t, toolSpan.Attributes, "gen_ai.tool.type", "function")
+}
+
 // Helper functions for attribute assertions
 
 func assertHasAttribute(t *testing.T, attrs []attribute.KeyValue, key string, expected any) {

--- a/plugins/otel/tool.go
+++ b/plugins/otel/tool.go
@@ -34,6 +34,26 @@ func (t *TracingInterceptor) InterceptToolExecution(
 		attrs = append(attrs, genAIConversationID(session.ID))
 	}
 
+	// Add tool type and description if definition is available
+	if info.Definition != nil {
+		if info.Definition.Description != "" {
+			attrs = append(attrs, genAIToolDescription(info.Definition.Description))
+		}
+
+		toolType := info.Definition.Type
+		switch toolType {
+		case "", llm.ToolTypeFunction:
+			toolType = llm.ToolTypeFunction
+		case llm.ToolTypeExtension, llm.ToolTypeDatastore:
+			// Valid types - use as-is
+		default:
+			// Invalid type - default to function for OTel compliance
+			toolType = llm.ToolTypeFunction
+		}
+
+		attrs = append(attrs, genAIToolType(toolType))
+	}
+
 	// Call attribute injector if configured (before span creation for sampling)
 	if t.cfg.attributeInjector != nil {
 		sessionID := ""

--- a/tool/builtin/artifact_emit.go
+++ b/tool/builtin/artifact_emit.go
@@ -61,6 +61,7 @@ EXAMPLES:
 New artifact: {"name": "Analysis Report", "description": "Summary of findings", "text": "Analysis results...\n\nConclusions..."}
 Append to existing: {"append_to_artifact_id": "artifact-123", "text": "Additional findings..."}`,
 		Parameters: schemaBytes,
+		Type:       llm.ToolTypeFunction,
 	}
 }
 

--- a/tool/builtin/plot/tool.go
+++ b/tool/builtin/plot/tool.go
@@ -64,6 +64,7 @@ Bar: {"name": "Regional Sales", "description": "Q1 sales by region", "chart_type
 Scatter: {"name": "Transaction Analysis", "description": "Amount vs fraud score correlation", "chart_type": "scatter", "scatter_data": {"series": [{"name": "Transactions", "x": [10,20,30], "y": [0.1,0.5,0.9]}]}}
 Histogram: {"name": "Response Time Distribution", "description": "API response time frequency", "chart_type": "histogram", "histogram_data": {"values": [12.3,45.2,23.1], "bins": 10}}`,
 		Parameters: schemaBytes,
+		Type:       llm.ToolTypeFunction,
 		Metadata: map[string]any{
 			"category": "visualization",
 		},

--- a/tool/builtin/require_input.go
+++ b/tool/builtin/require_input.go
@@ -72,6 +72,7 @@ IMPORTANT:
 - Use appropriate type to categorize the input request
 - This will pause task execution until user responds`,
 		Parameters: schema,
+		Type:       llm.ToolTypeFunction,
 	}
 }
 

--- a/tool/builtin/todo/todo_update.go
+++ b/tool/builtin/todo/todo_update.go
@@ -97,6 +97,7 @@ IMPORTANT RULES:
 - Use FAILED for tasks that were attempted but couldn't be completed
 - Use ABANDONED for tasks that are no longer relevant or needed`,
 		Parameters: schema,
+		Type:       llm.ToolTypeFunction,
 	}
 }
 
@@ -227,6 +228,7 @@ IMPORTANT RULES:
 - Provide clear, actionable descriptions
 - Use specific, measurable content`,
 		Parameters: schema,
+		Type:       llm.ToolTypeFunction, // Explicit: local execution
 	}
 }
 

--- a/tool/builtin/webfetch/tool.go
+++ b/tool/builtin/webfetch/tool.go
@@ -62,6 +62,7 @@ func (t *Tool) Definition() llm.ToolDefinition {
 		Name:        "webfetch",
 		Description: "Fetch a HTTPS URL (GET/HEAD) with SSRF protection and size limits. Text/JSON/XML only.",
 		Parameters:  schemaBytes,
+		Type:        llm.ToolTypeFunction,
 		Metadata: map[string]any{
 			"category": "web",
 			"security": "high",

--- a/tool/mcp/tools.go
+++ b/tool/mcp/tools.go
@@ -233,6 +233,7 @@ func (c *clientImpl) computeToolDiff(prepared map[string]*preparedTool) []regist
 			Name:        namespaced,
 			Description: prep.mcpTool.Description,
 			Parameters:  prep.paramsJSON,
+			Type:        llm.ToolTypeExtension, // MCP tools are remote (extension)
 		}
 
 		if w, exists := c.tools[namespaced]; exists {


### PR DESCRIPTION
Adds `ToolDefinition.Type` field with constants (`function`, `extension`, `datastore`) to distinguish local vs remote tool execution for observability. MCP tools now correctly emit `extension` type instead of `function`, while builtin tools explicitly emit `function`. The otel plugin now tracks both tool type and description attributes per OpenTelemetry semantic conventions.