### PR TITLE
Add AI Gateway support for Google provider

### DIFF
--- a/providers/google/provider.go
+++ b/providers/google/provider.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
+	"time"
 
 	"google.golang.org/genai"
 
@@ -12,9 +14,12 @@ import (
 
 // Provider implements the Google Gemini model provider.
 type Provider struct {
-	APIKey  string
-	client  *genai.Client
-	context context.Context //nolint:containedctx // Context required for Gemini client lifetime management
+	APIKey     string
+	BaseURL    string
+	HTTPClient *http.Client
+	Timeout    time.Duration
+	client     *genai.Client
+	context    context.Context //nolint:containedctx // Context required for Gemini client lifetime management
 }
 
 // Name returns the provider identifier.
@@ -37,8 +42,14 @@ func NewProvider(ctx context.Context, apiKey string, opts ...ProviderOption) (*P
 		ctx = context.Background()
 	}
 
+	timeout := 10 * time.Minute
 	p := &Provider{
 		APIKey:  apiKey,
+		BaseURL: "",
+		HTTPClient: &http.Client{
+			Timeout: timeout,
+		},
+		Timeout: timeout,
 		context: ctx,
 	}
 
@@ -49,10 +60,22 @@ func NewProvider(ctx context.Context, apiKey string, opts ...ProviderOption) (*P
 		}
 	}
 
-	// Initialize Gemini client
-	client, err := genai.NewClient(ctx, &genai.ClientConfig{
+	// Initialize Gemini client with provider configuration
+	clientConfig := &genai.ClientConfig{
 		APIKey: apiKey,
-	})
+	}
+
+	// Set HTTPClient if provided
+	if p.HTTPClient != nil {
+		clientConfig.HTTPClient = p.HTTPClient
+	}
+
+	// Set BaseURL via HTTPOptions if provided
+	if p.BaseURL != "" {
+		clientConfig.HTTPOptions.BaseURL = p.BaseURL
+	}
+
+	client, err := genai.NewClient(ctx, clientConfig)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create Gemini client: %w", err)
 	}
@@ -60,6 +83,52 @@ func NewProvider(ctx context.Context, apiKey string, opts ...ProviderOption) (*P
 	p.client = client
 
 	return p, nil
+}
+
+// WithBaseURL sets a custom API endpoint for the Google provider.
+func WithBaseURL(url string) ProviderOption {
+	return func(p *Provider) error {
+		if url == "" {
+			return errors.New("base URL cannot be empty")
+		}
+
+		p.BaseURL = url
+
+		return nil
+	}
+}
+
+// WithHTTPClient sets a custom HTTP client for API requests.
+func WithHTTPClient(client *http.Client) ProviderOption {
+	return func(p *Provider) error {
+		if client == nil {
+			return errors.New("HTTP client cannot be nil")
+		}
+
+		p.HTTPClient = client
+
+		return nil
+	}
+}
+
+// WithTimeout sets the request timeout for API calls.
+// If a custom http.Client has been provided, the client is shallow-copied
+// to avoid mutating caller state.
+func WithTimeout(timeout time.Duration) ProviderOption {
+	return func(p *Provider) error {
+		if timeout <= 0 {
+			return fmt.Errorf("timeout must be positive, got %v", timeout)
+		}
+
+		p.Timeout = timeout
+
+		// Clone the existing client to avoid mutating caller-owned instances.
+		clone := *p.HTTPClient // shallow copy preserves Transport, Jar, etc.
+		clone.Timeout = timeout
+		p.HTTPClient = &clone
+
+		return nil
+	}
 }
 
 // Close closes the Gemini client and releases resources.

--- a/providers/google/provider_test.go
+++ b/providers/google/provider_test.go
@@ -1,0 +1,134 @@
+package google
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWithBaseURL(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		inputURL    string
+		expectedURL string
+	}{
+		{
+			name:        "custom gateway URL",
+			inputURL:    "https://gateway.example.com",
+			expectedURL: "https://gateway.example.com",
+		},
+		{
+			name:        "URL with path",
+			inputURL:    "https://api.example.com/v1",
+			expectedURL: "https://api.example.com/v1",
+		},
+		{
+			name:        "URL with trailing slash",
+			inputURL:    "https://api.example.com/",
+			expectedURL: "https://api.example.com/",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := context.Background()
+			provider, err := NewProvider(ctx, "test-key", WithBaseURL(tt.inputURL))
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedURL, provider.BaseURL)
+		})
+	}
+}
+
+func TestWithBaseURLValidation(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	// Empty URL should fail
+	_, err := NewProvider(ctx, "test-key", WithBaseURL(""))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "base URL cannot be empty")
+}
+
+func TestWithHTTPClient(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	// Valid HTTP client
+	customClient := &http.Client{Timeout: 30 * time.Second}
+	provider, err := NewProvider(ctx, "test-key", WithHTTPClient(customClient))
+	require.NoError(t, err)
+	assert.NotNil(t, provider.HTTPClient)
+	assert.Equal(t, 30*time.Second, provider.HTTPClient.Timeout)
+
+	// Nil HTTP client should fail
+	_, err = NewProvider(ctx, "test-key", WithHTTPClient(nil))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "HTTP client cannot be nil")
+}
+
+func TestWithTimeout(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	// Valid timeout
+	provider, err := NewProvider(ctx, "test-key", WithTimeout(5*time.Minute))
+	require.NoError(t, err)
+	assert.Equal(t, 5*time.Minute, provider.Timeout)
+	assert.Equal(t, 5*time.Minute, provider.HTTPClient.Timeout)
+
+	// Invalid timeout should fail
+	_, err = NewProvider(ctx, "test-key", WithTimeout(-1*time.Second))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "timeout must be positive")
+
+	// Zero timeout should fail
+	_, err = NewProvider(ctx, "test-key", WithTimeout(0))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "timeout must be positive")
+}
+
+func TestProviderOptionsDefaults(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	// Provider without options should have defaults
+	provider, err := NewProvider(ctx, "test-key")
+	require.NoError(t, err)
+	assert.NotNil(t, provider.HTTPClient)
+	assert.Equal(t, 10*time.Minute, provider.Timeout)
+	assert.Equal(t, 10*time.Minute, provider.HTTPClient.Timeout)
+	assert.Empty(t, provider.BaseURL)
+}
+
+func TestProviderOptionsCombination(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	// Combine multiple options
+	customClient := &http.Client{Timeout: 1 * time.Second}
+	provider, err := NewProvider(
+		ctx,
+		"test-key",
+		WithBaseURL("https://gateway.example.com"),
+		WithHTTPClient(customClient),
+		WithTimeout(5*time.Minute),
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "https://gateway.example.com", provider.BaseURL)
+	assert.NotNil(t, provider.HTTPClient)
+	assert.Equal(t, 5*time.Minute, provider.Timeout)
+	assert.Equal(t, 5*time.Minute, provider.HTTPClient.Timeout)
+}


### PR DESCRIPTION
Adds WithBaseURL, WithHTTPClient, and WithTimeout ProviderOptions to enable routing Google Gemini requests through AI Gateway infrastructure. Includes comprehensive tests matching coverage of OpenAI and Anthropic providers.