### PR TITLE
fix(agent): recover incomplete tool calls from interrupted sessions

### DIFF
--- a/agent/llmagent/llmagent.go
+++ b/agent/llmagent/llmagent.go
@@ -120,6 +120,15 @@ func (a *LLMAgent) Run(ctx context.Context, inv *agent.InvocationMetadata) iter.
 			}
 		}
 
+		// Recover incomplete tool calls before the first turn executes.
+		// This handles sessions where the previous invocation was interrupted
+		// after the assistant emitted tool requests but before tool responses
+		// were added to the session.
+		if err := a.recoverIncompleteToolCalls(ctx, inv, makeEnvelope, yield); err != nil {
+			yield(nil, err)
+			return
+		}
+
 		// Execute turn loop
 		for inv.Turn() < a.config.maxTurns {
 			// Emit turn started
@@ -550,6 +559,118 @@ func (a *LLMAgent) executeTools(
 	}
 
 	return parts
+}
+
+// recoverIncompleteToolCalls detects and executes incomplete tool calls from a
+// previous interrupted invocation.
+//
+// An incomplete tool call occurs when:
+//  1. The assistant responds with tool requests
+//  2. The session is saved (runner saves after MessageEvent)
+//  3. The process crashes/disconnects before tool execution completes
+//  4. A new user message arrives, appended to the session by the runner
+//
+// The resulting session has: [..., assistant(tool_request), user(text)] with no
+// tool response in between. LLMs reject this with "No tool output found for function call".
+//
+// This method detects the pattern, executes the incomplete tools, and inserts the
+// tool response message before the new user message, repairing the session.
+//
+// Error handling:
+//   - Tool execution errors are captured in ToolResponse.Error and become part
+//     of the repaired session. The LLM can reason about these failures.
+//   - Context cancellation stops the yield loop, terminating recovery gracefully.
+//   - If yield returns false (consumer stopped), recovery aborts without error.
+//
+// Observability: A StatusEvent with stage ToolExec is emitted before executing
+// incomplete tools, indicating how many are being recovered.
+func (a *LLMAgent) recoverIncompleteToolCalls(
+	ctx context.Context,
+	inv *agent.InvocationMetadata,
+	makeEnvelope func() agent.EventEnvelope,
+	yield func(agent.Event, error) bool,
+) error {
+	sess := inv.Session()
+
+	incomplete := detectIncompleteToolCalls(sess.Messages)
+	if len(incomplete) == 0 {
+		return nil
+	}
+
+	// Emit status: recovering incomplete tools
+	if !yield(agent.StatusEvent{
+		Envelope: makeEnvelope(),
+		Stage:    agent.StatusStageToolExec,
+		Details:  fmt.Sprintf("recovering %d incomplete tool calls from interrupted session", len(incomplete)),
+	}, nil) {
+		return nil // Consumer stopped
+	}
+
+	// Need tool registry to execute
+	if a.config.tools == nil {
+		return agent.ErrToolRegistry
+	}
+
+	// Execute the incomplete tools
+	toolDefs := a.config.tools.List()
+	toolParts := a.executeTools(ctx, inv, incomplete, toolDefs, makeEnvelope, yield)
+
+	// Insert tool response message BEFORE the last user message.
+	// Current: [..., assistant(tool_req), user(text)]
+	// After:   [..., assistant(tool_req), user(tool_resp), user(text)]
+	toolMsg := llm.NewMessage(llm.RoleUser, toolParts...)
+	lastIdx := len(sess.Messages) - 1
+	sess.Messages = append(sess.Messages[:lastIdx], toolMsg, sess.Messages[lastIdx])
+
+	return nil
+}
+
+// detectIncompleteToolCalls checks if the session ends with incomplete tool calls.
+//
+// Returns the incomplete tool requests if found, nil otherwise.
+//
+// Pattern detected: [..., assistant(tool_requests), user(text_only)]
+// The user message has text but no tool responses, indicating the previous
+// invocation was interrupted after tool requests but before tool execution.
+//
+// Why tail-only detection is correct:
+// Incomplete tool calls can only occur at the session tail. The sequence is:
+//  1. Runner receives user message, appends to session, calls agent
+//  2. Agent generates response with tool requests
+//  3. Runner saves session after MessageEvent (assistant message persisted)
+//  4. Crash/disconnect before tool execution completes
+//  5. New user message arrives, runner loads session and appends it
+//
+// The incomplete calls are always between the last assistant message and the
+// new user message. Incomplete calls earlier in the session would indicate a
+// different bug (session corruption, not crash recovery).
+func detectIncompleteToolCalls(msgs []llm.Message) []*llm.ToolRequest {
+	if len(msgs) < 2 {
+		return nil
+	}
+
+	lastIdx := len(msgs) - 1
+	lastMsg := msgs[lastIdx]
+	prevMsg := msgs[lastIdx-1]
+
+	// Last should be user (new message from runner), prev should be assistant
+	if lastMsg.Role != llm.RoleUser || prevMsg.Role != llm.RoleAssistant {
+		return nil
+	}
+
+	// Previous (assistant) message must have tool requests
+	toolReqs := prevMsg.ToolRequests()
+	if len(toolReqs) == 0 {
+		return nil
+	}
+
+	// If last (user) message has tool responses, session is valid
+	if len(lastMsg.ToolResponses()) > 0 {
+		return nil
+	}
+
+	// Incomplete tool calls detected
+	return toolReqs
 }
 
 // mapLLMFinishReason converts an llm.FinishReason to an agent.FinishReason.

--- a/agent/llmagent/session_recovery_integration_test.go
+++ b/agent/llmagent/session_recovery_integration_test.go
@@ -1,0 +1,220 @@
+package llmagent_test
+
+import (
+	"context"
+	_ "embed"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/encoding/protojson"
+
+	"github.com/redpanda-data/ai-sdk-go/agent"
+	"github.com/redpanda-data/ai-sdk-go/agent/llmagent"
+	"github.com/redpanda-data/ai-sdk-go/llm"
+	"github.com/redpanda-data/ai-sdk-go/providers/openai"
+	"github.com/redpanda-data/ai-sdk-go/providers/openai/openaitest"
+	"github.com/redpanda-data/ai-sdk-go/store/session"
+	"github.com/redpanda-data/ai-sdk-go/store/session/kvstore"
+	llmpb "github.com/redpanda-data/ai-sdk-go/store/session/kvstore/proto/gen/go/redpanda/llm/v1"
+	"github.com/redpanda-data/ai-sdk-go/tool"
+)
+
+//go:embed testdata/session_recovery_single.json
+var sessionRecoverySingleJSON []byte
+
+//go:embed testdata/session_recovery_multiple.json
+var sessionRecoveryMultipleJSON []byte
+
+// TestSessionRecovery_Single verifies recovery from a single incomplete tool call.
+//
+// Loads a session with pattern: [user, assistant(tool_request), user] where the
+// tool request has no response. The agent should detect this, execute the
+// incomplete tool, insert the response, and proceed normally.
+func TestSessionRecovery_Single(t *testing.T) {
+	t.Parallel()
+
+	apiKey := openaitest.GetAPIKeyOrSkipTest(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), integrationTestTimeout)
+	defer cancel()
+
+	// Parse session state from testdata
+	sess, incompleteReqs := loadRecoverySession(t, sessionRecoverySingleJSON)
+	require.Len(t, incompleteReqs, 1, "expected 1 incomplete tool request")
+
+	t.Logf("Incomplete tool: id=%s name=%s", incompleteReqs[0].ID, incompleteReqs[0].Name)
+
+	// Create mock tool matching the incomplete request
+	registry := tool.NewRegistry(tool.RegistryConfig{})
+	err := registry.Register(&mockTool{
+		definition: llm.ToolDefinition{
+			Name:        incompleteReqs[0].Name,
+			Description: "Mock tool for session recovery test",
+			Parameters:  json.RawMessage(`{"type":"object","properties":{}}`),
+		},
+		executeFn: func(_ context.Context, _ json.RawMessage) (json.RawMessage, error) {
+			return json.RawMessage(`{"status":"recovered"}`), nil
+		},
+	})
+	require.NoError(t, err)
+
+	// Create agent
+	provider, err := openai.NewProvider(apiKey)
+	require.NoError(t, err)
+
+	model, err := provider.NewModel(openaitest.TestModelName)
+	require.NoError(t, err)
+
+	ag, err := llmagent.New("test-agent", "You are a helpful assistant.", model,
+		llmagent.WithTools(registry),
+	)
+	require.NoError(t, err)
+
+	// Run agent directly with incomplete session
+	inv := agent.NewInvocationMetadata(sess, agent.Info{})
+	events := collectEvents(t, ag.Run(ctx, inv))
+
+	// Verify no errors, completed successfully
+	endEvent := findInvocationEndEvent(events)
+	require.NotNil(t, endEvent)
+	assert.Equal(t, agent.FinishReasonStop, endEvent.FinishReason)
+
+	// Verify incomplete tool was recovered
+	toolResponses := filterEvents[agent.ToolResponseEvent](events)
+	var recovered bool
+
+	for _, evt := range toolResponses {
+		if evt.Response.ID == incompleteReqs[0].ID {
+			recovered = true
+			break
+		}
+	}
+
+	assert.True(t, recovered, "incomplete tool call should have been recovered")
+}
+
+// TestSessionRecovery_Multiple verifies recovery when the assistant made
+// multiple parallel tool requests before interruption.
+func TestSessionRecovery_Multiple(t *testing.T) {
+	t.Parallel()
+
+	apiKey := openaitest.GetAPIKeyOrSkipTest(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), integrationTestTimeout)
+	defer cancel()
+
+	// Parse session state from testdata
+	sess, incompleteReqs := loadRecoverySession(t, sessionRecoveryMultipleJSON)
+	require.Len(t, incompleteReqs, 3, "expected 3 incomplete tool requests")
+
+	for i, req := range incompleteReqs {
+		t.Logf("Incomplete tool %d: id=%s name=%s", i+1, req.ID, req.Name)
+	}
+
+	// Track tool executions
+	var executedCities []string
+
+	// Create mock tool
+	registry := tool.NewRegistry(tool.RegistryConfig{})
+	err := registry.Register(&mockTool{
+		definition: llm.ToolDefinition{
+			Name:        "get_weather",
+			Description: "Get weather for a city",
+			Parameters:  json.RawMessage(`{"type":"object","properties":{"city":{"type":"string"}}}`),
+		},
+		executeFn: func(_ context.Context, args json.RawMessage) (json.RawMessage, error) {
+			var params struct {
+				City string `json:"city"`
+			}
+
+			if err := json.Unmarshal(args, &params); err != nil {
+				return nil, err
+			}
+
+			executedCities = append(executedCities, params.City)
+
+			weather := map[string]string{
+				"Paris":  "Sunny, 22C",
+				"London": "Cloudy, 15C",
+				"Tokyo":  "Rainy, 18C",
+			}
+
+			return json.Marshal(map[string]string{
+				"city":    params.City,
+				"weather": weather[params.City],
+			})
+		},
+	})
+	require.NoError(t, err)
+
+	// Create agent
+	provider, err := openai.NewProvider(apiKey)
+	require.NoError(t, err)
+
+	model, err := provider.NewModel(openaitest.TestModelName)
+	require.NoError(t, err)
+
+	ag, err := llmagent.New("weather-agent",
+		"You are a helpful weather assistant.",
+		model,
+		llmagent.WithTools(registry),
+	)
+	require.NoError(t, err)
+
+	// Run agent
+	inv := agent.NewInvocationMetadata(sess, agent.Info{})
+	events := collectEvents(t, ag.Run(ctx, inv))
+
+	// Verify completion
+	endEvent := findInvocationEndEvent(events)
+	require.NotNil(t, endEvent)
+	assert.Equal(t, agent.FinishReasonStop, endEvent.FinishReason)
+
+	// Verify all 3 incomplete tools were executed
+	assert.Len(t, executedCities, 3, "all 3 incomplete tools should have been executed")
+	t.Logf("Executed cities: %v", executedCities)
+
+	// Verify all incomplete IDs have responses
+	toolResponses := filterEvents[agent.ToolResponseEvent](events)
+
+	incompleteIDs := make(map[string]bool)
+	for _, req := range incompleteReqs {
+		incompleteIDs[req.ID] = true
+	}
+
+	recoveredCount := 0
+
+	for _, evt := range toolResponses {
+		if incompleteIDs[evt.Response.ID] {
+			recoveredCount++
+		}
+	}
+
+	assert.Equal(t, 3, recoveredCount, "all 3 incomplete tool calls should have responses")
+}
+
+// loadRecoverySession parses a protojson session and extracts incomplete tool requests.
+func loadRecoverySession(t *testing.T, data []byte) (*session.State, []*llm.ToolRequest) {
+	t.Helper()
+
+	var protoState llmpb.SessionState
+	err := protojson.Unmarshal(data, &protoState)
+	require.NoError(t, err, "failed to parse session JSON")
+
+	sess, err := kvstore.FromProtoSessionState(&protoState)
+	require.NoError(t, err, "failed to convert proto to session")
+
+	// Find incomplete tool requests (in second-to-last message if pattern matches)
+	if len(sess.Messages) < 2 {
+		return sess, nil
+	}
+
+	prevMsg := sess.Messages[len(sess.Messages)-2]
+	if prevMsg.Role == llm.RoleAssistant {
+		return sess, prevMsg.ToolRequests()
+	}
+
+	return sess, nil
+}

--- a/agent/llmagent/testdata/session_recovery_multiple.json
+++ b/agent/llmagent/testdata/session_recovery_multiple.json
@@ -1,0 +1,58 @@
+{
+    "id": "agent-chat-multi-tool-recovery-test",
+    "messages": [
+        {
+            "role": "MESSAGE_ROLE_USER",
+            "content": [
+                {
+                    "kind": "PART_KIND_TEXT",
+                    "text": "Get the weather in Paris, London, and Tokyo simultaneously.",
+                    "metadata": null
+                }
+            ]
+        },
+        {
+            "role": "MESSAGE_ROLE_ASSISTANT",
+            "content": [
+                {
+                    "kind": "PART_KIND_TOOL_REQUEST",
+                    "toolRequest": {
+                        "id": "call_paris_weather_001",
+                        "name": "get_weather",
+                        "arguments": "eyJjaXR5IjoiUGFyaXMifQ=="
+                    },
+                    "metadata": null
+                },
+                {
+                    "kind": "PART_KIND_TOOL_REQUEST",
+                    "toolRequest": {
+                        "id": "call_london_weather_002",
+                        "name": "get_weather",
+                        "arguments": "eyJjaXR5IjoiTG9uZG9uIn0="
+                    },
+                    "metadata": null
+                },
+                {
+                    "kind": "PART_KIND_TOOL_REQUEST",
+                    "toolRequest": {
+                        "id": "call_tokyo_weather_003",
+                        "name": "get_weather",
+                        "arguments": "eyJjaXR5IjoiVG9reW8ifQ=="
+                    },
+                    "metadata": null
+                }
+            ]
+        },
+        {
+            "role": "MESSAGE_ROLE_USER",
+            "content": [
+                {
+                    "kind": "PART_KIND_TEXT",
+                    "text": "Actually, just summarize what you found.",
+                    "metadata": null
+                }
+            ]
+        }
+    ],
+    "metadata": {}
+}

--- a/agent/llmagent/testdata/session_recovery_single.json
+++ b/agent/llmagent/testdata/session_recovery_single.json
@@ -1,0 +1,40 @@
+{
+    "id": "agent-chat-d60b7jmuc85c73dvgj10-1H5UkWUlC6yQlmBwcKNsC",
+    "messages": [
+        {
+            "role": "MESSAGE_ROLE_USER",
+            "content": [
+                {
+                    "kind": "PART_KIND_TEXT",
+                    "text": "Look for stale Jiras, don't add any labels, just query.",
+                    "metadata": null
+                }
+            ]
+        },
+        {
+            "role": "MESSAGE_ROLE_ASSISTANT",
+            "content": [
+                {
+                    "kind": "PART_KIND_TOOL_REQUEST",
+                    "toolRequest": {
+                        "id": "call_DAmImBLMWNpSIBvmibH64e4T",
+                        "name": "d60bcamuc85c73dvgj1g__slack_post_message",
+                        "arguments": "eyJibG9ja3MiOnt9LCJjaGFubmVsIjoiYWdlbnQtY29yZS1lbnRlcnByaXNlIiwidGV4dCI6IvCfp7kgSmlyYSBTdGFsZS1Jc3N1ZSBTY2FuIn0="
+                    },
+                    "metadata": null
+                }
+            ]
+        },
+        {
+            "role": "MESSAGE_ROLE_USER",
+            "content": [
+                {
+                    "kind": "PART_KIND_TEXT",
+                    "text": "test",
+                    "metadata": null
+                }
+            ]
+        }
+    ],
+    "metadata": {}
+}

--- a/store/session/kvstore/proto_convert.go
+++ b/store/session/kvstore/proto_convert.go
@@ -18,7 +18,7 @@ func getToProtoConverter() func(*session.State) (*llmpb.SessionState, error) {
 
 // getFromProtoConverter returns the conversion function from proto to State.
 func getFromProtoConverter() func(*llmpb.SessionState) (*session.State, error) {
-	return fromProtoSessionState
+	return FromProtoSessionState
 }
 
 // toProtoSessionState converts a Go session.State to protobuf.
@@ -57,8 +57,9 @@ func toProtoSessionState(s *session.State) (*llmpb.SessionState, error) {
 	}, nil
 }
 
-// fromProtoSessionState converts a protobuf SessionState to Go session.State.
-func fromProtoSessionState(pb *llmpb.SessionState) (*session.State, error) {
+// FromProtoSessionState converts a protobuf SessionState to Go session.State.
+// Exported for tests that need to parse protojson test fixtures.
+func FromProtoSessionState(pb *llmpb.SessionState) (*session.State, error) {
 	if pb == nil {
 		return nil, errors.New("cannot convert nil proto SessionState")
 	}


### PR DESCRIPTION
## What

Add recovery logic for incomplete tool calls in LLMAgent. When a session contains an assistant message with tool requests followed by a user message without matching tool responses, the agent executes those tools before proceeding.

## Why

Sessions can become corrupted when:
1. Assistant emits tool requests
2. Session is saved (runner saves after MessageEvent)
3. Process crashes/disconnects before tool execution completes
4. New user message arrives

The resulting session has `[..., assistant(tool_request), user(text)]` with no tool response in between. LLMs reject this with "No tool output found for function call".

## Implementation details

Recovery runs once at the start of `LLMAgent.Run()`, before the turn loop:

1. `detectIncompleteToolCalls()` scans the session tail for the pattern:
   - Second-to-last message is assistant with tool requests
   - Last message is user with text only (no tool responses)

2. `recoverIncompleteToolCalls()` executes the incomplete tools and inserts responses before the new user message:
   ```
   Before: [..., assistant(tool_req), user(text)]
   After:  [..., assistant(tool_req), user(tool_resp), user(text)]
   ```

3. Normal turn loop proceeds with the repaired session

Also exports `FromProtoSessionState` from kvstore package for use in integration tests.

## References

Integration tests use real OpenAI API with testdata from a production incident.