### PR TITLE
feat: add AWS OIDC + Bedrock IAM for CI

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,6 +18,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   test:
@@ -42,6 +43,11 @@ jobs:
           key: ${{ runner.os }}-build-${{ hashFiles('**/go.sum', 'Taskfile.yaml', 'taskfiles/install.yaml') }}
           restore-keys: |
             ${{ runner.os }}-build-
+
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::961547496971:role/ai-sdk-go-ci-bedrock
+          aws-region: us-east-1
 
       - uses: go-task/setup-task@v1
 

--- a/terraform/.gitignore
+++ b/terraform/.gitignore
@@ -1,0 +1,3 @@
+.terraform/
+*.tfstate
+*.tfstate.backup

--- a/terraform/ai-sdk-ci/.terraform.lock.hcl
+++ b/terraform/ai-sdk-ci/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/terraform/ai-sdk-ci/README.md
+++ b/terraform/ai-sdk-ci/README.md
@@ -1,0 +1,110 @@
+# ai-sdk-ci
+
+Terraform configuration for AWS resources needed to run Bedrock conformance tests in CI.
+
+## What it creates
+
+- **GitHub Actions OIDC provider** — allows GitHub Actions to assume an IAM role without static credentials
+- **IAM role** (`ai-sdk-go-ci-bedrock`) — assumed by the `redpanda-data/ai-sdk-go` repo via OIDC
+- **IAM policy** — grants Bedrock Converse API access (invoke, list models, inference profiles)
+
+## Architecture
+
+```
+GitHub Actions workflow
+  │
+  ├─ requests OIDC token from GitHub
+  │
+  ├─ aws-actions/configure-aws-credentials
+  │    └─ exchanges OIDC token for temporary AWS credentials via sts:AssumeRoleWithWebIdentity
+  │
+  └─ go test ./...
+       └─ Bedrock conformance tests use AWS credentials from the environment
+```
+
+## Bootstrap
+
+These steps were performed once to set up the infrastructure. They are documented here for reference.
+
+### 1. Create the S3 state bucket (manual, not managed by Terraform)
+
+```bash
+aws s3api create-bucket \
+  --bucket ai-sdk-ci-tfstate \
+  --region us-east-2 \
+  --create-bucket-configuration LocationConstraint=us-east-2
+
+aws s3api put-bucket-versioning \
+  --bucket ai-sdk-ci-tfstate \
+  --versioning-configuration Status=Enabled
+
+aws s3api put-public-access-block \
+  --bucket ai-sdk-ci-tfstate \
+  --public-access-block-configuration \
+    BlockPublicAcls=true,IgnorePublicAcls=true,BlockPublicPolicy=true,RestrictPublicBuckets=true
+
+aws s3api put-bucket-encryption \
+  --bucket ai-sdk-ci-tfstate \
+  --server-side-encryption-configuration \
+    '{"Rules":[{"ApplyServerSideEncryptionByDefault":{"SSEAlgorithm":"aws:kms"},"BucketKeyEnabled":true}]}'
+```
+
+### 2. Apply Terraform with local state (backend block commented out)
+
+```bash
+terraform init
+terraform plan
+terraform apply
+```
+
+### 3. Enable the S3 backend and migrate state
+
+Uncomment the `backend "s3"` block in `main.tf`, then:
+
+```bash
+terraform init -migrate-state
+```
+
+### 4. Update the GitHub Actions workflow
+
+Add the OIDC permission and AWS credentials step to `.github/workflows/test.yaml`:
+
+```yaml
+permissions:
+  contents: read
+  id-token: write
+
+steps:
+  # ... checkout, setup-go, etc.
+
+  - uses: aws-actions/configure-aws-credentials@v4
+    with:
+      role-to-assume: arn:aws:iam::961547496971:role/ai-sdk-go-ci-bedrock
+      aws-region: us-east-1
+
+  # ... run tests
+```
+
+## Day-to-day usage
+
+```bash
+cd terraform/ai-sdk-ci
+terraform plan
+terraform apply
+```
+
+### If the GitHub OIDC provider already exists in another account
+
+Set `create_oidc_provider = false`, or import the existing one:
+
+```bash
+terraform import aws_iam_openid_connect_provider.github \
+  arn:aws:iam::<ACCOUNT_ID>:oidc-provider/token.actions.githubusercontent.com
+```
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| `role_arn` | IAM role ARN — use as `role-to-assume` in the GitHub Actions workflow |
+| `role_name` | IAM role name |

--- a/terraform/ai-sdk-ci/main.tf
+++ b/terraform/ai-sdk-ci/main.tf
@@ -1,0 +1,151 @@
+terraform {
+  required_version = ">= 1.10"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+
+  backend "s3" {
+    bucket       = "ai-sdk-ci-tfstate"
+    key          = "ai-sdk-ci/terraform.tfstate"
+    region       = "us-east-2"
+    use_lockfile = true
+    encrypt      = true
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}
+
+data "aws_caller_identity" "current" {}
+data "aws_partition" "current" {}
+
+# --------------------------------------------------------------------------
+# GitHub Actions OIDC provider
+# --------------------------------------------------------------------------
+# If your account already has the GitHub OIDC provider, import it:
+#   terraform import aws_iam_openid_connect_provider.github \
+#     arn:aws:iam::<ACCOUNT_ID>:oidc-provider/token.actions.githubusercontent.com
+#
+# Or set var.create_oidc_provider = false to reference the existing one.
+# --------------------------------------------------------------------------
+
+resource "aws_iam_openid_connect_provider" "github" {
+  count = var.create_oidc_provider ? 1 : 0
+
+  url             = "https://token.actions.githubusercontent.com"
+  client_id_list  = ["sts.amazonaws.com"]
+  # AWS no longer validates thumbprints for GitHub's OIDC provider (it uses
+  # a trusted CA library instead). The field is still required by the API,
+  # so the all-f placeholder is the standard convention.
+  thumbprint_list = ["ffffffffffffffffffffffffffffffffffffffff"]
+}
+
+data "aws_iam_openid_connect_provider" "github" {
+  count = var.create_oidc_provider ? 0 : 1
+  url   = "https://token.actions.githubusercontent.com"
+}
+
+locals {
+  oidc_provider_arn = (
+    var.create_oidc_provider
+    ? aws_iam_openid_connect_provider.github[0].arn
+    : data.aws_iam_openid_connect_provider.github[0].arn
+  )
+  account_id = data.aws_caller_identity.current.account_id
+  partition  = data.aws_partition.current.partition
+}
+
+# --------------------------------------------------------------------------
+# IAM role assumed by GitHub Actions via OIDC
+# --------------------------------------------------------------------------
+
+data "aws_iam_policy_document" "assume_role" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+
+    principals {
+      type        = "Federated"
+      identifiers = [local.oidc_provider_arn]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "token.actions.githubusercontent.com:aud"
+      values   = ["sts.amazonaws.com"]
+    }
+
+    condition {
+      test     = "StringLike"
+      variable = "token.actions.githubusercontent.com:sub"
+      values   = [for r in var.github_repos : "repo:${r}:*"]
+    }
+  }
+}
+
+resource "aws_iam_role" "ci_bedrock" {
+  name               = var.role_name
+  assume_role_policy = data.aws_iam_policy_document.assume_role.json
+}
+
+# --------------------------------------------------------------------------
+# Bedrock permissions
+# --------------------------------------------------------------------------
+# The provider uses the Converse API with cross-region inference profiles
+# (e.g. "us.anthropic.claude-sonnet-4-6"). These require permissions on
+# both foundation model and inference profile ARNs.
+# --------------------------------------------------------------------------
+
+data "aws_iam_policy_document" "bedrock" {
+  # Converse / ConverseStream (used for all model calls)
+  statement {
+    effect = "Allow"
+    actions = [
+      "bedrock:InvokeModel",
+      "bedrock:InvokeModelWithResponseStream",
+    ]
+    resources = [
+      # Foundation models
+      "arn:${local.partition}:bedrock:*::foundation-model/*",
+      # Cross-region inference profiles
+      "arn:${local.partition}:bedrock:*:${local.account_id}:inference-profile/*",
+      # System-defined cross-region inference profiles
+      "arn:${local.partition}:bedrock:*:*:inference-profile/*",
+    ]
+  }
+
+  # ListFoundationModels / GetFoundationModel (used for model discovery)
+  statement {
+    effect = "Allow"
+    actions = [
+      "bedrock:ListFoundationModels",
+      "bedrock:GetFoundationModel",
+    ]
+    resources = ["*"]
+  }
+
+  # ListInferenceProfiles (may be needed for profile resolution)
+  statement {
+    effect = "Allow"
+    actions = [
+      "bedrock:ListInferenceProfiles",
+      "bedrock:GetInferenceProfile",
+    ]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_policy" "bedrock" {
+  name   = "${var.role_name}-bedrock"
+  policy = data.aws_iam_policy_document.bedrock.json
+}
+
+resource "aws_iam_role_policy_attachment" "bedrock" {
+  role       = aws_iam_role.ci_bedrock.name
+  policy_arn = aws_iam_policy.bedrock.arn
+}

--- a/terraform/ai-sdk-ci/outputs.tf
+++ b/terraform/ai-sdk-ci/outputs.tf
@@ -1,0 +1,9 @@
+output "role_arn" {
+  description = "ARN of the IAM role for GitHub Actions. Use this in the workflow's role-to-assume parameter."
+  value       = aws_iam_role.ci_bedrock.arn
+}
+
+output "role_name" {
+  description = "Name of the IAM role."
+  value       = aws_iam_role.ci_bedrock.name
+}

--- a/terraform/ai-sdk-ci/variables.tf
+++ b/terraform/ai-sdk-ci/variables.tf
@@ -1,0 +1,24 @@
+variable "aws_region" {
+  description = "AWS region for the provider and Bedrock access."
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "role_name" {
+  description = "Name for the IAM role assumed by GitHub Actions."
+  type        = string
+  default     = "ai-sdk-go-ci-bedrock"
+}
+
+variable "github_repos" {
+  description = "GitHub repos allowed to assume the role (org/repo format)."
+  type        = list(string)
+  default     = ["redpanda-data/ai-sdk-go"]
+}
+
+variable "create_oidc_provider" {
+  description = "Set to false if the GitHub OIDC provider already exists in your account."
+  type        = bool
+  default     = true
+}
+


### PR DESCRIPTION
## Summary

- Adds Terraform config (`terraform/ai-sdk-ci/`) for GitHub Actions OIDC federation with AWS, creating an IAM role with Bedrock permissions (invoke, inference profiles, model discovery)
- Updates `.github/workflows/test.yaml` to assume the IAM role via OIDC so Bedrock conformance tests run in CI without static credentials
- S3 state bucket (`ai-sdk-ci-tfstate` in us-east-2) was created manually; Terraform state is stored there with S3 native lock files

## Test plan

- [x] Verify the GitHub Actions workflow can assume the IAM role via OIDC
- [x] Verify Bedrock conformance tests pass in CI
- [x] Verify `terraform plan` shows no drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)