### PR TITLE
test: drop gemini-3-pro-preview from conformance suite

### DIFF
--- a/providers/google/google_conformance_test.go
+++ b/providers/google/google_conformance_test.go
@@ -90,7 +90,6 @@ func TestGoogleConformance(t *testing.T) {
 	modelsToTest := []string{
 		google.ModelGemini25Flash,       // gemini-2.5-flash
 		google.ModelGemini31ProPreview,  // gemini-3.1-pro-preview
-		google.ModelGemini3ProPreview,   // gemini-3-pro-preview
 		google.ModelGemini3FlashPreview, // gemini-3-flash-preview
 	}
 


### PR DESCRIPTION
## Summary
- Remove `gemini-3-pro-preview` from the Google conformance test matrix
- `gemini-3.1-pro-preview` (its successor) remains in the suite and covers the same capabilities
- The model has known server-side stability issues causing intermittent 10+ minute hangs during CI, leading to test timeouts and panics

## Test plan
- [ ] CI passes without the Google conformance timeout/panic
- [ ] `gemini-3.1-pro-preview` conformance tests still run and pass