### PR TITLE
wire conformance tests: compare SDK requests against native provider SDKs

### DIFF
--- a/providers/openai/openai_wire_test.go
+++ b/providers/openai/openai_wire_test.go
@@ -16,13 +16,17 @@ package openai_test
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"testing"
 	"time"
 
 	nativeopenai "github.com/openai/openai-go/v3"
 	"github.com/openai/openai-go/v3/option"
+	"github.com/openai/openai-go/v3/packages/param"
 	"github.com/openai/openai-go/v3/responses"
+	"github.com/openai/openai-go/v3/shared"
+	"github.com/openai/openai-go/v3/shared/constant"
 
 	"github.com/redpanda-data/ai-sdk-go/llm"
 	"github.com/redpanda-data/ai-sdk-go/providers/openai"
@@ -65,11 +69,45 @@ var cannedOpenAIResponse = []byte(`{
 	}
 }`)
 
+// defaultIgnorePaths are fields that legitimately differ between native and ai-sdk calls.
+var defaultIgnorePaths = []string{
+	"stream",
+	"stream_options",
+	"truncation",
+}
+
+// defaultIgnoreHeaders are SDK-internal headers that don't affect behavior.
+var defaultIgnoreHeaders = []string{
+	"X-Stainless-Lang",
+	"X-Stainless-Package-Version",
+	"X-Stainless-Os",
+	"X-Stainless-Arch",
+	"X-Stainless-Runtime",
+	"X-Stainless-Runtime-Version",
+	"X-Stainless-Retry-Count",
+	"X-Stainless-Read-Timeout",
+	"X-Stainless-Poll-Helper",
+	"Idempotency-Key",
+	"Openai-Organization",
+}
+
 func TestOpenAIWireConformance(t *testing.T) {
 	t.Parallel()
 
 	scenarios := []wireconformance.WireScenario{
 		simpleTextGeneration(),
+		systemMessage(),
+		multiTurnConversation(),
+		temperatureSetting(),
+		topPSetting(),
+		multipleToolDefinitions(),
+		toolDefinitionWithAutoChoice(),
+		toolChoiceRequired(),
+		toolChoiceSpecificFunction(),
+		toolCallRoundTrip(),
+		structuredOutputJSONSchema(),
+		reasoningEffortAndSummary(),
+		schemaWithOptionalFields(),
 	}
 
 	for _, scenario := range scenarios {
@@ -77,21 +115,18 @@ func TestOpenAIWireConformance(t *testing.T) {
 	}
 }
 
+func newTestCtx() (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.Background(), 5*time.Second)
+}
+
 func simpleTextGeneration() wireconformance.WireScenario {
 	return wireconformance.WireScenario{
 		Name: "simple_text_generation",
 		NativeCall: func(t *testing.T, transport *wireconformance.RecordingTransport) {
 			t.Helper()
-
-			client := nativeopenai.NewClient(
-				option.WithAPIKey("test-key"),
-				option.WithHTTPClient(&http.Client{Transport: transport}),
-			)
-
-			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			client := nativeopenai.NewClient(option.WithAPIKey("test-key"), option.WithHTTPClient(&http.Client{Transport: transport}))
+			ctx, cancel := newTestCtx()
 			defer cancel()
-
-			// Use the native SDK exactly how a user would.
 			_, _ = client.Responses.New(ctx, responses.ResponseNewParams{
 				Model: "gpt-5-mini",
 				Input: responses.ResponseNewParamsInputUnion{
@@ -104,46 +139,825 @@ func simpleTextGeneration() wireconformance.WireScenario {
 		},
 		SDKCall: func(t *testing.T, transport *wireconformance.RecordingTransport) {
 			t.Helper()
-
-			provider, err := openai.NewProvider("test-key",
-				openai.WithHTTPClient(&http.Client{Transport: transport}),
-			)
+			provider, err := openai.NewProvider("test-key", openai.WithHTTPClient(&http.Client{Transport: transport}))
 			if err != nil {
 				t.Fatalf("failed to create provider: %v", err)
 			}
-
 			model, err := provider.NewModel("gpt-5-mini", openai.WithMaxTokens(256))
 			if err != nil {
 				t.Fatalf("failed to create model: %v", err)
 			}
-
-			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			ctx, cancel := newTestCtx()
 			defer cancel()
-
 			_, _ = model.Generate(ctx, &llm.Request{
 				Messages: []llm.Message{
 					llm.NewMessage(llm.RoleUser, llm.NewTextPart("Say 'Hello, World!' and nothing else.")),
 				},
 			})
 		},
-		IgnorePaths: []string{
-			"stream",           // ai-sdk may or may not set this
-			"stream_options",   // streaming config
-			"truncation",      // SDK default that native may not set
+		IgnorePaths:   defaultIgnorePaths,
+		IgnoreHeaders: defaultIgnoreHeaders,
+		FixHint:       "providers/openai/request_mapper.go (ToProvider method)",
+	}
+}
+
+func systemMessage() wireconformance.WireScenario {
+	return wireconformance.WireScenario{
+		Name: "system_message",
+		NativeCall: func(t *testing.T, transport *wireconformance.RecordingTransport) {
+			t.Helper()
+			client := nativeopenai.NewClient(option.WithAPIKey("test-key"), option.WithHTTPClient(&http.Client{Transport: transport}))
+			ctx, cancel := newTestCtx()
+			defer cancel()
+			_, _ = client.Responses.New(ctx, responses.ResponseNewParams{
+				Model: "gpt-5-mini",
+				Input: responses.ResponseNewParamsInputUnion{
+					OfInputItemList: []responses.ResponseInputItemUnionParam{
+						responses.ResponseInputItemParamOfMessage("You are a helpful assistant that speaks like a pirate.", responses.EasyInputMessageRoleSystem),
+						responses.ResponseInputItemParamOfMessage("Tell me about Go.", responses.EasyInputMessageRoleUser),
+					},
+				},
+				MaxOutputTokens: nativeopenai.Int(256),
+			})
 		},
-		IgnoreHeaders: []string{
-			"X-Stainless-Lang",
-			"X-Stainless-Package-Version",
-			"X-Stainless-Os",
-			"X-Stainless-Arch",
-			"X-Stainless-Runtime",
-			"X-Stainless-Runtime-Version",
-			"X-Stainless-Retry-Count",
-			"X-Stainless-Read-Timeout",
-			"X-Stainless-Poll-Helper",
-			"Idempotency-Key",
-			"Openai-Organization",
+		SDKCall: func(t *testing.T, transport *wireconformance.RecordingTransport) {
+			t.Helper()
+			provider, err := openai.NewProvider("test-key", openai.WithHTTPClient(&http.Client{Transport: transport}))
+			if err != nil {
+				t.Fatalf("failed to create provider: %v", err)
+			}
+			model, err := provider.NewModel("gpt-5-mini", openai.WithMaxTokens(256))
+			if err != nil {
+				t.Fatalf("failed to create model: %v", err)
+			}
+			ctx, cancel := newTestCtx()
+			defer cancel()
+			_, _ = model.Generate(ctx, &llm.Request{
+				Messages: []llm.Message{
+					llm.NewMessage(llm.RoleSystem, llm.NewTextPart("You are a helpful assistant that speaks like a pirate.")),
+					llm.NewMessage(llm.RoleUser, llm.NewTextPart("Tell me about Go.")),
+				},
+			})
 		},
-		FixHint: "providers/openai/request_mapper.go (ToProvider method)",
+		IgnorePaths:   defaultIgnorePaths,
+		IgnoreHeaders: defaultIgnoreHeaders,
+		FixHint:       "providers/openai/request_mapper.go (ToProvider method)",
+	}
+}
+
+func multiTurnConversation() wireconformance.WireScenario {
+	return wireconformance.WireScenario{
+		Name: "multi_turn_conversation",
+		NativeCall: func(t *testing.T, transport *wireconformance.RecordingTransport) {
+			t.Helper()
+			client := nativeopenai.NewClient(option.WithAPIKey("test-key"), option.WithHTTPClient(&http.Client{Transport: transport}))
+			ctx, cancel := newTestCtx()
+			defer cancel()
+			_, _ = client.Responses.New(ctx, responses.ResponseNewParams{
+				Model: "gpt-5-mini",
+				Input: responses.ResponseNewParamsInputUnion{
+					OfInputItemList: []responses.ResponseInputItemUnionParam{
+						responses.ResponseInputItemParamOfMessage("What is 2+2?", responses.EasyInputMessageRoleUser),
+						responses.ResponseInputItemParamOfMessage("2+2 equals 4.", responses.EasyInputMessageRoleAssistant),
+						responses.ResponseInputItemParamOfMessage("And what is 4+4?", responses.EasyInputMessageRoleUser),
+					},
+				},
+				MaxOutputTokens: nativeopenai.Int(256),
+			})
+		},
+		SDKCall: func(t *testing.T, transport *wireconformance.RecordingTransport) {
+			t.Helper()
+			provider, err := openai.NewProvider("test-key", openai.WithHTTPClient(&http.Client{Transport: transport}))
+			if err != nil {
+				t.Fatalf("failed to create provider: %v", err)
+			}
+			model, err := provider.NewModel("gpt-5-mini", openai.WithMaxTokens(256))
+			if err != nil {
+				t.Fatalf("failed to create model: %v", err)
+			}
+			ctx, cancel := newTestCtx()
+			defer cancel()
+			_, _ = model.Generate(ctx, &llm.Request{
+				Messages: []llm.Message{
+					llm.NewMessage(llm.RoleUser, llm.NewTextPart("What is 2+2?")),
+					llm.NewMessage(llm.RoleAssistant, llm.NewTextPart("2+2 equals 4.")),
+					llm.NewMessage(llm.RoleUser, llm.NewTextPart("And what is 4+4?")),
+				},
+			})
+		},
+		IgnorePaths:   defaultIgnorePaths,
+		IgnoreHeaders: defaultIgnoreHeaders,
+		FixHint:       "providers/openai/request_mapper.go (ToProvider method)",
+	}
+}
+
+func temperatureSetting() wireconformance.WireScenario {
+	return wireconformance.WireScenario{
+		Name: "temperature_setting",
+		NativeCall: func(t *testing.T, transport *wireconformance.RecordingTransport) {
+			t.Helper()
+			client := nativeopenai.NewClient(option.WithAPIKey("test-key"), option.WithHTTPClient(&http.Client{Transport: transport}))
+			ctx, cancel := newTestCtx()
+			defer cancel()
+			_, _ = client.Responses.New(ctx, responses.ResponseNewParams{
+				Model: "gpt-5-mini",
+				Input: responses.ResponseNewParamsInputUnion{
+					OfInputItemList: []responses.ResponseInputItemUnionParam{
+						responses.ResponseInputItemParamOfMessage("Hello", responses.EasyInputMessageRoleUser),
+					},
+				},
+				Temperature:     nativeopenai.Float(0.7),
+				MaxOutputTokens: nativeopenai.Int(256),
+			})
+		},
+		SDKCall: func(t *testing.T, transport *wireconformance.RecordingTransport) {
+			t.Helper()
+			provider, err := openai.NewProvider("test-key", openai.WithHTTPClient(&http.Client{Transport: transport}))
+			if err != nil {
+				t.Fatalf("failed to create provider: %v", err)
+			}
+			model, err := provider.NewModel("gpt-5-mini", openai.WithTemperature(0.7), openai.WithMaxTokens(256))
+			if err != nil {
+				t.Fatalf("failed to create model: %v", err)
+			}
+			ctx, cancel := newTestCtx()
+			defer cancel()
+			_, _ = model.Generate(ctx, &llm.Request{
+				Messages: []llm.Message{
+					llm.NewMessage(llm.RoleUser, llm.NewTextPart("Hello")),
+				},
+			})
+		},
+		IgnorePaths:   defaultIgnorePaths,
+		IgnoreHeaders: defaultIgnoreHeaders,
+		FixHint:       "providers/openai/request_mapper.go (ToProvider method)",
+	}
+}
+
+func toolDefinitionWithAutoChoice() wireconformance.WireScenario {
+	weatherSchema := map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"location": map[string]any{
+				"type":        "string",
+				"description": "City name",
+			},
+		},
+		"required":             []any{"location"},
+		"additionalProperties": false,
+	}
+
+	schemaBytes, _ := json.Marshal(weatherSchema)
+
+	return wireconformance.WireScenario{
+		Name: "tool_definition_with_auto_choice",
+		NativeCall: func(t *testing.T, transport *wireconformance.RecordingTransport) {
+			t.Helper()
+			client := nativeopenai.NewClient(option.WithAPIKey("test-key"), option.WithHTTPClient(&http.Client{Transport: transport}))
+			ctx, cancel := newTestCtx()
+			defer cancel()
+			_, _ = client.Responses.New(ctx, responses.ResponseNewParams{
+				Model: "gpt-5-mini",
+				Input: responses.ResponseNewParamsInputUnion{
+					OfInputItemList: []responses.ResponseInputItemUnionParam{
+						responses.ResponseInputItemParamOfMessage("What's the weather in Berlin?", responses.EasyInputMessageRoleUser),
+					},
+				},
+				Tools: []responses.ToolUnionParam{
+					{
+						OfFunction: &responses.FunctionToolParam{
+							Type:        constant.Function(""),
+							Name:        "get_weather",
+							Description: param.NewOpt("Get current weather for a city"),
+							Parameters:  weatherSchema,
+							Strict:      param.NewOpt(true),
+						},
+					},
+				},
+				ToolChoice: responses.ResponseNewParamsToolChoiceUnion{
+					OfToolChoiceMode: param.NewOpt(responses.ToolChoiceOptionsAuto),
+				},
+				MaxOutputTokens: nativeopenai.Int(256),
+			})
+		},
+		SDKCall: func(t *testing.T, transport *wireconformance.RecordingTransport) {
+			t.Helper()
+			provider, err := openai.NewProvider("test-key", openai.WithHTTPClient(&http.Client{Transport: transport}))
+			if err != nil {
+				t.Fatalf("failed to create provider: %v", err)
+			}
+			model, err := provider.NewModel("gpt-5-mini", openai.WithMaxTokens(256))
+			if err != nil {
+				t.Fatalf("failed to create model: %v", err)
+			}
+			ctx, cancel := newTestCtx()
+			defer cancel()
+			_, _ = model.Generate(ctx, &llm.Request{
+				Messages: []llm.Message{
+					llm.NewMessage(llm.RoleUser, llm.NewTextPart("What's the weather in Berlin?")),
+				},
+				Tools: []llm.ToolDefinition{
+					{
+						Name:        "get_weather",
+						Description: "Get current weather for a city",
+						Parameters:  schemaBytes,
+					},
+				},
+				ToolChoice: &llm.ToolChoice{Type: llm.ToolChoiceAuto},
+			})
+		},
+		IgnorePaths:   defaultIgnorePaths,
+		IgnoreHeaders: defaultIgnoreHeaders,
+		FixHint:       "providers/openai/request_mapper.go (mapToolDefinitions / mapToolChoice)",
+	}
+}
+
+func toolChoiceRequired() wireconformance.WireScenario {
+	weatherSchema := map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"location": map[string]any{
+				"type":        "string",
+				"description": "City name",
+			},
+		},
+		"required":             []any{"location"},
+		"additionalProperties": false,
+	}
+	schemaBytes, _ := json.Marshal(weatherSchema)
+
+	return wireconformance.WireScenario{
+		Name: "tool_choice_required",
+		NativeCall: func(t *testing.T, transport *wireconformance.RecordingTransport) {
+			t.Helper()
+			client := nativeopenai.NewClient(option.WithAPIKey("test-key"), option.WithHTTPClient(&http.Client{Transport: transport}))
+			ctx, cancel := newTestCtx()
+			defer cancel()
+			_, _ = client.Responses.New(ctx, responses.ResponseNewParams{
+				Model: "gpt-5-mini",
+				Input: responses.ResponseNewParamsInputUnion{
+					OfInputItemList: []responses.ResponseInputItemUnionParam{
+						responses.ResponseInputItemParamOfMessage("What's the weather?", responses.EasyInputMessageRoleUser),
+					},
+				},
+				Tools: []responses.ToolUnionParam{
+					{
+						OfFunction: &responses.FunctionToolParam{
+							Type:        constant.Function(""),
+							Name:        "get_weather",
+							Description: param.NewOpt("Get current weather for a city"),
+							Parameters:  weatherSchema,
+							Strict:      param.NewOpt(true),
+						},
+					},
+				},
+				ToolChoice: responses.ResponseNewParamsToolChoiceUnion{
+					OfToolChoiceMode: param.NewOpt(responses.ToolChoiceOptionsRequired),
+				},
+				MaxOutputTokens: nativeopenai.Int(256),
+			})
+		},
+		SDKCall: func(t *testing.T, transport *wireconformance.RecordingTransport) {
+			t.Helper()
+			provider, err := openai.NewProvider("test-key", openai.WithHTTPClient(&http.Client{Transport: transport}))
+			if err != nil {
+				t.Fatalf("failed to create provider: %v", err)
+			}
+			model, err := provider.NewModel("gpt-5-mini", openai.WithMaxTokens(256))
+			if err != nil {
+				t.Fatalf("failed to create model: %v", err)
+			}
+			ctx, cancel := newTestCtx()
+			defer cancel()
+			_, _ = model.Generate(ctx, &llm.Request{
+				Messages: []llm.Message{
+					llm.NewMessage(llm.RoleUser, llm.NewTextPart("What's the weather?")),
+				},
+				Tools: []llm.ToolDefinition{
+					{
+						Name:        "get_weather",
+						Description: "Get current weather for a city",
+						Parameters:  schemaBytes,
+					},
+				},
+				ToolChoice: &llm.ToolChoice{Type: llm.ToolChoiceRequired},
+			})
+		},
+		IgnorePaths:   defaultIgnorePaths,
+		IgnoreHeaders: defaultIgnoreHeaders,
+		FixHint:       "providers/openai/request_mapper.go (mapToolChoice)",
+	}
+}
+
+func toolChoiceSpecificFunction() wireconformance.WireScenario {
+	weatherSchema := map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"location": map[string]any{"type": "string"},
+		},
+		"required":             []any{"location"},
+		"additionalProperties": false,
+	}
+	schemaBytes, _ := json.Marshal(weatherSchema)
+
+	return wireconformance.WireScenario{
+		Name: "tool_choice_specific_function",
+		NativeCall: func(t *testing.T, transport *wireconformance.RecordingTransport) {
+			t.Helper()
+			client := nativeopenai.NewClient(option.WithAPIKey("test-key"), option.WithHTTPClient(&http.Client{Transport: transport}))
+			ctx, cancel := newTestCtx()
+			defer cancel()
+			_, _ = client.Responses.New(ctx, responses.ResponseNewParams{
+				Model: "gpt-5-mini",
+				Input: responses.ResponseNewParamsInputUnion{
+					OfInputItemList: []responses.ResponseInputItemUnionParam{
+						responses.ResponseInputItemParamOfMessage("Weather in Berlin", responses.EasyInputMessageRoleUser),
+					},
+				},
+				Tools: []responses.ToolUnionParam{
+					{
+						OfFunction: &responses.FunctionToolParam{
+							Type:        constant.Function(""),
+							Name:        "get_weather",
+							Description: param.NewOpt("Get weather"),
+							Parameters:  weatherSchema,
+							Strict:      param.NewOpt(true),
+						},
+					},
+				},
+				ToolChoice: responses.ResponseNewParamsToolChoiceUnion{
+					OfFunctionTool: &responses.ToolChoiceFunctionParam{
+						Type: "function",
+						Name: "get_weather",
+					},
+				},
+				MaxOutputTokens: nativeopenai.Int(256),
+			})
+		},
+		SDKCall: func(t *testing.T, transport *wireconformance.RecordingTransport) {
+			t.Helper()
+			provider, err := openai.NewProvider("test-key", openai.WithHTTPClient(&http.Client{Transport: transport}))
+			if err != nil {
+				t.Fatalf("failed to create provider: %v", err)
+			}
+			model, err := provider.NewModel("gpt-5-mini", openai.WithMaxTokens(256))
+			if err != nil {
+				t.Fatalf("failed to create model: %v", err)
+			}
+			ctx, cancel := newTestCtx()
+			defer cancel()
+			funcName := "get_weather"
+			_, _ = model.Generate(ctx, &llm.Request{
+				Messages: []llm.Message{
+					llm.NewMessage(llm.RoleUser, llm.NewTextPart("Weather in Berlin")),
+				},
+				Tools: []llm.ToolDefinition{
+					{
+						Name:        "get_weather",
+						Description: "Get weather",
+						Parameters:  schemaBytes,
+					},
+				},
+				ToolChoice: &llm.ToolChoice{Type: llm.ToolChoiceSpecific, Name: &funcName},
+			})
+		},
+		IgnorePaths:   defaultIgnorePaths,
+		IgnoreHeaders: defaultIgnoreHeaders,
+		FixHint:       "providers/openai/request_mapper.go (mapToolChoice)",
+	}
+}
+
+func toolCallRoundTrip() wireconformance.WireScenario {
+	// Simulates: user asks -> assistant calls tool -> user provides tool result -> next turn
+	return wireconformance.WireScenario{
+		Name: "tool_call_round_trip",
+		NativeCall: func(t *testing.T, transport *wireconformance.RecordingTransport) {
+			t.Helper()
+			client := nativeopenai.NewClient(option.WithAPIKey("test-key"), option.WithHTTPClient(&http.Client{Transport: transport}))
+			ctx, cancel := newTestCtx()
+			defer cancel()
+			_, _ = client.Responses.New(ctx, responses.ResponseNewParams{
+				Model: "gpt-5-mini",
+				Input: responses.ResponseNewParamsInputUnion{
+					OfInputItemList: []responses.ResponseInputItemUnionParam{
+						// User message
+						responses.ResponseInputItemParamOfMessage("What's the weather in Berlin?", responses.EasyInputMessageRoleUser),
+						// Assistant's tool call
+						{
+							OfFunctionCall: &responses.ResponseFunctionToolCallParam{
+								CallID:    "call_123",
+								Name:      "get_weather",
+								Arguments: `{"location":"Berlin"}`,
+								Type:      constant.FunctionCall(""),
+							},
+						},
+						// Tool result
+						{
+							OfFunctionCallOutput: &responses.ResponseInputItemFunctionCallOutputParam{
+								CallID: "call_123",
+								Output: responses.ResponseInputItemFunctionCallOutputOutputUnionParam{
+									OfString: param.NewOpt(`{"temp":20,"unit":"celsius"}`),
+								},
+								Type: constant.FunctionCallOutput(""),
+							},
+						},
+					},
+				},
+				MaxOutputTokens: nativeopenai.Int(256),
+			})
+		},
+		SDKCall: func(t *testing.T, transport *wireconformance.RecordingTransport) {
+			t.Helper()
+			provider, err := openai.NewProvider("test-key", openai.WithHTTPClient(&http.Client{Transport: transport}))
+			if err != nil {
+				t.Fatalf("failed to create provider: %v", err)
+			}
+			model, err := provider.NewModel("gpt-5-mini", openai.WithMaxTokens(256))
+			if err != nil {
+				t.Fatalf("failed to create model: %v", err)
+			}
+			ctx, cancel := newTestCtx()
+			defer cancel()
+			_, _ = model.Generate(ctx, &llm.Request{
+				Messages: []llm.Message{
+					llm.NewMessage(llm.RoleUser, llm.NewTextPart("What's the weather in Berlin?")),
+					llm.NewMessage(llm.RoleAssistant, llm.NewToolRequestPart(&llm.ToolRequest{
+						ID:        "call_123",
+						Name:      "get_weather",
+						Arguments: json.RawMessage(`{"location":"Berlin"}`),
+					})),
+					llm.NewMessage(llm.RoleUser, llm.NewToolResponsePart(&llm.ToolResponse{
+						ID:     "call_123",
+						Result: json.RawMessage(`{"temp":20,"unit":"celsius"}`),
+					})),
+				},
+			})
+		},
+		IgnorePaths:   defaultIgnorePaths,
+		IgnoreHeaders: defaultIgnoreHeaders,
+		FixHint:       "providers/openai/request_mapper.go (mapToolRequestMessage / mapToolResponseMessage)",
+	}
+}
+
+func structuredOutputJSONSchema() wireconformance.WireScenario {
+	outputSchema := map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"name": map[string]any{
+				"type": "string",
+			},
+			"age": map[string]any{
+				"type": "integer",
+			},
+		},
+		"required":             []any{"name", "age"},
+		"additionalProperties": false,
+	}
+	schemaBytes, _ := json.Marshal(outputSchema)
+
+	return wireconformance.WireScenario{
+		Name: "structured_output_json_schema",
+		NativeCall: func(t *testing.T, transport *wireconformance.RecordingTransport) {
+			t.Helper()
+			client := nativeopenai.NewClient(option.WithAPIKey("test-key"), option.WithHTTPClient(&http.Client{Transport: transport}))
+			ctx, cancel := newTestCtx()
+			defer cancel()
+			_, _ = client.Responses.New(ctx, responses.ResponseNewParams{
+				Model: "gpt-5-mini",
+				Input: responses.ResponseNewParamsInputUnion{
+					OfInputItemList: []responses.ResponseInputItemUnionParam{
+						responses.ResponseInputItemParamOfMessage("Extract: John is 30 years old", responses.EasyInputMessageRoleUser),
+					},
+				},
+				Text: responses.ResponseTextConfigParam{
+					Format: responses.ResponseFormatTextConfigUnionParam{
+						OfJSONSchema: &responses.ResponseFormatTextJSONSchemaConfigParam{
+							Type:        "json_schema",
+							Name:        "person",
+							Schema:      outputSchema,
+							Description: param.NewOpt("A person's details"),
+							Strict:      param.NewOpt(true),
+						},
+					},
+				},
+				MaxOutputTokens: nativeopenai.Int(256),
+			})
+		},
+		SDKCall: func(t *testing.T, transport *wireconformance.RecordingTransport) {
+			t.Helper()
+			provider, err := openai.NewProvider("test-key", openai.WithHTTPClient(&http.Client{Transport: transport}))
+			if err != nil {
+				t.Fatalf("failed to create provider: %v", err)
+			}
+			model, err := provider.NewModel("gpt-5-mini", openai.WithMaxTokens(256))
+			if err != nil {
+				t.Fatalf("failed to create model: %v", err)
+			}
+			ctx, cancel := newTestCtx()
+			defer cancel()
+			_, _ = model.Generate(ctx, &llm.Request{
+				Messages: []llm.Message{
+					llm.NewMessage(llm.RoleUser, llm.NewTextPart("Extract: John is 30 years old")),
+				},
+				ResponseFormat: &llm.ResponseFormat{
+					Type: llm.ResponseFormatJSONSchema,
+					JSONSchema: &llm.JSONSchema{
+						Name:        "person",
+						Description: "A person's details",
+						Schema:      schemaBytes,
+					},
+				},
+			})
+		},
+		IgnorePaths:   defaultIgnorePaths,
+		IgnoreHeaders: defaultIgnoreHeaders,
+		FixHint:       "providers/openai/request_mapper.go (mapResponseFormat)",
+	}
+}
+
+// multipleToolDefinitions tests that multiple tools with different schemas are correctly mapped.
+func multipleToolDefinitions() wireconformance.WireScenario {
+	weatherSchema := map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"location": map[string]any{"type": "string"},
+		},
+		"required":             []any{"location"},
+		"additionalProperties": false,
+	}
+	calcSchema := map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"expression": map[string]any{"type": "string", "description": "Math expression to evaluate"},
+		},
+		"required":             []any{"expression"},
+		"additionalProperties": false,
+	}
+	weatherBytes, _ := json.Marshal(weatherSchema)
+	calcBytes, _ := json.Marshal(calcSchema)
+
+	return wireconformance.WireScenario{
+		Name: "multiple_tool_definitions",
+		NativeCall: func(t *testing.T, transport *wireconformance.RecordingTransport) {
+			t.Helper()
+			client := nativeopenai.NewClient(option.WithAPIKey("test-key"), option.WithHTTPClient(&http.Client{Transport: transport}))
+			ctx, cancel := newTestCtx()
+			defer cancel()
+			_, _ = client.Responses.New(ctx, responses.ResponseNewParams{
+				Model: "gpt-5-mini",
+				Input: responses.ResponseNewParamsInputUnion{
+					OfInputItemList: []responses.ResponseInputItemUnionParam{
+						responses.ResponseInputItemParamOfMessage("What's 2+2 and what's the weather in Berlin?", responses.EasyInputMessageRoleUser),
+					},
+				},
+				Tools: []responses.ToolUnionParam{
+					{
+						OfFunction: &responses.FunctionToolParam{
+							Type:        constant.Function(""),
+							Name:        "get_weather",
+							Description: param.NewOpt("Get weather for a location"),
+							Parameters:  weatherSchema,
+							Strict:      param.NewOpt(true),
+						},
+					},
+					{
+						OfFunction: &responses.FunctionToolParam{
+							Type:        constant.Function(""),
+							Name:        "calculate",
+							Description: param.NewOpt("Evaluate a math expression"),
+							Parameters:  calcSchema,
+							Strict:      param.NewOpt(true),
+						},
+					},
+				},
+				MaxOutputTokens: nativeopenai.Int(256),
+			})
+		},
+		SDKCall: func(t *testing.T, transport *wireconformance.RecordingTransport) {
+			t.Helper()
+			provider, err := openai.NewProvider("test-key", openai.WithHTTPClient(&http.Client{Transport: transport}))
+			if err != nil {
+				t.Fatalf("failed to create provider: %v", err)
+			}
+			model, err := provider.NewModel("gpt-5-mini", openai.WithMaxTokens(256))
+			if err != nil {
+				t.Fatalf("failed to create model: %v", err)
+			}
+			ctx, cancel := newTestCtx()
+			defer cancel()
+			_, _ = model.Generate(ctx, &llm.Request{
+				Messages: []llm.Message{
+					llm.NewMessage(llm.RoleUser, llm.NewTextPart("What's 2+2 and what's the weather in Berlin?")),
+				},
+				Tools: []llm.ToolDefinition{
+					{
+						Name:        "get_weather",
+						Description: "Get weather for a location",
+						Parameters:  weatherBytes,
+					},
+					{
+						Name:        "calculate",
+						Description: "Evaluate a math expression",
+						Parameters:  calcBytes,
+					},
+				},
+			})
+		},
+		IgnorePaths:   defaultIgnorePaths,
+		IgnoreHeaders: defaultIgnoreHeaders,
+		FixHint:       "providers/openai/request_mapper.go (mapToolDefinitions)",
+	}
+}
+
+// topPSetting tests that top_p is actually sent on the wire.
+// BUG: The request mapper has a TopP field in Config but never maps it to the API request.
+func topPSetting() wireconformance.WireScenario {
+	return wireconformance.WireScenario{
+		Name: "top_p_setting",
+		NativeCall: func(t *testing.T, transport *wireconformance.RecordingTransport) {
+			t.Helper()
+			client := nativeopenai.NewClient(option.WithAPIKey("test-key"), option.WithHTTPClient(&http.Client{Transport: transport}))
+			ctx, cancel := newTestCtx()
+			defer cancel()
+			_, _ = client.Responses.New(ctx, responses.ResponseNewParams{
+				Model: "gpt-5-mini",
+				Input: responses.ResponseNewParamsInputUnion{
+					OfInputItemList: []responses.ResponseInputItemUnionParam{
+						responses.ResponseInputItemParamOfMessage("Hello", responses.EasyInputMessageRoleUser),
+					},
+				},
+				TopP:            nativeopenai.Float(0.9),
+				MaxOutputTokens: nativeopenai.Int(256),
+			})
+		},
+		SDKCall: func(t *testing.T, transport *wireconformance.RecordingTransport) {
+			t.Helper()
+			provider, err := openai.NewProvider("test-key", openai.WithHTTPClient(&http.Client{Transport: transport}))
+			if err != nil {
+				t.Fatalf("failed to create provider: %v", err)
+			}
+			model, err := provider.NewModel("gpt-5-mini", openai.WithTopP(0.9), openai.WithMaxTokens(256))
+			if err != nil {
+				t.Fatalf("failed to create model: %v", err)
+			}
+			ctx, cancel := newTestCtx()
+			defer cancel()
+			_, _ = model.Generate(ctx, &llm.Request{
+				Messages: []llm.Message{
+					llm.NewMessage(llm.RoleUser, llm.NewTextPart("Hello")),
+				},
+			})
+		},
+		IgnorePaths:   defaultIgnorePaths,
+		IgnoreHeaders: defaultIgnoreHeaders,
+		FixHint:       "providers/openai/request_mapper.go (ToProvider method - TopP not mapped)",
+	}
+}
+
+// reasoningEffortAndSummary tests reasoning parameters with a reasoning-capable model.
+func reasoningEffortAndSummary() wireconformance.WireScenario {
+	return wireconformance.WireScenario{
+		Name: "reasoning_effort_and_summary",
+		NativeCall: func(t *testing.T, transport *wireconformance.RecordingTransport) {
+			t.Helper()
+			client := nativeopenai.NewClient(option.WithAPIKey("test-key"), option.WithHTTPClient(&http.Client{Transport: transport}))
+			ctx, cancel := newTestCtx()
+			defer cancel()
+			_, _ = client.Responses.New(ctx, responses.ResponseNewParams{
+				Model: "gpt-5",
+				Input: responses.ResponseNewParamsInputUnion{
+					OfInputItemList: []responses.ResponseInputItemUnionParam{
+						responses.ResponseInputItemParamOfMessage("Solve: what is 123 * 456?", responses.EasyInputMessageRoleUser),
+					},
+				},
+				Reasoning: shared.ReasoningParam{
+					Effort:  shared.ReasoningEffortHigh,
+					Summary: shared.ReasoningSummaryDetailed,
+				},
+				MaxOutputTokens: nativeopenai.Int(1024),
+			})
+		},
+		SDKCall: func(t *testing.T, transport *wireconformance.RecordingTransport) {
+			t.Helper()
+			provider, err := openai.NewProvider("test-key", openai.WithHTTPClient(&http.Client{Transport: transport}))
+			if err != nil {
+				t.Fatalf("failed to create provider: %v", err)
+			}
+			model, err := provider.NewModel("gpt-5",
+				openai.WithReasoningEffort(openai.ReasoningEffortHigh),
+				openai.WithReasoningSummary(openai.ReasoningSummaryDetailed),
+				openai.WithMaxTokens(1024),
+			)
+			if err != nil {
+				t.Fatalf("failed to create model: %v", err)
+			}
+			ctx, cancel := newTestCtx()
+			defer cancel()
+			_, _ = model.Generate(ctx, &llm.Request{
+				Messages: []llm.Message{
+					llm.NewMessage(llm.RoleUser, llm.NewTextPart("Solve: what is 123 * 456?")),
+				},
+			})
+		},
+		IgnorePaths:   defaultIgnorePaths,
+		IgnoreHeaders: defaultIgnoreHeaders,
+		FixHint:       "providers/openai/request_mapper.go (ToProvider method - reasoning config)",
+	}
+}
+
+// schemaWithOptionalFields tests that our schema adaptation (making all fields required,
+// using ["type", "null"] for optional fields) matches what a user would pass natively.
+// This catches divergences in the SchemaMapper.
+func schemaWithOptionalFields() wireconformance.WireScenario {
+	// Schema where "nickname" is optional (not in required).
+	// Our SDK's SchemaMapper should transform this to match OpenAI's strict mode requirements.
+	// The native side passes the schema already in OpenAI format (all required, nullable union).
+	openaiStyleSchema := map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"name": map[string]any{
+				"type": "string",
+			},
+			"nickname": map[string]any{
+				"type": []any{"string", "null"},
+			},
+		},
+		"required":             []any{"name", "nickname"},
+		"additionalProperties": false,
+	}
+
+	// The schema as a user would naturally write it (standard JSON Schema).
+	userStyleSchema := map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"name": map[string]any{
+				"type": "string",
+			},
+			"nickname": map[string]any{
+				"type": "string",
+			},
+		},
+		"required":             []any{"name"},
+		"additionalProperties": false,
+	}
+	userSchemaBytes, _ := json.Marshal(userStyleSchema)
+
+	return wireconformance.WireScenario{
+		Name: "schema_with_optional_fields",
+		NativeCall: func(t *testing.T, transport *wireconformance.RecordingTransport) {
+			t.Helper()
+			client := nativeopenai.NewClient(option.WithAPIKey("test-key"), option.WithHTTPClient(&http.Client{Transport: transport}))
+			ctx, cancel := newTestCtx()
+			defer cancel()
+			_, _ = client.Responses.New(ctx, responses.ResponseNewParams{
+				Model: "gpt-5-mini",
+				Input: responses.ResponseNewParamsInputUnion{
+					OfInputItemList: []responses.ResponseInputItemUnionParam{
+						responses.ResponseInputItemParamOfMessage("Extract person info from: Bob, also known as Bobby", responses.EasyInputMessageRoleUser),
+					},
+				},
+				Text: responses.ResponseTextConfigParam{
+					Format: responses.ResponseFormatTextConfigUnionParam{
+						OfJSONSchema: &responses.ResponseFormatTextJSONSchemaConfigParam{
+							Type:        "json_schema",
+							Name:        "person_info",
+							Schema:      openaiStyleSchema,
+							Description: param.NewOpt("Person with optional nickname"),
+							Strict:      param.NewOpt(true),
+						},
+					},
+				},
+				MaxOutputTokens: nativeopenai.Int(256),
+			})
+		},
+		SDKCall: func(t *testing.T, transport *wireconformance.RecordingTransport) {
+			t.Helper()
+			provider, err := openai.NewProvider("test-key", openai.WithHTTPClient(&http.Client{Transport: transport}))
+			if err != nil {
+				t.Fatalf("failed to create provider: %v", err)
+			}
+			model, err := provider.NewModel("gpt-5-mini", openai.WithMaxTokens(256))
+			if err != nil {
+				t.Fatalf("failed to create model: %v", err)
+			}
+			ctx, cancel := newTestCtx()
+			defer cancel()
+			_, _ = model.Generate(ctx, &llm.Request{
+				Messages: []llm.Message{
+					llm.NewMessage(llm.RoleUser, llm.NewTextPart("Extract person info from: Bob, also known as Bobby")),
+				},
+				ResponseFormat: &llm.ResponseFormat{
+					Type: llm.ResponseFormatJSONSchema,
+					JSONSchema: &llm.JSONSchema{
+						Name:        "person_info",
+						Description: "Person with optional nickname",
+						Schema:      userSchemaBytes,
+					},
+				},
+			})
+		},
+		IgnorePaths:   defaultIgnorePaths,
+		IgnoreHeaders: defaultIgnoreHeaders,
+		FixHint:       "providers/openai/schema_mapper.go (AdaptSchemaForOpenAI)",
 	}
 }

--- a/providers/openai/openai_wire_test.go
+++ b/providers/openai/openai_wire_test.go
@@ -1,0 +1,149 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package openai_test
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	nativeopenai "github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/option"
+	"github.com/openai/openai-go/v3/responses"
+
+	"github.com/redpanda-data/ai-sdk-go/llm"
+	"github.com/redpanda-data/ai-sdk-go/providers/openai"
+	"github.com/redpanda-data/ai-sdk-go/providers/wireconformance"
+)
+
+// cannedOpenAIResponse is a minimal valid OpenAI Responses API response.
+// It must be valid enough that neither SDK chokes during response parsing,
+// but the exact content doesn't matter -- we only care about the request.
+var cannedOpenAIResponse = []byte(`{
+	"id": "resp_test_001",
+	"object": "response",
+	"created_at": 1700000000,
+	"status": "completed",
+	"model": "gpt-5-mini",
+	"output": [
+		{
+			"type": "message",
+			"id": "msg_test_001",
+			"status": "completed",
+			"role": "assistant",
+			"content": [
+				{
+					"type": "output_text",
+					"text": "Hello, World!",
+					"annotations": []
+				}
+			]
+		}
+	],
+	"usage": {
+		"input_tokens": 10,
+		"output_tokens": 5,
+		"total_tokens": 15,
+		"input_tokens_details": {"cached_tokens": 0},
+		"output_tokens_details": {"reasoning_tokens": 0}
+	},
+	"text": {
+		"format": {"type": "text"}
+	}
+}`)
+
+func TestOpenAIWireConformance(t *testing.T) {
+	t.Parallel()
+
+	scenarios := []wireconformance.WireScenario{
+		simpleTextGeneration(),
+	}
+
+	for _, scenario := range scenarios {
+		wireconformance.RunScenario(t, scenario, cannedOpenAIResponse)
+	}
+}
+
+func simpleTextGeneration() wireconformance.WireScenario {
+	return wireconformance.WireScenario{
+		Name: "simple_text_generation",
+		NativeCall: func(t *testing.T, transport *wireconformance.RecordingTransport) {
+			t.Helper()
+
+			client := nativeopenai.NewClient(
+				option.WithAPIKey("test-key"),
+				option.WithHTTPClient(&http.Client{Transport: transport}),
+			)
+
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+
+			// Use the native SDK exactly how a user would.
+			_, _ = client.Responses.New(ctx, responses.ResponseNewParams{
+				Model: "gpt-5-mini",
+				Input: responses.ResponseNewParamsInputUnion{
+					OfInputItemList: []responses.ResponseInputItemUnionParam{
+						responses.ResponseInputItemParamOfMessage("Say 'Hello, World!' and nothing else.", responses.EasyInputMessageRoleUser),
+					},
+				},
+				MaxOutputTokens: nativeopenai.Int(256),
+			})
+		},
+		SDKCall: func(t *testing.T, transport *wireconformance.RecordingTransport) {
+			t.Helper()
+
+			provider, err := openai.NewProvider("test-key",
+				openai.WithHTTPClient(&http.Client{Transport: transport}),
+			)
+			if err != nil {
+				t.Fatalf("failed to create provider: %v", err)
+			}
+
+			model, err := provider.NewModel("gpt-5-mini", openai.WithMaxTokens(256))
+			if err != nil {
+				t.Fatalf("failed to create model: %v", err)
+			}
+
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+
+			_, _ = model.Generate(ctx, &llm.Request{
+				Messages: []llm.Message{
+					llm.NewMessage(llm.RoleUser, llm.NewTextPart("Say 'Hello, World!' and nothing else.")),
+				},
+			})
+		},
+		IgnorePaths: []string{
+			"stream",           // ai-sdk may or may not set this
+			"stream_options",   // streaming config
+			"truncation",      // SDK default that native may not set
+		},
+		IgnoreHeaders: []string{
+			"X-Stainless-Lang",
+			"X-Stainless-Package-Version",
+			"X-Stainless-Os",
+			"X-Stainless-Arch",
+			"X-Stainless-Runtime",
+			"X-Stainless-Runtime-Version",
+			"X-Stainless-Retry-Count",
+			"X-Stainless-Read-Timeout",
+			"X-Stainless-Poll-Helper",
+			"Idempotency-Key",
+			"Openai-Organization",
+		},
+		FixHint: "providers/openai/request_mapper.go (ToProvider method)",
+	}
+}

--- a/providers/wireconformance/differ.go
+++ b/providers/wireconformance/differ.go
@@ -1,0 +1,278 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package wireconformance
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// DiffKind classifies a single field-level difference.
+type DiffKind int
+
+const (
+	// DiffMissing means a field is present in the native SDK request but absent in ai-sdk-go.
+	DiffMissing DiffKind = iota
+	// DiffExtra means a field is present in ai-sdk-go but absent in the native SDK request.
+	DiffExtra
+	// DiffChanged means both have the field but with different values.
+	DiffChanged
+	// DiffTypeMismatch means both have the field but the JSON types differ.
+	DiffTypeMismatch
+)
+
+func (k DiffKind) String() string {
+	switch k {
+	case DiffMissing:
+		return "MISSING"
+	case DiffExtra:
+		return "EXTRA"
+	case DiffChanged:
+		return "CHANGED"
+	case DiffTypeMismatch:
+		return "TYPE_MISMATCH"
+	default:
+		return "UNKNOWN"
+	}
+}
+
+// FieldDiff represents a single difference at a specific JSON path.
+type FieldDiff struct {
+	Path     string          // JSON path, e.g. "messages[0].content"
+	Kind     DiffKind        // Type of difference
+	Expected json.RawMessage // Value from native SDK (nil if DiffExtra)
+	Actual   json.RawMessage // Value from ai-sdk-go (nil if DiffMissing)
+}
+
+// DiffJSON performs a recursive structural diff between two JSON values.
+// Fields matching any ignore rule are skipped.
+func DiffJSON(native, aisdk json.RawMessage, ignores map[string]bool) []FieldDiff {
+	var diffs []FieldDiff
+	diffRecursive("", native, aisdk, ignores, &diffs)
+	return diffs
+}
+
+func diffRecursive(path string, native, aisdk json.RawMessage, ignores map[string]bool, diffs *[]FieldDiff) {
+	if shouldIgnore(path, ignores) {
+		return
+	}
+
+	// Determine JSON types
+	nType := jsonType(native)
+	aType := jsonType(aisdk)
+
+	// Handle nil/null cases
+	if isAbsent(native) && isAbsent(aisdk) {
+		return
+	}
+	if isAbsent(native) && !isAbsent(aisdk) {
+		*diffs = append(*diffs, FieldDiff{
+			Path:   path,
+			Kind:   DiffExtra,
+			Actual: aisdk,
+		})
+		return
+	}
+	if !isAbsent(native) && isAbsent(aisdk) {
+		*diffs = append(*diffs, FieldDiff{
+			Path:     path,
+			Kind:     DiffMissing,
+			Expected: native,
+		})
+		return
+	}
+
+	// Type mismatch
+	if nType != aType {
+		*diffs = append(*diffs, FieldDiff{
+			Path:     path,
+			Kind:     DiffTypeMismatch,
+			Expected: native,
+			Actual:   aisdk,
+		})
+		return
+	}
+
+	switch nType {
+	case "object":
+		diffObjects(path, native, aisdk, ignores, diffs)
+	case "array":
+		diffArrays(path, native, aisdk, ignores, diffs)
+	default:
+		// Scalar comparison
+		if string(native) != string(aisdk) {
+			*diffs = append(*diffs, FieldDiff{
+				Path:     path,
+				Kind:     DiffChanged,
+				Expected: native,
+				Actual:   aisdk,
+			})
+		}
+	}
+}
+
+func diffObjects(path string, native, aisdk json.RawMessage, ignores map[string]bool, diffs *[]FieldDiff) {
+	var nMap, aMap map[string]json.RawMessage
+	json.Unmarshal(native, &nMap)  //nolint:errcheck
+	json.Unmarshal(aisdk, &aMap)   //nolint:errcheck
+
+	// Collect all keys
+	allKeys := make(map[string]bool)
+	for k := range nMap {
+		allKeys[k] = true
+	}
+	for k := range aMap {
+		allKeys[k] = true
+	}
+
+	// Sort for deterministic output
+	keys := make([]string, 0, len(allKeys))
+	for k := range allKeys {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	for _, key := range keys {
+		childPath := joinPath(path, key)
+		nVal, nOK := nMap[key]
+		aVal, aOK := aMap[key]
+
+		switch {
+		case nOK && aOK:
+			diffRecursive(childPath, nVal, aVal, ignores, diffs)
+		case nOK && !aOK:
+			diffRecursive(childPath, nVal, nil, ignores, diffs)
+		case !nOK && aOK:
+			diffRecursive(childPath, nil, aVal, ignores, diffs)
+		}
+	}
+}
+
+func diffArrays(path string, native, aisdk json.RawMessage, ignores map[string]bool, diffs *[]FieldDiff) {
+	var nArr, aArr []json.RawMessage
+	json.Unmarshal(native, &nArr) //nolint:errcheck
+	json.Unmarshal(aisdk, &aArr)  //nolint:errcheck
+
+	maxLen := len(nArr)
+	if len(aArr) > maxLen {
+		maxLen = len(aArr)
+	}
+
+	for i := 0; i < maxLen; i++ {
+		childPath := fmt.Sprintf("%s[%d]", path, i)
+		var nVal, aVal json.RawMessage
+		if i < len(nArr) {
+			nVal = nArr[i]
+		}
+		if i < len(aArr) {
+			aVal = aArr[i]
+		}
+		diffRecursive(childPath, nVal, aVal, ignores, diffs)
+	}
+}
+
+func joinPath(parent, child string) string {
+	if parent == "" {
+		return child
+	}
+	return parent + "." + child
+}
+
+func jsonType(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return "null"
+	}
+	switch raw[0] {
+	case '{':
+		return "object"
+	case '[':
+		return "array"
+	case '"':
+		return "string"
+	case 't', 'f':
+		return "boolean"
+	case 'n':
+		return "null"
+	default:
+		return "number"
+	}
+}
+
+func isAbsent(raw json.RawMessage) bool {
+	if len(raw) == 0 {
+		return true
+	}
+	return string(raw) == "null"
+}
+
+// shouldIgnore checks if a path matches any ignore pattern.
+// Supports exact match and wildcard suffix match (e.g. "metadata.*" ignores "metadata.foo").
+func shouldIgnore(path string, ignores map[string]bool) bool {
+	if ignores[path] {
+		return true
+	}
+	// Check wildcard patterns: "foo.*" matches "foo.bar" and "foo.bar.baz"
+	for pattern := range ignores {
+		if strings.HasSuffix(pattern, ".*") {
+			prefix := strings.TrimSuffix(pattern, ".*")
+			if strings.HasPrefix(path, prefix+".") {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// FormatDiffs produces a human/agent-readable report of all diffs.
+func FormatDiffs(scenario string, diffs []FieldDiff, fixHint string) string {
+	if len(diffs) == 0 {
+		return ""
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "FAIL: %s (%d diffs)\n\n", scenario, len(diffs))
+
+	for _, d := range diffs {
+		fmt.Fprintf(&b, "  Path: %s\n", d.Path)
+		fmt.Fprintf(&b, "    kind:    %s\n", d.Kind)
+		if d.Expected != nil {
+			fmt.Fprintf(&b, "    native:  %s\n", truncate(string(d.Expected), 200))
+		}
+		if d.Actual != nil {
+			fmt.Fprintf(&b, "    ai-sdk:  %s\n", truncate(string(d.Actual), 200))
+		}
+		if d.Expected == nil {
+			fmt.Fprintf(&b, "    native:  <absent>\n")
+		}
+		if d.Actual == nil {
+			fmt.Fprintf(&b, "    ai-sdk:  <absent>\n")
+		}
+		if fixHint != "" {
+			fmt.Fprintf(&b, "    fix-in:  %s\n", fixHint)
+		}
+		b.WriteString("\n")
+	}
+
+	return b.String()
+}
+
+func truncate(s string, max int) string {
+	if len(s) <= max {
+		return s
+	}
+	return s[:max] + "..."
+}

--- a/providers/wireconformance/differ_test.go
+++ b/providers/wireconformance/differ_test.go
@@ -1,0 +1,167 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package wireconformance
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDiffJSON_Identical(t *testing.T) {
+	t.Parallel()
+
+	a := json.RawMessage(`{"model":"gpt-5","input":[{"role":"user","content":"hi"}],"max_tokens":100}`)
+	diffs := DiffJSON(a, a, nil)
+	assert.Empty(t, diffs)
+}
+
+func TestDiffJSON_MissingField(t *testing.T) {
+	t.Parallel()
+
+	native := json.RawMessage(`{"model":"gpt-5","temperature":0.7}`)
+	aisdk := json.RawMessage(`{"model":"gpt-5"}`)
+
+	diffs := DiffJSON(native, aisdk, nil)
+	require.Len(t, diffs, 1)
+	assert.Equal(t, "temperature", diffs[0].Path)
+	assert.Equal(t, DiffMissing, diffs[0].Kind)
+}
+
+func TestDiffJSON_ExtraField(t *testing.T) {
+	t.Parallel()
+
+	native := json.RawMessage(`{"model":"gpt-5"}`)
+	aisdk := json.RawMessage(`{"model":"gpt-5","extra":true}`)
+
+	diffs := DiffJSON(native, aisdk, nil)
+	require.Len(t, diffs, 1)
+	assert.Equal(t, "extra", diffs[0].Path)
+	assert.Equal(t, DiffExtra, diffs[0].Kind)
+}
+
+func TestDiffJSON_ChangedValue(t *testing.T) {
+	t.Parallel()
+
+	native := json.RawMessage(`{"model":"gpt-5","temperature":0.7}`)
+	aisdk := json.RawMessage(`{"model":"gpt-5","temperature":0.9}`)
+
+	diffs := DiffJSON(native, aisdk, nil)
+	require.Len(t, diffs, 1)
+	assert.Equal(t, "temperature", diffs[0].Path)
+	assert.Equal(t, DiffChanged, diffs[0].Kind)
+}
+
+func TestDiffJSON_NestedObject(t *testing.T) {
+	t.Parallel()
+
+	native := json.RawMessage(`{"config":{"a":1,"b":2}}`)
+	aisdk := json.RawMessage(`{"config":{"a":1,"b":3}}`)
+
+	diffs := DiffJSON(native, aisdk, nil)
+	require.Len(t, diffs, 1)
+	assert.Equal(t, "config.b", diffs[0].Path)
+	assert.Equal(t, DiffChanged, diffs[0].Kind)
+}
+
+func TestDiffJSON_ArrayElements(t *testing.T) {
+	t.Parallel()
+
+	native := json.RawMessage(`{"items":["a","b","c"]}`)
+	aisdk := json.RawMessage(`{"items":["a","x","c"]}`)
+
+	diffs := DiffJSON(native, aisdk, nil)
+	require.Len(t, diffs, 1)
+	assert.Equal(t, "items[1]", diffs[0].Path)
+	assert.Equal(t, DiffChanged, diffs[0].Kind)
+}
+
+func TestDiffJSON_ArrayLengthMismatch(t *testing.T) {
+	t.Parallel()
+
+	native := json.RawMessage(`{"items":[1,2,3]}`)
+	aisdk := json.RawMessage(`{"items":[1,2]}`)
+
+	diffs := DiffJSON(native, aisdk, nil)
+	require.Len(t, diffs, 1)
+	assert.Equal(t, "items[2]", diffs[0].Path)
+	assert.Equal(t, DiffMissing, diffs[0].Kind)
+}
+
+func TestDiffJSON_TypeMismatch(t *testing.T) {
+	t.Parallel()
+
+	native := json.RawMessage(`{"value":"string"}`)
+	aisdk := json.RawMessage(`{"value":42}`)
+
+	diffs := DiffJSON(native, aisdk, nil)
+	require.Len(t, diffs, 1)
+	assert.Equal(t, "value", diffs[0].Path)
+	assert.Equal(t, DiffTypeMismatch, diffs[0].Kind)
+}
+
+func TestDiffJSON_IgnoredPaths(t *testing.T) {
+	t.Parallel()
+
+	native := json.RawMessage(`{"model":"gpt-5","stream":true,"metadata":{"key":"val"}}`)
+	aisdk := json.RawMessage(`{"model":"gpt-5"}`)
+
+	ignores := map[string]bool{
+		"stream":     true,
+		"metadata.*": true,
+	}
+
+	diffs := DiffJSON(native, aisdk, ignores)
+	// "stream" is ignored directly, "metadata" itself is not ignored but
+	// if we also want to ignore the parent, we need to add it.
+	// Let's just check stream is ignored:
+	for _, d := range diffs {
+		assert.NotEqual(t, "stream", d.Path)
+	}
+}
+
+func TestDiffJSON_WildcardIgnore(t *testing.T) {
+	t.Parallel()
+
+	native := json.RawMessage(`{"metadata":{"key":"val","nested":{"deep":1}}}`)
+	aisdk := json.RawMessage(`{"metadata":{"key":"different"}}`)
+
+	ignores := map[string]bool{
+		"metadata.*": true,
+	}
+
+	diffs := DiffJSON(native, aisdk, ignores)
+	assert.Empty(t, diffs)
+}
+
+func TestFormatDiffs_Output(t *testing.T) {
+	t.Parallel()
+
+	diffs := []FieldDiff{
+		{
+			Path:     "tools[0].cache_control",
+			Kind:     DiffMissing,
+			Expected: json.RawMessage(`{"type":"ephemeral"}`),
+		},
+	}
+
+	output := FormatDiffs("tool_test", diffs, "request_mapper.go")
+	assert.Contains(t, output, "FAIL: tool_test (1 diffs)")
+	assert.Contains(t, output, "tools[0].cache_control")
+	assert.Contains(t, output, "MISSING")
+	assert.Contains(t, output, "request_mapper.go")
+}

--- a/providers/wireconformance/recorder.go
+++ b/providers/wireconformance/recorder.go
@@ -1,0 +1,114 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package wireconformance
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"sync"
+)
+
+// CapturedExchange holds a single HTTP request captured by the recording transport.
+type CapturedExchange struct {
+	Method      string
+	URL         string
+	Path        string
+	RequestBody json.RawMessage
+	Headers     http.Header
+}
+
+// RecordingTransport is an http.RoundTripper that captures outgoing request
+// bodies and returns a canned response. No real network calls are made.
+type RecordingTransport struct {
+	// CannedStatusCode is returned for every request. Defaults to 200.
+	CannedStatusCode int
+	// CannedBody is the response body returned for every request.
+	CannedBody []byte
+	// CannedHeaders are merged into every response.
+	CannedHeaders http.Header
+
+	mu       sync.Mutex
+	captured []CapturedExchange
+}
+
+// RoundTrip implements http.RoundTripper. It records the request and returns
+// the canned response without touching the network.
+func (rt *RecordingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	var body []byte
+	if req.Body != nil {
+		var err error
+		body, err = io.ReadAll(req.Body)
+		if err != nil {
+			return nil, err
+		}
+		req.Body.Close()
+	}
+
+	exchange := CapturedExchange{
+		Method:      req.Method,
+		URL:         req.URL.String(),
+		Path:        req.URL.Path,
+		RequestBody: json.RawMessage(body),
+		Headers:     req.Header.Clone(),
+	}
+
+	rt.mu.Lock()
+	rt.captured = append(rt.captured, exchange)
+	rt.mu.Unlock()
+
+	statusCode := rt.CannedStatusCode
+	if statusCode == 0 {
+		statusCode = http.StatusOK
+	}
+
+	respHeaders := make(http.Header)
+	respHeaders.Set("Content-Type", "application/json")
+	for k, vs := range rt.CannedHeaders {
+		for _, v := range vs {
+			respHeaders.Add(k, v)
+		}
+	}
+
+	cannedBody := rt.CannedBody
+	if cannedBody == nil {
+		cannedBody = []byte(`{}`)
+	}
+
+	return &http.Response{
+		StatusCode: statusCode,
+		Header:     respHeaders,
+		Body:       io.NopCloser(bytes.NewReader(cannedBody)),
+	}, nil
+}
+
+// Captured returns a copy of all captured exchanges.
+func (rt *RecordingTransport) Captured() []CapturedExchange {
+	rt.mu.Lock()
+	defer rt.mu.Unlock()
+
+	out := make([]CapturedExchange, len(rt.captured))
+	copy(out, rt.captured)
+	return out
+}
+
+// Reset clears all captured exchanges.
+func (rt *RecordingTransport) Reset() {
+	rt.mu.Lock()
+	defer rt.mu.Unlock()
+
+	rt.captured = nil
+}

--- a/providers/wireconformance/suite.go
+++ b/providers/wireconformance/suite.go
@@ -1,0 +1,187 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package wireconformance provides infrastructure for wire-level conformance
+// testing of AI SDK providers. It captures HTTP requests made by both the
+// native provider SDK and the ai-sdk-go provider, then structurally diffs
+// them to detect silent field drops, wrong mappings, or missing headers.
+//
+// Tests using this package do not make real API calls. A recording HTTP
+// transport returns canned responses, making tests free, fast, and
+// deterministic.
+package wireconformance
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// WireScenario defines a single wire conformance test case.
+type WireScenario struct {
+	// Name identifies the scenario in test output.
+	Name string
+
+	// NativeCall uses the native provider SDK (configured with the recording
+	// transport) to make an API call. The call may return an error from
+	// response parsing (since the canned response is minimal) -- that's fine,
+	// we only care about the captured request.
+	NativeCall func(t *testing.T, transport *RecordingTransport)
+
+	// SDKCall uses ai-sdk-go (configured with the recording transport) to
+	// make the equivalent API call.
+	SDKCall func(t *testing.T, transport *RecordingTransport)
+
+	// IgnorePaths are JSON paths to ignore when diffing request bodies.
+	// Use dotted paths for nested fields, "field.*" for wildcard.
+	IgnorePaths []string
+
+	// IgnoreHeaders are header names to skip when comparing headers.
+	IgnoreHeaders []string
+
+	// FixHint tells the agent where to look to fix diffs.
+	FixHint string
+}
+
+// RunScenario executes a single wire scenario: captures both requests, diffs them.
+func RunScenario(t *testing.T, scenario WireScenario, cannedResponse []byte) {
+	t.Helper()
+	t.Run(scenario.Name, func(t *testing.T) {
+		// Set up two independent recording transports with the same canned response.
+		nativeTransport := &RecordingTransport{
+			CannedStatusCode: http.StatusOK,
+			CannedBody:       cannedResponse,
+		}
+		sdkTransport := &RecordingTransport{
+			CannedStatusCode: http.StatusOK,
+			CannedBody:       cannedResponse,
+		}
+
+		// Run both calls.
+		scenario.NativeCall(t, nativeTransport)
+		scenario.SDKCall(t, sdkTransport)
+
+		// Get captured exchanges.
+		nativeCaptured := nativeTransport.Captured()
+		sdkCaptured := sdkTransport.Captured()
+
+		require.NotEmpty(t, nativeCaptured, "native SDK made no HTTP requests")
+		require.NotEmpty(t, sdkCaptured, "ai-sdk-go made no HTTP requests")
+		require.Equal(t, len(nativeCaptured), len(sdkCaptured),
+			"native SDK made %d requests, ai-sdk-go made %d", len(nativeCaptured), len(sdkCaptured))
+
+		// Build ignore set.
+		ignores := make(map[string]bool)
+		for _, p := range scenario.IgnorePaths {
+			ignores[p] = true
+		}
+
+		// Diff each request pair.
+		for i := range nativeCaptured {
+			native := nativeCaptured[i]
+			sdk := sdkCaptured[i]
+
+			// Compare request bodies.
+			diffs := DiffJSON(native.RequestBody, sdk.RequestBody, ignores)
+			if len(diffs) > 0 {
+				report := FormatDiffs(scenario.Name, diffs, scenario.FixHint)
+				t.Errorf("wire conformance request body mismatch:\n%s", report)
+			}
+
+			// Compare headers (optional).
+			headerIgnores := map[string]bool{
+				"User-Agent":    true,
+				"Authorization": true,
+				"Content-Type":  true,
+				"Content-Length": true,
+				"Accept":        true,
+				"Accept-Encoding": true,
+			}
+			for _, h := range scenario.IgnoreHeaders {
+				headerIgnores[http.CanonicalHeaderKey(h)] = true
+			}
+
+			headerDiffs := diffHeaders(native.Headers, sdk.Headers, headerIgnores)
+			if len(headerDiffs) > 0 {
+				report := FormatDiffs(scenario.Name+" [headers]", headerDiffs, scenario.FixHint)
+				t.Errorf("wire conformance header mismatch:\n%s", report)
+			}
+		}
+	})
+}
+
+// diffHeaders compares two sets of HTTP headers, ignoring specified header names.
+func diffHeaders(native, sdk http.Header, ignores map[string]bool) []FieldDiff {
+	var diffs []FieldDiff
+
+	allKeys := make(map[string]bool)
+	for k := range native {
+		allKeys[http.CanonicalHeaderKey(k)] = true
+	}
+	for k := range sdk {
+		allKeys[http.CanonicalHeaderKey(k)] = true
+	}
+
+	for key := range allKeys {
+		if ignores[key] {
+			continue
+		}
+
+		nVals := native.Values(key)
+		sVals := sdk.Values(key)
+
+		nStr := headerValStr(nVals)
+		sStr := headerValStr(sVals)
+
+		if nStr == sStr {
+			continue
+		}
+
+		diff := FieldDiff{Path: "Header:" + key}
+		switch {
+		case len(nVals) > 0 && len(sVals) == 0:
+			diff.Kind = DiffMissing
+			diff.Expected = []byte(`"` + nStr + `"`)
+		case len(nVals) == 0 && len(sVals) > 0:
+			diff.Kind = DiffExtra
+			diff.Actual = []byte(`"` + sStr + `"`)
+		default:
+			diff.Kind = DiffChanged
+			diff.Expected = []byte(`"` + nStr + `"`)
+			diff.Actual = []byte(`"` + sStr + `"`)
+		}
+
+		diffs = append(diffs, diff)
+	}
+
+	return diffs
+}
+
+func headerValStr(vals []string) string {
+	if len(vals) == 0 {
+		return ""
+	}
+	if len(vals) == 1 {
+		return vals[0]
+	}
+	result := ""
+	for i, v := range vals {
+		if i > 0 {
+			result += ", "
+		}
+		result += v
+	}
+	return result
+}

--- a/rfcs/wire-conformance-tests.md
+++ b/rfcs/wire-conformance-tests.md
@@ -1,0 +1,375 @@
+# RFC: Wire Conformance Tests
+
+## Problem
+
+The existing conformance test suite validates behavior: "given this `llm.Request`, does the
+provider return a sane `llm.Response`?" This catches high-level breakage but is blind to
+silent wire-level regressions. If a request mapper drops a field, sends a wrong type, or
+omits a header, the model usually still returns *something* -- the test passes, the bug
+ships.
+
+Examples of bugs this misses:
+
+- `cache_control` markers silently dropped -- requests work, but caching never activates
+  and the user pays full price.
+- `tool_choice` mapped as `"auto"` when the user asked for `"required"` -- model still
+  calls tools most of the time, behavioral test passes by luck.
+- Provider-specific headers missing (e.g., `anthropic-beta`) -- API falls back to default
+  behavior, which happens to work today but may not tomorrow.
+- New fields added to native SDK (e.g., a new `metadata` or `reasoning` parameter) that
+  our mapper never learned about -- no error, just silent feature loss.
+
+## Solution
+
+Add a second conformance axis: **wire conformance**. For each provider, run the same
+logical operation two ways:
+
+1. **Native SDK** -- use `anthropic-sdk-go` / `openai-go` / `google.golang.org/genai`
+   directly.
+2. **ai-sdk-go provider** -- use our `providers/anthropic` / `providers/openai` / etc.
+
+Both go through a **recording HTTP transport** that captures the outgoing request. Then
+**structurally diff the two request bodies** and fail with exact JSON paths if they
+diverge.
+
+## Design principles
+
+- **No API calls.** The recording transport returns canned responses. Wire tests are free,
+  fast, and deterministic. They run in CI without API keys.
+- **Native SDK is the oracle.** We don't maintain hand-written expected JSON. The native
+  SDK *is* the spec. When it changes serialization, we track it automatically.
+- **Agent-fixable output.** Test failures print the exact JSON path, the native value, the
+  ai-sdk value, and which file to fix. A coding agent can resolve the diff without reading
+  API documentation.
+
+## Architecture
+
+```
+providers/
+  wireconformance/
+    recorder.go        -- recording http.RoundTripper (MITM transport)
+    differ.go          -- structural JSON diff engine, path-based output
+    normalize.go       -- normalization rules (ignore, sort, strip)
+    suite.go           -- generic wire conformance suite (testify suite)
+    fixture.go         -- WireFixture interface
+    report.go          -- human/agent-readable failure formatter
+    canned/            -- minimal valid response bodies per provider
+```
+
+Each provider adds a wire test file:
+
+```
+providers/anthropic/anthropic_wire_test.go
+providers/openai/openai_wire_test.go
+providers/google/google_wire_test.go
+```
+
+## Key types
+
+### Recording transport
+
+```go
+// RecordingTransport is an http.RoundTripper that captures request bodies
+// and returns canned responses. No real network calls.
+type RecordingTransport struct {
+    // CannedResponse is returned for every request.
+    CannedStatusCode int
+    CannedBody       []byte
+    CannedHeaders    http.Header
+
+    // Captured holds all recorded exchanges after the test runs.
+    Captured []CapturedExchange
+}
+
+type CapturedExchange struct {
+    Method      string
+    URL         string
+    RequestBody json.RawMessage
+    Headers     http.Header
+}
+```
+
+The transport reads and buffers the request body, records it, and returns the canned
+response. No network involved.
+
+### Wire fixture
+
+```go
+type WireFixture interface {
+    Name() string
+    Scenarios() []WireScenario
+}
+
+type WireScenario struct {
+    Name string
+
+    // NativeCall makes the API call using the native provider SDK,
+    // configured with the recording transport.
+    NativeCall func(t *testing.T, transport *RecordingTransport) error
+
+    // SDKCall makes the equivalent call using ai-sdk-go,
+    // configured with the recording transport.
+    SDKCall func(t *testing.T, transport *RecordingTransport) error
+
+    // NormalizeRules are provider/scenario-specific rules applied
+    // before diffing. Merged with default rules.
+    NormalizeRules []NormalizeRule
+}
+```
+
+### Differ
+
+```go
+type FieldDiff struct {
+    Path     string          // e.g. "messages[0].content[1].cache_control"
+    Expected json.RawMessage // from native SDK call
+    Actual   json.RawMessage // from ai-sdk-go call
+    Kind     DiffKind        // Missing, Extra, Changed, TypeMismatch
+}
+
+type DiffKind int
+
+const (
+    DiffMissing      DiffKind = iota // field in native, absent in ai-sdk
+    DiffExtra                        // field in ai-sdk, absent in native
+    DiffChanged                      // both present, values differ
+    DiffTypeMismatch                 // both present, JSON types differ
+)
+
+func DiffJSON(native, aisdk json.RawMessage, rules []NormalizeRule) []FieldDiff
+```
+
+### Normalization
+
+```go
+type NormalizeAction int
+
+const (
+    Ignore         NormalizeAction = iota // drop field before comparison
+    SortArray                             // sort array elements before comparison
+    StripWhitespace                       // normalize whitespace in strings
+)
+
+type NormalizeRule struct {
+    Path   string          // JSON path pattern, supports wildcards (e.g. "*.metadata")
+    Action NormalizeAction
+}
+```
+
+Default rules applied to all providers:
+
+```go
+var defaultRules = []NormalizeRule{
+    {Path: "stream", Action: Ignore},            // streaming flag expectedly differs
+    {Path: "stream_options", Action: Ignore},     // streaming config
+    {Path: "metadata", Action: Ignore},           // SDK-injected metadata
+}
+```
+
+Provider-specific rules handle legitimate differences, e.g.:
+
+- Anthropic: ignore `anthropic-version` header value (SDK pins its own version)
+- OpenAI: ignore `stream_options.include_usage` (our SDK may set this unconditionally)
+- Google: ignore request URL path differences (SDK versions may vary)
+
+## Test execution flow
+
+For each `WireScenario`:
+
+1. Create two `RecordingTransport` instances with the same canned response.
+2. Run `NativeCall(t, nativeTransport)` -- captures what the native SDK sends.
+3. Run `SDKCall(t, sdkTransport)` -- captures what ai-sdk-go sends.
+4. Assert both captured exactly one exchange (or the same number).
+5. Apply normalization rules to both request bodies.
+6. Run `DiffJSON(native.RequestBody, sdk.RequestBody, rules)`.
+7. Optionally diff headers (with separate header normalization).
+8. If any diffs remain, fail with the structured report.
+
+## Failure output format
+
+Designed for consumption by both humans and coding agents:
+
+```
+=== WIRE CONFORMANCE: anthropic ===
+
+FAIL: tool_call_with_cache_control (2 diffs)
+
+  [REQUEST BODY]
+
+  Path: tools[0].cache_control
+    native:  {"type":"ephemeral"}
+    ai-sdk:  <missing>
+    kind:    MISSING - field present in native SDK request but absent in ai-sdk-go
+    fix-in:  providers/anthropic/request_mapper.go (ToProvider method)
+
+  Path: messages[1].content[0].cache_control
+    native:  {"type":"ephemeral"}
+    ai-sdk:  <missing>
+    kind:    MISSING
+    fix-in:  providers/anthropic/request_mapper.go (ToProvider method)
+
+  [HEADERS]
+
+  Path: anthropic-beta
+    native:  "prompt-caching-2024-07-31"
+    ai-sdk:  <missing>
+    kind:    MISSING
+    fix-in:  providers/anthropic/provider.go (NewProvider)
+```
+
+The `fix-in` hint is derived from a per-provider mapping: request body diffs point to
+`request_mapper.go`, header diffs point to `provider.go`, response diffs (if added later)
+point to `response_mapper.go`.
+
+## Example scenario (Anthropic)
+
+```go
+{
+    Name: "simple_text_generation",
+    NativeCall: func(t *testing.T, rt *RecordingTransport) error {
+        client := anthropic.NewClient(
+            option.WithAPIKey("test-key"),
+            option.WithHTTPClient(&http.Client{Transport: rt}),
+        )
+        _, _ = client.Beta.Messages.New(ctx, anthropic.BetaMessageNewParams{
+            Model:     "claude-sonnet-4-5",
+            MaxTokens: 1024,
+            Messages: []anthropic.BetaMessageParam{
+                anthropic.NewBetaUserMessage(
+                    anthropic.NewBetaTextBlock("Say hello"),
+                ),
+            },
+        })
+        return nil
+    },
+    SDKCall: func(t *testing.T, rt *RecordingTransport) error {
+        provider, _ := NewProvider("test-key",
+            WithHTTPClient(&http.Client{Transport: rt}),
+        )
+        model, _ := provider.NewModel("claude-sonnet-4-5")
+        _, _ = model.Generate(ctx, &llm.Request{
+            Messages: []llm.Message{
+                llm.NewMessage(llm.RoleUser, llm.NewTextPart("Say hello")),
+            },
+            Config: &llm.Config{MaxTokens: intPtr(1024)},
+        })
+        return nil
+    },
+}
+```
+
+## Scenarios to cover per provider
+
+Each provider should have wire scenarios for:
+
+- Simple text generation (single user message)
+- System message handling
+- Multi-turn conversation (user/assistant/user)
+- Tool definitions + tool_choice variants (auto, required, specific)
+- Tool call response (assistant tool_use + user tool_result)
+- Structured output / response format
+- Temperature, top_p, stop sequences
+- Max tokens configuration
+- Reasoning / thinking mode (where supported)
+- Image input (where supported)
+- Prompt caching (where supported)
+
+## Maintenance concern and mitigation
+
+Each scenario requires writing the same call twice (native + ai-sdk-go). With ~12
+scenarios per provider and 4 providers, that's ~96 function pairs. This is real
+maintenance cost.
+
+Mitigation options (not for v1, but worth noting):
+
+1. **Derive native calls from `llm.Request`**: Build a per-provider helper that takes an
+   `llm.Request` and constructs the expected native SDK call programmatically. This halves
+   the scenario code but requires per-provider reflection/construction logic.
+
+2. **Golden file mode**: Instead of running the native SDK every time, capture its output
+   once and store as golden files. Regenerate when the native SDK is upgraded. Trades
+   always-live comparison for lower maintenance, at the cost of staleness.
+
+3. **Auto-generate from behavioral conformance**: Each behavioral conformance test already
+   defines an `llm.Request`. A wire test could be auto-derived from it if the native SDK
+   call can be constructed programmatically.
+
+For v1, explicit dual-call scenarios are fine. The verbosity is acceptable because each
+scenario is simple, self-contained, and easy to review.
+
+## Phasing
+
+### Phase 1: Foundation + Anthropic
+
+Build the infrastructure and prove it on one provider.
+
+### Phase 2: OpenAI + Google
+
+Port to remaining providers with real native SDKs.
+
+### Phase 3: Response mapping
+
+Extend to also compare response parsing: feed the same canned response body through the
+native SDK's response types and through our `ResponseMapper`, diff the resulting
+structures.
+
+### Phase 4: Streaming
+
+Compare SSE event streams. The recording transport returns a canned SSE body; diff the
+parsed event sequence between native SDK streaming and our `GenerateEvents`.
+
+## TODO
+
+### Infrastructure (Phase 1)
+
+- [ ] Create `providers/wireconformance/` package
+- [ ] Implement `RecordingTransport` (captures request body/headers, returns canned response)
+- [ ] Implement `DiffJSON` engine (recursive structural diff with JSON path tracking)
+- [ ] Implement `NormalizeRule` application (ignore, sort, strip on path patterns)
+- [ ] Implement failure report formatter (structured output with fix-in hints)
+- [ ] Define `WireFixture` and `WireScenario` types
+- [ ] Implement `WireSuite` (testify suite runner that executes scenarios and diffs)
+- [ ] Add canned response bodies for Anthropic (minimal valid `/v1/messages` response)
+
+### Anthropic scenarios (Phase 1)
+
+- [ ] Scenario: simple text generation
+- [ ] Scenario: system message
+- [ ] Scenario: multi-turn conversation
+- [ ] Scenario: tool definitions with tool_choice (auto, required, specific)
+- [ ] Scenario: tool call round-trip (tool_use + tool_result)
+- [ ] Scenario: structured output / response format
+- [ ] Scenario: generation config (temperature, top_p, stop_sequences, max_tokens)
+- [ ] Scenario: reasoning / thinking mode
+- [ ] Scenario: prompt caching (cache_control markers)
+- [ ] Scenario: header comparison (anthropic-beta, anthropic-version, content-type)
+
+### OpenAI scenarios (Phase 2)
+
+- [ ] Add canned response bodies for OpenAI
+- [ ] Port all applicable scenarios to OpenAI native SDK
+- [ ] Add OpenAI-specific scenarios (response_format, function calling variants)
+
+### Google scenarios (Phase 2)
+
+- [ ] Add canned response bodies for Google/Gemini
+- [ ] Port all applicable scenarios to Google genai SDK
+- [ ] Add Google-specific scenarios (safety settings, thinking config)
+
+### Response mapping (Phase 3)
+
+- [ ] Extend `RecordingTransport` to also capture/inject response bodies
+- [ ] Build response comparison: canned response -> native SDK parse vs. ResponseMapper parse
+- [ ] Add response diff scenarios per provider
+
+### Streaming (Phase 4)
+
+- [ ] Build SSE canned response support in `RecordingTransport`
+- [ ] Compare parsed event sequences (native streaming vs. GenerateEvents)
+- [ ] Add streaming scenarios per provider
+
+### Maintenance / DX
+
+- [ ] Add `go generate` or helper script to regenerate canned responses from native SDKs
+- [ ] Document how to add new wire scenarios (CONTRIBUTING or package doc)
+- [ ] Investigate auto-deriving scenarios from behavioral conformance test requests


### PR DESCRIPTION
## What

Wire-level conformance test infrastructure that compares the HTTP request bodies our SDK produces against what the native provider SDKs send for the same operation. First provider: OpenAI with 13 scenarios.

## Why

Existing conformance tests only check behavioral correctness ("did we get a sane response?"). They are blind to silent field drops on the wire. A missing `top_p`, a wrong `tool_choice` mapping, a skipped header -- these pass behavioral tests because the model still returns something. Wire tests catch the class of bugs where our request mapper silently loses user-specified parameters.

## Implementation details

**Recording transport**: An `http.RoundTripper` that captures outgoing request bodies and returns canned responses. No real API calls, no keys needed, runs in CI for free in ~10ms.

**JSON differ**: Recursive structural diff that reports exact JSON paths (e.g. `tools[0].cache_control`), diff kind (MISSING/EXTRA/CHANGED/TYPE_MISMATCH), and fix-in hints pointing to the file and method to patch. Output is designed for consumption by coding agents.

**Test flow per scenario**: Run the same logical operation through native SDK and ai-sdk-go, both using recording transports. Diff the captured request bodies. Fail with path-specific report if they diverge.

**13 OpenAI scenarios**: simple text, system messages, multi-turn, temperature, top_p, multiple tools, tool_choice (auto/required/specific), tool call round-trip, structured output JSON schema, reasoning effort+summary, schema adaptation for optional fields.

### Bugs found

**`top_p` silently dropped**: `WithTopP()` stores the value in config but `ToProvider()` never maps it to `apiReq.TopP`. The `top_p_setting` scenario fails, confirming the bug.

**Dead config options**: `frequency_penalty`, `presence_penalty`, `seed`, `stop`, and `logprobs` are accepted as model options but the Responses API has no such fields. These can never reach the wire -- they are accepted without error then silently discarded.

### New files

- `providers/wireconformance/` -- recorder, differ, suite infrastructure
- `providers/openai/openai_wire_test.go` -- 13 scenarios
- `rfcs/wire-conformance-tests.md` -- design doc with phased TODO

## References

RFC in `rfcs/wire-conformance-tests.md` covers phasing: Anthropic/Google providers (phase 2), response mapping comparison (phase 3), streaming (phase 4).