### PR TITLE
feat: migrate Bedrock CI to production-ai AWS account

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,6 +15,8 @@ on:
       - 'go.mod'
       - 'go.sum'
       - '.github/workflows/test.yaml'
+  pull_request_target:
+    types: [labeled]
 
 permissions:
   contents: read
@@ -23,10 +25,15 @@ permissions:
 jobs:
   test:
     name: Test
+    if: >-
+      github.event_name != 'pull_request_target' ||
+      github.event.label.name == 'ci:force-tests'
     runs-on: blacksmith-8vcpu-ubuntu-2404
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - uses: actions/setup-go@v6
         with:
@@ -46,7 +53,7 @@ jobs:
 
       - uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: arn:aws:iam::961547496971:role/ai-sdk-go-ci-bedrock
+          role-to-assume: arn:aws:iam::502376765358:role/ai-sdk-go-ci-bedrock
           aws-region: us-east-1
 
       - uses: go-task/setup-task@v1

--- a/terraform/ai-sdk-ci/README.md
+++ b/terraform/ai-sdk-ci/README.md
@@ -49,41 +49,43 @@ aws s3api put-bucket-encryption \
     '{"Rules":[{"ApplyServerSideEncryptionByDefault":{"SSEAlgorithm":"aws:kms"},"BucketKeyEnabled":true}]}'
 ```
 
-### 2. Apply Terraform with local state (backend block commented out)
+### 2. Apply Terraform
+
+The S3 backend is already configured in `main.tf`, so init connects directly to the bucket:
 
 ```bash
 terraform init
-terraform plan
-terraform apply
+terraform plan -var="create_oidc_provider=false"   # if the GitHub OIDC provider already exists
+terraform apply -var="create_oidc_provider=false"
 ```
 
-### 3. Enable the S3 backend and migrate state
+### 3. Enable Bedrock model access (manual)
 
-Uncomment the `backend "s3"` block in `main.tf`, then:
+Models must be enabled individually via the AWS CLI. Get the offer token, then create the agreement:
 
 ```bash
-terraform init -migrate-state
+OFFER_TOKEN=$(aws bedrock list-foundation-model-agreement-offers \
+  --model-id anthropic.claude-sonnet-4-5-20250929-v1:0 \
+  --region us-east-1 \
+  --query 'offers[0].offerToken' --output text)
+
+aws bedrock create-foundation-model-agreement \
+  --model-id anthropic.claude-sonnet-4-5-20250929-v1:0 \
+  --offer-token "$OFFER_TOKEN" \
+  --region us-east-1
 ```
+
+Repeat for each model needed. The following models are currently enabled:
+
+- `anthropic.claude-sonnet-4-5-20250929-v1:0`
+- `anthropic.claude-sonnet-4-6`
+- `anthropic.claude-haiku-4-5-20251001-v1:0`
+- `anthropic.claude-opus-4-5-20251101-v1:0`
+- `anthropic.claude-opus-4-6-v1`
 
 ### 4. Update the GitHub Actions workflow
 
-Add the OIDC permission and AWS credentials step to `.github/workflows/test.yaml`:
-
-```yaml
-permissions:
-  contents: read
-  id-token: write
-
-steps:
-  # ... checkout, setup-go, etc.
-
-  - uses: aws-actions/configure-aws-credentials@v4
-    with:
-      role-to-assume: arn:aws:iam::961547496971:role/ai-sdk-go-ci-bedrock
-      aws-region: us-east-1
-
-  # ... run tests
-```
+Update the role ARN in `.github/workflows/test.yaml` with the `role_arn` output from the apply.
 
 ## Day-to-day usage
 


### PR DESCRIPTION
## Summary

- Migrates the GitHub Actions OIDC Bedrock IAM role from the old AWS account to `production-ai` (`502376765358`)
- Adds `ci:force-tests` label trigger to run tests on non-code PRs (e.g. Terraform changes)
- Simplifies bootstrap docs to match actual setup flow
- Documents manual model enablement via `aws bedrock create-foundation-model-agreement`

## Infrastructure applied

- S3 state bucket `ai-sdk-ci-tfstate` (us-east-2) — created manually
- IAM role `ai-sdk-go-ci-bedrock` with OIDC trust for `redpanda-data/ai-sdk-go`
- IAM policy with Bedrock invoke, model discovery, and inference profile permissions
- Enabled models: claude-sonnet-4-5, claude-sonnet-4-6, claude-haiku-4-5, claude-opus-4-5, claude-opus-4-6

## Test plan

- [x] Verify GitHub Actions workflow can assume the new role via OIDC
- [x] Verify Bedrock conformance tests pass in CI
- [x] Verify `ci:force-tests` label triggers a test run

🤖 Generated with [Claude Code](https://claude.com/claude-code)