### PR TITLE
refactor: remove DefaultModelID from bedrock ModelDefinition

### DIFF
--- a/providers/bedrock/bedrocktest/constants.go
+++ b/providers/bedrock/bedrocktest/constants.go
@@ -16,9 +16,9 @@ package bedrocktest
 
 const (
 	// TestModelName is the model to use for integration tests.
-	TestModelName = "claude-sonnet-4-5"
+	TestModelName = "anthropic.claude-sonnet-4-5-20250929-v1:0"
 	// TestReasoningModelName is the model for reasoning tests.
-	TestReasoningModelName = "claude-opus-4-5"
+	TestReasoningModelName = "anthropic.claude-opus-4-5-20251101-v1:0"
 	// TestRegion is the default AWS region for tests, overridable via AWS_REGION.
 	TestRegion = "us-east-1"
 )

--- a/providers/bedrock/models.go
+++ b/providers/bedrock/models.go
@@ -15,27 +15,10 @@
 package bedrock
 
 import (
-	"sort"
 	"strings"
 
 	"github.com/redpanda-data/ai-sdk-go/llm"
 )
-
-// modelFamilies is sorted by descending length for deterministic longest-prefix matching.
-var modelFamilies = buildModelFamilies()
-
-func buildModelFamilies() []string {
-	families := make([]string, 0, len(supportedModels))
-	for family := range supportedModels {
-		families = append(families, family)
-	}
-
-	sort.Slice(families, func(i, j int) bool {
-		return len(families[i]) > len(families[j])
-	})
-
-	return families
-}
 
 // Model ID constants for Claude models on Bedrock.
 // These are real Bedrock model IDs that can be passed directly to NewModel.
@@ -45,16 +28,6 @@ const (
 	ModelClaudeHaiku45  = "anthropic.claude-haiku-4-5-20251001-v1:0"
 	ModelClaudeOpus46   = "anthropic.claude-opus-4-6-v1"
 	ModelClaudeOpus45   = "anthropic.claude-opus-4-5-20251101-v1:0"
-)
-
-// familyClaudeSonnet46 and siblings are short family keys used internally
-// for longest-prefix matching in resolveModelFamily.
-const (
-	familyClaudeSonnet46 = "claude-sonnet-4-6"
-	familyClaudeSonnet45 = "claude-sonnet-4-5"
-	familyClaudeHaiku45  = "claude-haiku-4-5"
-	familyClaudeOpus46   = "claude-opus-4-6"
-	familyClaudeOpus45   = "claude-opus-4-5"
 )
 
 // ModelDefinition defines a model with its capabilities and constraints.
@@ -89,39 +62,28 @@ func hasRegionPrefix(modelID string) bool {
 	return strings.ContainsRune(after, '.')
 }
 
-// resolveModelFamily extracts the family key from any Bedrock model ID format.
-//
-// Supports multiple formats:
-//
-//	"claude-sonnet-4-6"                           → "claude-sonnet-4-6" (direct)
-//	"eu.anthropic.claude-sonnet-4-6"              → "claude-sonnet-4-6" (cross-region inference profile)
-//	"global.anthropic.claude-opus-4-6-v1"         → "claude-opus-4-6"  (global inference profile)
-//	"eu.anthropic.claude-sonnet-4-5-20250929-v1:0"→ "claude-sonnet-4-5" (versioned)
-//	"anthropic.claude-sonnet-4-6-v2:0"            → "claude-sonnet-4-6" (provider prefix)
-//
-// Algorithm:
-//  1. Strip region + provider prefix (everything through "anthropic.")
-//  2. Match remaining string against known family keys using prefix matching
-//  3. If no match, return original string (caller rejects unknown models)
-func resolveModelFamily(model string) string {
-	for _, family := range modelFamilies {
-		if strings.HasPrefix(model, family) {
-			return family
-		}
+// lookupModel finds a ModelDefinition by model ID.
+// It tries a direct map lookup first, then strips the region prefix
+// (e.g. "us." from "us.anthropic.claude-sonnet-4-6") and retries.
+func lookupModel(modelName string) (ModelDefinition, bool) {
+	if def, ok := supportedModels[modelName]; ok {
+		return def, true
+	}
 
-		if strings.HasPrefix(model, "anthropic."+family) ||
-			strings.Contains(model, ".anthropic."+family) {
-			return family
+	// Strip region prefix: "us.anthropic.claude-…" → "anthropic.claude-…"
+	if _, after, ok := strings.Cut(modelName, "."); ok {
+		if def, ok := supportedModels[after]; ok {
+			return def, true
 		}
 	}
 
-	return model
+	return ModelDefinition{}, false
 }
 
 // supportedModels defines Claude models available on Bedrock via the Converse API.
 // Standard features only — no Anthropic-specific thinking/effort/speed.
 var supportedModels = map[string]ModelDefinition{
-	familyClaudeSonnet46: {
+	ModelClaudeSonnet46: {
 		Name:  ModelClaudeSonnet46,
 		Label: "Claude Sonnet 4.6",
 		Capabilities: llm.ModelCapabilities{
@@ -139,7 +101,7 @@ var supportedModels = map[string]ModelDefinition{
 			SupportedParams:  []string{"temperature", "top_p", "max_tokens", "stop"},
 		},
 	},
-	familyClaudeSonnet45: {
+	ModelClaudeSonnet45: {
 		Name:  ModelClaudeSonnet45,
 		Label: "Claude Sonnet 4.5",
 		Capabilities: llm.ModelCapabilities{
@@ -157,7 +119,7 @@ var supportedModels = map[string]ModelDefinition{
 			SupportedParams:  []string{"temperature", "top_p", "max_tokens", "stop"},
 		},
 	},
-	familyClaudeHaiku45: {
+	ModelClaudeHaiku45: {
 		Name:  ModelClaudeHaiku45,
 		Label: "Claude Haiku 4.5",
 		Capabilities: llm.ModelCapabilities{
@@ -175,7 +137,7 @@ var supportedModels = map[string]ModelDefinition{
 			SupportedParams:  []string{"temperature", "top_p", "max_tokens", "stop"},
 		},
 	},
-	familyClaudeOpus46: {
+	ModelClaudeOpus46: {
 		Name:  ModelClaudeOpus46,
 		Label: "Claude Opus 4.6",
 		Capabilities: llm.ModelCapabilities{
@@ -193,7 +155,7 @@ var supportedModels = map[string]ModelDefinition{
 			SupportedParams:  []string{"temperature", "top_p", "max_tokens", "stop"},
 		},
 	},
-	familyClaudeOpus45: {
+	ModelClaudeOpus45: {
 		Name:  ModelClaudeOpus45,
 		Label: "Claude Opus 4.5",
 		Capabilities: llm.ModelCapabilities{

--- a/providers/bedrock/models.go
+++ b/providers/bedrock/models.go
@@ -71,12 +71,12 @@ func inferenceProfileRegion(region string) string {
 // segments: bare model IDs like "anthropic.claude-sonnet-4-6" have one dot,
 // while prefixed IDs have two or more.
 func hasRegionPrefix(modelID string) bool {
-	first := strings.IndexByte(modelID, '.')
-	if first < 0 {
+	_, after, ok := strings.Cut(modelID, ".")
+	if !ok {
 		return false
 	}
 
-	return strings.IndexByte(modelID[first+1:], '.') >= 0
+	return strings.ContainsRune(after, '.')
 }
 
 // resolveModelFamily extracts the family key from any Bedrock model ID format.

--- a/providers/bedrock/models.go
+++ b/providers/bedrock/models.go
@@ -65,6 +65,20 @@ func inferenceProfileRegion(region string) string {
 	return "us"
 }
 
+// hasRegionPrefix reports whether a model ID already contains a region
+// inference-profile prefix (e.g. "us.anthropic.claude-sonnet-4-6").
+// It checks for the "{region}.{provider}." pattern by counting dot-separated
+// segments: bare model IDs like "anthropic.claude-sonnet-4-6" have one dot,
+// while prefixed IDs have two or more.
+func hasRegionPrefix(modelID string) bool {
+	first := strings.IndexByte(modelID, '.')
+	if first < 0 {
+		return false
+	}
+
+	return strings.IndexByte(modelID[first+1:], '.') >= 0
+}
+
 // resolveModelFamily extracts the family key from any Bedrock model ID format.
 //
 // Supports multiple formats:

--- a/providers/bedrock/models.go
+++ b/providers/bedrock/models.go
@@ -49,11 +49,10 @@ const (
 
 // ModelDefinition defines a model with its capabilities and constraints.
 type ModelDefinition struct {
-	Name           string
-	Label          string
-	DefaultModelID string // Default Bedrock model ID for this family (e.g. "anthropic.claude-sonnet-4-5-20250929-v1:0")
-	Capabilities   llm.ModelCapabilities
-	Constraints    llm.ModelConstraints
+	Name         string // Real Bedrock model ID (e.g. "anthropic.claude-sonnet-4-5-20250929-v1:0")
+	Label        string
+	Capabilities llm.ModelCapabilities
+	Constraints  llm.ModelConstraints
 }
 
 // inferenceProfileRegion maps an AWS region to the Bedrock inference profile
@@ -99,9 +98,8 @@ func resolveModelFamily(model string) string {
 // Standard features only — no Anthropic-specific thinking/effort/speed.
 var supportedModels = map[string]ModelDefinition{
 	ModelClaudeSonnet46: {
-		Name:           ModelClaudeSonnet46,
-		Label:          "Claude Sonnet 4.6",
-		DefaultModelID: "anthropic.claude-sonnet-4-6",
+		Name:  "anthropic.claude-sonnet-4-6",
+		Label: "Claude Sonnet 4.6",
 		Capabilities: llm.ModelCapabilities{
 			Streaming:     true,
 			Tools:         true,
@@ -118,9 +116,8 @@ var supportedModels = map[string]ModelDefinition{
 		},
 	},
 	ModelClaudeSonnet45: {
-		Name:           ModelClaudeSonnet45,
-		Label:          "Claude Sonnet 4.5",
-		DefaultModelID: "anthropic.claude-sonnet-4-5-20250929-v1:0",
+		Name:  "anthropic.claude-sonnet-4-5-20250929-v1:0",
+		Label: "Claude Sonnet 4.5",
 		Capabilities: llm.ModelCapabilities{
 			Streaming:     true,
 			Tools:         true,
@@ -137,9 +134,8 @@ var supportedModels = map[string]ModelDefinition{
 		},
 	},
 	ModelClaudeHaiku45: {
-		Name:           ModelClaudeHaiku45,
-		Label:          "Claude Haiku 4.5",
-		DefaultModelID: "anthropic.claude-haiku-4-5-20251001-v1:0",
+		Name:  "anthropic.claude-haiku-4-5-20251001-v1:0",
+		Label: "Claude Haiku 4.5",
 		Capabilities: llm.ModelCapabilities{
 			Streaming:     true,
 			Tools:         true,
@@ -156,9 +152,8 @@ var supportedModels = map[string]ModelDefinition{
 		},
 	},
 	ModelClaudeOpus46: {
-		Name:           ModelClaudeOpus46,
-		Label:          "Claude Opus 4.6",
-		DefaultModelID: "anthropic.claude-opus-4-6-v1",
+		Name:  "anthropic.claude-opus-4-6-v1",
+		Label: "Claude Opus 4.6",
 		Capabilities: llm.ModelCapabilities{
 			Streaming:     true,
 			Tools:         true,
@@ -175,9 +170,8 @@ var supportedModels = map[string]ModelDefinition{
 		},
 	},
 	ModelClaudeOpus45: {
-		Name:           ModelClaudeOpus45,
-		Label:          "Claude Opus 4.5",
-		DefaultModelID: "anthropic.claude-opus-4-5-20251101-v1:0",
+		Name:  "anthropic.claude-opus-4-5-20251101-v1:0",
+		Label: "Claude Opus 4.5",
 		Capabilities: llm.ModelCapabilities{
 			Streaming:     true,
 			Tools:         true,

--- a/providers/bedrock/models.go
+++ b/providers/bedrock/models.go
@@ -37,14 +37,24 @@ func buildModelFamilies() []string {
 	return families
 }
 
-// Model family constants for Claude models on Bedrock.
-// These are the canonical short names used as map keys.
+// Model ID constants for Claude models on Bedrock.
+// These are real Bedrock model IDs that can be passed directly to NewModel.
 const (
-	ModelClaudeSonnet46 = "claude-sonnet-4-6"
-	ModelClaudeSonnet45 = "claude-sonnet-4-5"
-	ModelClaudeHaiku45  = "claude-haiku-4-5"
-	ModelClaudeOpus46   = "claude-opus-4-6"
-	ModelClaudeOpus45   = "claude-opus-4-5"
+	ModelClaudeSonnet46 = "anthropic.claude-sonnet-4-6"
+	ModelClaudeSonnet45 = "anthropic.claude-sonnet-4-5-20250929-v1:0"
+	ModelClaudeHaiku45  = "anthropic.claude-haiku-4-5-20251001-v1:0"
+	ModelClaudeOpus46   = "anthropic.claude-opus-4-6-v1"
+	ModelClaudeOpus45   = "anthropic.claude-opus-4-5-20251101-v1:0"
+)
+
+// familyClaudeSonnet46 and siblings are short family keys used internally
+// for longest-prefix matching in resolveModelFamily.
+const (
+	familyClaudeSonnet46 = "claude-sonnet-4-6"
+	familyClaudeSonnet45 = "claude-sonnet-4-5"
+	familyClaudeHaiku45  = "claude-haiku-4-5"
+	familyClaudeOpus46   = "claude-opus-4-6"
+	familyClaudeOpus45   = "claude-opus-4-5"
 )
 
 // ModelDefinition defines a model with its capabilities and constraints.
@@ -111,8 +121,8 @@ func resolveModelFamily(model string) string {
 // supportedModels defines Claude models available on Bedrock via the Converse API.
 // Standard features only — no Anthropic-specific thinking/effort/speed.
 var supportedModels = map[string]ModelDefinition{
-	ModelClaudeSonnet46: {
-		Name:  "anthropic.claude-sonnet-4-6",
+	familyClaudeSonnet46: {
+		Name:  ModelClaudeSonnet46,
 		Label: "Claude Sonnet 4.6",
 		Capabilities: llm.ModelCapabilities{
 			Streaming:     true,
@@ -129,8 +139,8 @@ var supportedModels = map[string]ModelDefinition{
 			SupportedParams:  []string{"temperature", "top_p", "max_tokens", "stop"},
 		},
 	},
-	ModelClaudeSonnet45: {
-		Name:  "anthropic.claude-sonnet-4-5-20250929-v1:0",
+	familyClaudeSonnet45: {
+		Name:  ModelClaudeSonnet45,
 		Label: "Claude Sonnet 4.5",
 		Capabilities: llm.ModelCapabilities{
 			Streaming:     true,
@@ -147,8 +157,8 @@ var supportedModels = map[string]ModelDefinition{
 			SupportedParams:  []string{"temperature", "top_p", "max_tokens", "stop"},
 		},
 	},
-	ModelClaudeHaiku45: {
-		Name:  "anthropic.claude-haiku-4-5-20251001-v1:0",
+	familyClaudeHaiku45: {
+		Name:  ModelClaudeHaiku45,
 		Label: "Claude Haiku 4.5",
 		Capabilities: llm.ModelCapabilities{
 			Streaming:     true,
@@ -165,8 +175,8 @@ var supportedModels = map[string]ModelDefinition{
 			SupportedParams:  []string{"temperature", "top_p", "max_tokens", "stop"},
 		},
 	},
-	ModelClaudeOpus46: {
-		Name:  "anthropic.claude-opus-4-6-v1",
+	familyClaudeOpus46: {
+		Name:  ModelClaudeOpus46,
 		Label: "Claude Opus 4.6",
 		Capabilities: llm.ModelCapabilities{
 			Streaming:     true,
@@ -183,8 +193,8 @@ var supportedModels = map[string]ModelDefinition{
 			SupportedParams:  []string{"temperature", "top_p", "max_tokens", "stop"},
 		},
 	},
-	ModelClaudeOpus45: {
-		Name:  "anthropic.claude-opus-4-5-20251101-v1:0",
+	familyClaudeOpus45: {
+		Name:  ModelClaudeOpus45,
 		Label: "Claude Opus 4.5",
 		Capabilities: llm.ModelCapabilities{
 			Streaming:     true,

--- a/providers/bedrock/provider.go
+++ b/providers/bedrock/provider.go
@@ -157,6 +157,7 @@ func (p *Provider) NewModel(modelName string, opts ...Option) (llm.Model, error)
 	if modelName == family {
 		apiModelID = modelDef.Name
 	}
+
 	if !hasRegionPrefix(apiModelID) {
 		apiModelID = inferenceProfileRegion(p.region) + "." + apiModelID
 	}

--- a/providers/bedrock/provider.go
+++ b/providers/bedrock/provider.go
@@ -149,12 +149,16 @@ func (p *Provider) NewModel(modelName string, opts ...Option) (llm.Model, error)
 	}
 
 	// Resolve the model ID to send to the Bedrock API.
-	// If the user passed a short name (matching the family key exactly),
-	// build the inference profile ID: {regionPrefix}.{modelID}
-	// Otherwise, the user passed a qualified ID — use it as-is.
+	// Short family names are expanded to the full model ID, then any
+	// ID missing a region inference-profile prefix gets one prepended.
+	// IDs that already contain a dotted prefix (e.g. "us.anthropic.…",
+	// "eu.anthropic.…") are used as-is.
 	apiModelID := modelName
 	if modelName == family {
-		apiModelID = inferenceProfileRegion(p.region) + "." + modelDef.Name
+		apiModelID = modelDef.Name
+	}
+	if !hasRegionPrefix(apiModelID) {
+		apiModelID = inferenceProfileRegion(p.region) + "." + apiModelID
 	}
 
 	cfg := &Config{

--- a/providers/bedrock/provider.go
+++ b/providers/bedrock/provider.go
@@ -141,22 +141,15 @@ func WithCaching() ProviderOption {
 
 // NewModel creates a new Bedrock model instance with the specified configuration.
 func (p *Provider) NewModel(modelName string, opts ...Option) (llm.Model, error) {
-	family := resolveModelFamily(modelName)
-
-	modelDef, ok := supportedModels[family]
+	modelDef, ok := lookupModel(modelName)
 	if !ok {
 		return nil, fmt.Errorf("unsupported Bedrock model: %s", modelName)
 	}
 
-	// Resolve the model ID to send to the Bedrock API.
-	// Short family names are expanded to the full model ID, then any
-	// ID missing a region inference-profile prefix gets one prepended.
-	// IDs that already contain a dotted prefix (e.g. "us.anthropic.…",
-	// "eu.anthropic.…") are used as-is.
+	// Build the API model ID with the region inference-profile prefix.
+	// If the caller already provided a region prefix (e.g. "eu.anthropic.…"),
+	// use it as-is. Otherwise prepend the provider's region.
 	apiModelID := modelName
-	if modelName == family {
-		apiModelID = modelDef.Name
-	}
 
 	if !hasRegionPrefix(apiModelID) {
 		apiModelID = inferenceProfileRegion(p.region) + "." + apiModelID

--- a/providers/bedrock/provider.go
+++ b/providers/bedrock/provider.go
@@ -153,8 +153,8 @@ func (p *Provider) NewModel(modelName string, opts ...Option) (llm.Model, error)
 	// build the inference profile ID: {regionPrefix}.{modelID}
 	// Otherwise, the user passed a qualified ID — use it as-is.
 	apiModelID := modelName
-	if modelName == family && modelDef.DefaultModelID != "" {
-		apiModelID = inferenceProfileRegion(p.region) + "." + modelDef.DefaultModelID
+	if modelName == family {
+		apiModelID = inferenceProfileRegion(p.region) + "." + modelDef.Name
 	}
 
 	cfg := &Config{

--- a/providers/bedrock/provider_test.go
+++ b/providers/bedrock/provider_test.go
@@ -28,88 +28,57 @@ import (
 	"github.com/redpanda-data/ai-sdk-go/llm"
 )
 
-// ---------- resolveModelFamily ----------
+// ---------- lookupModel ----------
 
-func TestResolveModelFamily(t *testing.T) {
+func TestLookupModel(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name     string
-		input    string
-		expected string
+		name    string
+		input   string
+		wantOK  bool
+		wantDef string // expected ModelDefinition.Name if found
 	}{
-		// Direct family names
 		{
-			name:     "direct family: claude-sonnet-4-6",
-			input:    "claude-sonnet-4-6",
-			expected: "claude-sonnet-4-6",
+			name:    "direct model ID",
+			input:   ModelClaudeSonnet46,
+			wantOK:  true,
+			wantDef: ModelClaudeSonnet46,
 		},
 		{
-			name:     "direct family: claude-opus-4-6",
-			input:    "claude-opus-4-6",
-			expected: "claude-opus-4-6",
+			name:    "with region prefix",
+			input:   "eu." + ModelClaudeSonnet46,
+			wantOK:  true,
+			wantDef: ModelClaudeSonnet46,
 		},
 		{
-			name:     "direct family: claude-haiku-4-5",
-			input:    "claude-haiku-4-5",
-			expected: "claude-haiku-4-5",
-		},
-		// Cross-region inference profiles
-		{
-			name:     "eu cross-region: eu.anthropic.claude-sonnet-4-6",
-			input:    "eu.anthropic.claude-sonnet-4-6",
-			expected: "claude-sonnet-4-6",
+			name:    "versioned with region",
+			input:   "us." + ModelClaudeHaiku45,
+			wantOK:  true,
+			wantDef: ModelClaudeHaiku45,
 		},
 		{
-			name:     "global cross-region: global.anthropic.claude-opus-4-6-v1",
-			input:    "global.anthropic.claude-opus-4-6-v1",
-			expected: "claude-opus-4-6",
-		},
-		// Versioned inference profiles
-		{
-			name:     "versioned: eu.anthropic.claude-sonnet-4-5-20250929-v1:0",
-			input:    "eu.anthropic.claude-sonnet-4-5-20250929-v1:0",
-			expected: "claude-sonnet-4-5",
+			name:   "unknown model",
+			input:  "llama-3.2-90b",
+			wantOK: false,
 		},
 		{
-			name:     "versioned: eu.anthropic.claude-haiku-4-5-20251001-v1:0",
-			input:    "eu.anthropic.claude-haiku-4-5-20251001-v1:0",
-			expected: "claude-haiku-4-5",
-		},
-		{
-			name:     "versioned: global.anthropic.claude-opus-4-5-20251101-v1:0",
-			input:    "global.anthropic.claude-opus-4-5-20251101-v1:0",
-			expected: "claude-opus-4-5",
-		},
-		// Provider prefix without region
-		{
-			name:     "provider prefix: anthropic.claude-sonnet-4-6-v2:0",
-			input:    "anthropic.claude-sonnet-4-6-v2:0",
-			expected: "claude-sonnet-4-6",
-		},
-		// Unknown model — returned as-is
-		{
-			name:     "unknown model returned as-is",
-			input:    "eu.anthropic.claude-3-5-sonnet-20240620-v1:0",
-			expected: "eu.anthropic.claude-3-5-sonnet-20240620-v1:0",
-		},
-		{
-			name:     "completely unknown model",
-			input:    "llama-3.2-90b",
-			expected: "llama-3.2-90b",
-		},
-		// Negative: "anthropic." must follow a dot or start the string
-		{
-			name:     "misleading prefix: notanthropic.claude-sonnet-4-6",
-			input:    "notanthropic.claude-sonnet-4-6",
-			expected: "notanthropic.claude-sonnet-4-6",
+			name:   "unknown with region prefix",
+			input:  "us.meta.llama-3.2-90b",
+			wantOK: false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			assert.Equal(t, tt.expected, resolveModelFamily(tt.input))
+
+			def, ok := lookupModel(tt.input)
+			assert.Equal(t, tt.wantOK, ok)
+
+			if tt.wantOK {
+				assert.Equal(t, tt.wantDef, def.Name)
+			}
 		})
 	}
 }
@@ -246,11 +215,10 @@ func TestNewModel_SupportedModels(t *testing.T) {
 		name      string
 		modelName string
 	}{
-		{"direct family", "claude-sonnet-4-6"},
-		{"bare model ID", "anthropic.claude-sonnet-4-6"},
-		{"eu cross-region", "eu.anthropic.claude-sonnet-4-6"},
-		{"global versioned", "global.anthropic.claude-opus-4-6-v1"},
-		{"versioned with suffix", "eu.anthropic.claude-haiku-4-5-20251001-v1:0"},
+		{"model constant", ModelClaudeSonnet46},
+		{"with region prefix", "eu." + ModelClaudeSonnet46},
+		{"opus with region", "global." + ModelClaudeOpus46},
+		{"haiku with region", "eu." + ModelClaudeHaiku45},
 	}
 
 	for _, tt := range tests {
@@ -281,7 +249,7 @@ func TestNewModel_WithOptions(t *testing.T) {
 
 	p := &Provider{client: nil}
 
-	model, err := p.NewModel("claude-sonnet-4-6",
+	model, err := p.NewModel(ModelClaudeSonnet46,
 		WithTemperature(0.7),
 		WithTopP(0.9),
 		WithMaxTokens(1000),
@@ -305,7 +273,7 @@ func TestNewModel_InvalidTemperature(t *testing.T) {
 
 	p := &Provider{client: nil}
 
-	_, err := p.NewModel("claude-sonnet-4-6", WithTemperature(2.0))
+	_, err := p.NewModel(ModelClaudeSonnet46, WithTemperature(2.0))
 	require.Error(t, err)
 }
 
@@ -314,7 +282,7 @@ func TestNewModel_MaxTokensExceedsLimit(t *testing.T) {
 
 	p := &Provider{client: nil}
 
-	_, err := p.NewModel("claude-sonnet-4-6", WithMaxTokens(999999))
+	_, err := p.NewModel(ModelClaudeSonnet46, WithMaxTokens(999999))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "exceeds limit")
 }
@@ -324,7 +292,7 @@ func TestNewModel_Capabilities(t *testing.T) {
 
 	p := &Provider{client: nil}
 
-	model, err := p.NewModel("claude-opus-4-6")
+	model, err := p.NewModel(ModelClaudeOpus46)
 	require.NoError(t, err)
 
 	caps := model.Capabilities()
@@ -709,7 +677,7 @@ func TestRequestMapper_StreamInput(t *testing.T) {
 func TestResponseMapper_TextResponse(t *testing.T) {
 	t.Parallel()
 
-	mapper := NewResponseMapper(supportedModels[familyClaudeSonnet46])
+	mapper := NewResponseMapper(supportedModels[ModelClaudeSonnet46])
 
 	output := &types.ConverseOutputMemberMessage{
 		Value: types.Message{
@@ -739,7 +707,7 @@ func TestResponseMapper_TextResponse(t *testing.T) {
 func TestResponseMapper_ToolUseResponse(t *testing.T) {
 	t.Parallel()
 
-	mapper := NewResponseMapper(supportedModels[familyClaudeSonnet46])
+	mapper := NewResponseMapper(supportedModels[ModelClaudeSonnet46])
 
 	output := &types.ConverseOutputMemberMessage{
 		Value: types.Message{
@@ -776,7 +744,7 @@ func TestResponseMapper_ToolUseResponse(t *testing.T) {
 func TestResponseMapper_StopReasons(t *testing.T) {
 	t.Parallel()
 
-	mapper := NewResponseMapper(supportedModels[familyClaudeSonnet46])
+	mapper := NewResponseMapper(supportedModels[ModelClaudeSonnet46])
 
 	tests := []struct {
 		name     string
@@ -802,7 +770,7 @@ func TestResponseMapper_StopReasons(t *testing.T) {
 func TestResponseMapper_NilOutput(t *testing.T) {
 	t.Parallel()
 
-	mapper := NewResponseMapper(supportedModels[familyClaudeSonnet46])
+	mapper := NewResponseMapper(supportedModels[ModelClaudeSonnet46])
 
 	_, err := mapper.FromConverseOutput(types.StopReasonEndTurn, nil, nil)
 	require.Error(t, err)
@@ -812,7 +780,7 @@ func TestResponseMapper_NilOutput(t *testing.T) {
 func TestResponseMapper_CachedTokens(t *testing.T) {
 	t.Parallel()
 
-	mapper := NewResponseMapper(supportedModels[familyClaudeSonnet46])
+	mapper := NewResponseMapper(supportedModels[ModelClaudeSonnet46])
 
 	output := &types.ConverseOutputMemberMessage{
 		Value: types.Message{
@@ -864,7 +832,7 @@ func TestWithStop_TooMany(t *testing.T) {
 
 	p := &Provider{client: nil}
 
-	_, err := p.NewModel("claude-sonnet-4-6", WithStop("a", "b", "c", "d", "e"))
+	_, err := p.NewModel(ModelClaudeSonnet46, WithStop("a", "b", "c", "d", "e"))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "maximum 4 stop sequences")
 }
@@ -874,7 +842,7 @@ func TestWithStop_Empty(t *testing.T) {
 
 	p := &Provider{client: nil}
 
-	_, err := p.NewModel("claude-sonnet-4-6", WithStop("a", ""))
+	_, err := p.NewModel(ModelClaudeSonnet46, WithStop("a", ""))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "cannot be empty")
 }
@@ -884,7 +852,7 @@ func TestWithTopP_OutOfRange(t *testing.T) {
 
 	p := &Provider{client: nil}
 
-	_, err := p.NewModel("claude-sonnet-4-6", WithTopP(1.5))
+	_, err := p.NewModel(ModelClaudeSonnet46, WithTopP(1.5))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "top_p must be 0.0-1.0")
 }
@@ -894,7 +862,7 @@ func TestWithMaxTokens_Negative(t *testing.T) {
 
 	p := &Provider{client: nil}
 
-	_, err := p.NewModel("claude-sonnet-4-6", WithMaxTokens(-1))
+	_, err := p.NewModel(ModelClaudeSonnet46, WithMaxTokens(-1))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "must be positive")
 }

--- a/providers/bedrock/provider_test.go
+++ b/providers/bedrock/provider_test.go
@@ -247,6 +247,7 @@ func TestNewModel_SupportedModels(t *testing.T) {
 		modelName string
 	}{
 		{"direct family", "claude-sonnet-4-6"},
+		{"bare model ID", "anthropic.claude-sonnet-4-6"},
 		{"eu cross-region", "eu.anthropic.claude-sonnet-4-6"},
 		{"global versioned", "global.anthropic.claude-opus-4-6-v1"},
 		{"versioned with suffix", "eu.anthropic.claude-haiku-4-5-20251001-v1:0"},

--- a/providers/bedrock/provider_test.go
+++ b/providers/bedrock/provider_test.go
@@ -351,7 +351,7 @@ func TestRequestMapper_InferenceConfig(t *testing.T) {
 	maxTokens := int32(2048)
 
 	cfg := &Config{
-		ModelName:   "claude-sonnet-4-6",
+		ModelName:   ModelClaudeSonnet46,
 		Temperature: &temp,
 		TopP:        &topP,
 		MaxTokens:   &maxTokens,
@@ -382,7 +382,7 @@ func TestRequestMapper_NoInferenceConfig(t *testing.T) {
 	t.Parallel()
 
 	cfg := &Config{
-		ModelName:  "claude-sonnet-4-6",
+		ModelName:  ModelClaudeSonnet46,
 		setOptions: make(map[string]bool),
 	}
 
@@ -401,7 +401,7 @@ func TestRequestMapper_ToolDefinitions(t *testing.T) {
 	t.Parallel()
 
 	cfg := &Config{
-		ModelName:  "claude-sonnet-4-6",
+		ModelName:  ModelClaudeSonnet46,
 		setOptions: make(map[string]bool),
 	}
 
@@ -443,7 +443,7 @@ func TestRequestMapper_ToolChoiceSpecific(t *testing.T) {
 	t.Parallel()
 
 	cfg := &Config{
-		ModelName:  "claude-sonnet-4-6",
+		ModelName:  ModelClaudeSonnet46,
 		setOptions: make(map[string]bool),
 	}
 
@@ -476,7 +476,7 @@ func TestRequestMapper_ToolResponse(t *testing.T) {
 	t.Parallel()
 
 	cfg := &Config{
-		ModelName:  "claude-sonnet-4-6",
+		ModelName:  ModelClaudeSonnet46,
 		setOptions: make(map[string]bool),
 	}
 
@@ -510,7 +510,7 @@ func TestRequestMapper_ToolResponseError(t *testing.T) {
 	t.Parallel()
 
 	cfg := &Config{
-		ModelName:  "claude-sonnet-4-6",
+		ModelName:  ModelClaudeSonnet46,
 		setOptions: make(map[string]bool),
 	}
 
@@ -540,7 +540,7 @@ func TestRequestMapper_AssistantWithToolUse(t *testing.T) {
 	t.Parallel()
 
 	cfg := &Config{
-		ModelName:  "claude-sonnet-4-6",
+		ModelName:  ModelClaudeSonnet46,
 		setOptions: make(map[string]bool),
 	}
 
@@ -582,7 +582,7 @@ func TestRequestMapper_CachingEnabled(t *testing.T) {
 	t.Parallel()
 
 	cfg := &Config{
-		ModelName:     "claude-sonnet-4-6",
+		ModelName:     ModelClaudeSonnet46,
 		EnableCaching: true,
 		setOptions:    make(map[string]bool),
 	}
@@ -621,7 +621,7 @@ func TestRequestMapper_CachingDisabled(t *testing.T) {
 	t.Parallel()
 
 	cfg := &Config{
-		ModelName:     "claude-sonnet-4-6",
+		ModelName:     ModelClaudeSonnet46,
 		EnableCaching: false,
 		setOptions:    make(map[string]bool),
 	}
@@ -649,7 +649,7 @@ func TestRequestMapper_StreamInput(t *testing.T) {
 
 	temp := 0.5
 	cfg := &Config{
-		ModelName:   "claude-sonnet-4-6",
+		ModelName:   ModelClaudeSonnet46,
 		APIModelID:  "anthropic.claude-sonnet-4-6",
 		Temperature: &temp,
 		setOptions:  make(map[string]bool),

--- a/providers/bedrock/provider_test.go
+++ b/providers/bedrock/provider_test.go
@@ -709,7 +709,7 @@ func TestRequestMapper_StreamInput(t *testing.T) {
 func TestResponseMapper_TextResponse(t *testing.T) {
 	t.Parallel()
 
-	mapper := NewResponseMapper(supportedModels[ModelClaudeSonnet46])
+	mapper := NewResponseMapper(supportedModels[familyClaudeSonnet46])
 
 	output := &types.ConverseOutputMemberMessage{
 		Value: types.Message{
@@ -739,7 +739,7 @@ func TestResponseMapper_TextResponse(t *testing.T) {
 func TestResponseMapper_ToolUseResponse(t *testing.T) {
 	t.Parallel()
 
-	mapper := NewResponseMapper(supportedModels[ModelClaudeSonnet46])
+	mapper := NewResponseMapper(supportedModels[familyClaudeSonnet46])
 
 	output := &types.ConverseOutputMemberMessage{
 		Value: types.Message{
@@ -776,7 +776,7 @@ func TestResponseMapper_ToolUseResponse(t *testing.T) {
 func TestResponseMapper_StopReasons(t *testing.T) {
 	t.Parallel()
 
-	mapper := NewResponseMapper(supportedModels[ModelClaudeSonnet46])
+	mapper := NewResponseMapper(supportedModels[familyClaudeSonnet46])
 
 	tests := []struct {
 		name     string
@@ -802,7 +802,7 @@ func TestResponseMapper_StopReasons(t *testing.T) {
 func TestResponseMapper_NilOutput(t *testing.T) {
 	t.Parallel()
 
-	mapper := NewResponseMapper(supportedModels[ModelClaudeSonnet46])
+	mapper := NewResponseMapper(supportedModels[familyClaudeSonnet46])
 
 	_, err := mapper.FromConverseOutput(types.StopReasonEndTurn, nil, nil)
 	require.Error(t, err)
@@ -812,7 +812,7 @@ func TestResponseMapper_NilOutput(t *testing.T) {
 func TestResponseMapper_CachedTokens(t *testing.T) {
 	t.Parallel()
 
-	mapper := NewResponseMapper(supportedModels[ModelClaudeSonnet46])
+	mapper := NewResponseMapper(supportedModels[familyClaudeSonnet46])
 
 	output := &types.ConverseOutputMemberMessage{
 		Value: types.Message{


### PR DESCRIPTION
## Summary
- Removed `DefaultModelID` field from bedrock `ModelDefinition` struct
- `Name` now holds the real Bedrock model ID (e.g. `anthropic.claude-sonnet-4-6`) instead of the short family name
- Updated `NewModel` to use `modelDef.Name` for inference profile construction
- Family constants (`ModelClaudeSonnet46` etc.) remain as map keys for family resolution

## Test plan
- [x] `go build ./providers/bedrock/...` compiles cleanly
- [x] All bedrock unit tests pass (`TestNewModel_SupportedModels`, `TestModelsDiscovery`, etc.)
- [x] Verified ai-agent does not use Bedrock yet — no breakage

🤖 Generated with [Claude Code](https://claude.com/claude-code)