### PR TITLE
feat(openai): add model family resolution for timestamped snapshot IDs

### DIFF
--- a/providers/openai/models.go
+++ b/providers/openai/models.go
@@ -42,14 +42,17 @@ type ModelDefinition struct {
 //	"gpt-4o"            -> "gpt-4o" (unchanged, exact match)
 func resolveModelFamily(model string) string {
 	best := ""
+
 	for family := range supportedModels {
 		if strings.HasPrefix(model, family) && len(family) > len(best) {
 			best = family
 		}
 	}
+
 	if best != "" {
 		return best
 	}
+
 	return model
 }
 

--- a/providers/openai/models.go
+++ b/providers/openai/models.go
@@ -14,7 +14,11 @@
 
 package openai
 
-import "github.com/redpanda-data/ai-sdk-go/llm"
+import (
+	"strings"
+
+	"github.com/redpanda-data/ai-sdk-go/llm"
+)
 
 // ModelDefinition defines an OpenAI model with its capabilities and constraints.
 type ModelDefinition struct {
@@ -23,6 +27,30 @@ type ModelDefinition struct {
 	Capabilities              llm.ModelCapabilities
 	Constraints               llm.ModelConstraints
 	SupportedReasoningEfforts []ReasoningEffort // Ascending order: safest/lowest first
+}
+
+// resolveModelFamily returns the model family key for a given model string.
+// If the model string has a known family as a prefix, that family is returned
+// (longest match wins). Otherwise the original string is returned unchanged.
+//
+// Unlike Anthropic and Bedrock, the OpenAI SDK has no built-in alias
+// resolution, so timestamped snapshot IDs like "o3-2025-04-16" are not
+// recognized. This function bridges that gap:
+//
+//	"o3-2025-04-16"  -> "o3"
+//	"gpt-4o-2024-11-20" -> "gpt-4o"
+//	"gpt-4o"            -> "gpt-4o" (unchanged, exact match)
+func resolveModelFamily(model string) string {
+	best := ""
+	for family := range supportedModels {
+		if strings.HasPrefix(model, family) && len(family) > len(best) {
+			best = family
+		}
+	}
+	if best != "" {
+		return best
+	}
+	return model
 }
 
 // supportedModels defines all current OpenAI models with their constraints.

--- a/providers/openai/openai_test.go
+++ b/providers/openai/openai_test.go
@@ -179,6 +179,73 @@ func TestModelCreation(t *testing.T) {
 	assert.Contains(t, err.Error(), "cannot use")
 }
 
+func TestResolveModelFamily(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "exact match returns unchanged",
+			input:    "o3",
+			expected: "o3",
+		},
+		{
+			name:     "timestamped o3 resolves to family",
+			input:    "o3-2025-04-16",
+			expected: "o3",
+		},
+		{
+			name:     "timestamped gpt-4o resolves to family",
+			input:    "gpt-4o-2024-11-20",
+			expected: "gpt-4o",
+		},
+		{
+			name:     "gpt-4o-mini not confused with gpt-4o",
+			input:    "gpt-4o-mini",
+			expected: "gpt-4o-mini",
+		},
+		{
+			name:     "timestamped gpt-4o-mini resolves to gpt-4o-mini not gpt-4o",
+			input:    "gpt-4o-mini-2024-07-18",
+			expected: "gpt-4o-mini",
+		},
+		{
+			name:     "unknown model returns unchanged",
+			input:    "unknown-model-2025-01-01",
+			expected: "unknown-model-2025-01-01",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expected, resolveModelFamily(tt.input))
+		})
+	}
+}
+
+func TestNewModelWithTimestampedName(t *testing.T) {
+	t.Parallel()
+
+	provider, err := NewProvider("sk-test-key")
+	require.NoError(t, err)
+
+	// Timestamped model should resolve and use the original name for API calls.
+	model, err := provider.NewModel("o3-2025-04-16")
+	require.NoError(t, err)
+	assert.Equal(t, "o3-2025-04-16", model.Name(), "original timestamped name preserved")
+	assert.True(t, model.Capabilities().Reasoning, "inherits o3 capabilities")
+
+	// Timestamped gpt-4o-mini resolves correctly (not to gpt-4o).
+	model, err = provider.NewModel("gpt-4o-mini-2024-07-18")
+	require.NoError(t, err)
+	assert.Equal(t, "gpt-4o-mini-2024-07-18", model.Name())
+	assert.False(t, model.Capabilities().Audio, "gpt-4o-mini has no audio")
+}
+
 func TestModelConstraints(t *testing.T) {
 	t.Parallel()
 

--- a/providers/openai/provider.go
+++ b/providers/openai/provider.go
@@ -149,6 +149,7 @@ func WithTimeout(timeout time.Duration) ProviderOption {
 // for capability/constraint lookup.
 func (p *Provider) NewModel(modelName string, opts ...Option) (llm.Model, error) {
 	family := resolveModelFamily(modelName)
+
 	modelDef, ok := supportedModels[family]
 	if !ok {
 		return nil, fmt.Errorf("unsupported OpenAI model: %s", modelName)

--- a/providers/openai/provider.go
+++ b/providers/openai/provider.go
@@ -144,8 +144,12 @@ func WithTimeout(timeout time.Duration) ProviderOption {
 }
 
 // NewModel creates a new OpenAI model instance with the specified configuration.
+// It accepts both family names (e.g. "o3") and timestamped snapshot IDs
+// (e.g. "o3-2025-04-16"), resolving the latter to the corresponding family
+// for capability/constraint lookup.
 func (p *Provider) NewModel(modelName string, opts ...Option) (llm.Model, error) {
-	modelDef, ok := supportedModels[modelName]
+	family := resolveModelFamily(modelName)
+	modelDef, ok := supportedModels[family]
 	if !ok {
 		return nil, fmt.Errorf("unsupported OpenAI model: %s", modelName)
 	}


### PR DESCRIPTION
## Summary
- Add `resolveModelFamily()` to the OpenAI provider, matching the pattern already used by Anthropic (`resolveModelFamily`) and Bedrock (`lookupModel`)
- Uses longest-prefix matching to correctly disambiguate models like `gpt-4o` vs `gpt-4o-mini` when resolving timestamped variants (e.g. `gpt-4o-mini-2024-07-18` → `gpt-4o-mini`, not `gpt-4o`)
- The original timestamped name is preserved in `Config.ModelName` for API calls; only capability/constraint lookup uses the resolved family

## Context
OpenAI returns dated snapshot IDs (e.g. `o3-2025-04-16`) in responses, and users may also pass them directly to `NewModel()`. Without alias resolution, these were rejected as unsupported. The Anthropic and Bedrock providers already handle this — this PR closes the gap for OpenAI.

## Test plan
- [x] `TestResolveModelFamily` — 6 cases: exact match, timestamped resolution, longest-prefix disambiguation, unknown models
- [x] `TestNewModelWithTimestampedName` — end-to-end through `NewModel()` verifying name preservation and capability inheritance
- [x] Full conformance + integration suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)