### PR TITLE
fix: reduce webfetch integration test flakiness

### DIFF
--- a/tool/registry_integration_test.go
+++ b/tool/registry_integration_test.go
@@ -475,6 +475,12 @@ func TestRegistry_WebfetchToolWithLLM_Integration(t *testing.T) {
 					llm.NewToolResponsePart(toolResponse),
 				},
 			},
+			{
+				Role: llm.RoleUser,
+				Content: []*llm.Part{
+					llm.NewTextPart("Summarize the data returned by the webfetch tool above."),
+				},
+			},
 		},
 		Tools: toolDefinitions,
 		ToolChoice: &llm.ToolChoice{


### PR DESCRIPTION
## Summary
- `TestRegistry_WebfetchToolWithLLM_Integration` was flaky because the LLM sometimes responded with "I can't fetch that URL" instead of summarizing the tool results it already received
- Added an explicit follow-up user message after the tool response asking the model to summarize the returned data, making the intent unambiguous

## Test plan
- [ ] CI passes on this branch (the fix targets the flaky test itself)
- [ ] Re-run the [failed workflow](https://github.com/redpanda-data/ai-sdk-go/actions/runs/24445674797) to confirm stability

🤖 Generated with [Claude Code](https://claude.com/claude-code)