### PR TITLE
feat: add Claude Opus 4.7 to anthropic and bedrock providers

### DIFF
--- a/providers/anthropic/alias_test.go
+++ b/providers/anthropic/alias_test.go
@@ -60,6 +60,16 @@ func TestModelResolution(t *testing.T) {
 			expectedModel: "claude-opus-4-6",
 		},
 		{
+			name:          "claude-opus-4-7 family name resolves",
+			modelKey:      "claude-opus-4-7",
+			expectedModel: "claude-opus-4-7",
+		},
+		{
+			name:          "claude-opus-4-7 timestamped preserves original",
+			modelKey:      "claude-opus-4-7-20260416",
+			expectedModel: "claude-opus-4-7-20260416",
+		},
+		{
 			name:          "claude-opus-4-5 family name resolves",
 			modelKey:      "claude-opus-4-5",
 			expectedModel: "claude-opus-4-5",

--- a/providers/anthropic/anthropic_conformance_test.go
+++ b/providers/anthropic/anthropic_conformance_test.go
@@ -73,7 +73,7 @@ func (f *AnthropicFixture) NewReasoningModel(t *testing.T) llm.Model {
 
 	model, err := f.provider.NewModel(anthropictest.TestReasoningModelName,
 		anthropic.WithThinking(true),
-		anthropic.WithMaxTokens(8192),
+		anthropic.WithMaxTokens(16384),
 	)
 	if err != nil {
 		t.Skipf("No reasoning model available: %v", err)

--- a/providers/anthropic/anthropictest/constants.go
+++ b/providers/anthropic/anthropictest/constants.go
@@ -18,7 +18,9 @@ const (
 	// TestModelName is the model to use for integration tests.
 	TestModelName = "claude-sonnet-4-5"
 	// TestReasoningModelName is the model for reasoning tests.
-	TestReasoningModelName = "claude-opus-4-1"
+	// Uses a model with forced (non-adaptive) extended thinking so the
+	// conformance reasoning test can reliably assert thinking traces.
+	TestReasoningModelName = "claude-opus-4-5"
 	// TestAdaptiveModelName is the model for adaptive thinking tests.
 	TestAdaptiveModelName = "claude-sonnet-4-6"
 )

--- a/providers/anthropic/models.go
+++ b/providers/anthropic/models.go
@@ -27,6 +27,7 @@ const (
 	ModelClaudeSonnet46 = "claude-sonnet-4-6"
 	ModelClaudeSonnet45 = "claude-sonnet-4-5"
 	ModelClaudeHaiku45  = "claude-haiku-4-5"
+	ModelClaudeOpus47   = "claude-opus-4-7"
 	ModelClaudeOpus46   = "claude-opus-4-6"
 	ModelClaudeOpus45   = "claude-opus-4-5"
 	ModelClaudeOpus41   = "claude-opus-4-1"
@@ -39,6 +40,7 @@ const (
 	EffortLow    Effort = "low"
 	EffortMedium Effort = "medium"
 	EffortHigh   Effort = "high"
+	EffortXHigh  Effort = "xhigh"
 	EffortMax    Effort = "max"
 )
 
@@ -80,6 +82,32 @@ func resolveModelFamily(model string) string {
 // supportedModels defines all Claude models with their capabilities and constraints.
 // Based on Anthropic API documentation and model specifications.
 var supportedModels = map[string]ModelDefinition{
+	ModelClaudeOpus47: {
+		Name:  ModelClaudeOpus47,
+		Label: "Claude Opus 4.7",
+		Capabilities: llm.ModelCapabilities{
+			Streaming:        true,
+			Tools:            true,
+			JSONMode:         false, // Anthropic doesn't have native JSON mode
+			StructuredOutput: false, // Use tool calling for structured output instead
+			Vision:           true,
+			MultiTurn:        true,
+			SystemPrompts:    true,
+			Reasoning:        true, // Adaptive thinking only; use effort to bias toward more/less thinking
+		},
+		Constraints: llm.ModelConstraints{
+			TemperatureRange: [2]float64{0.0, 1.0},
+			MaxInputTokens:   1000000, // 1M context window
+			MaxOutputTokens:  128000,  // 128K output tokens
+			// Opus 4.7 rejects thinking.type.enabled — thinking budget is not user-controllable.
+			// Use adaptive thinking + effort to bias reasoning depth.
+			SupportedParams:   []string{"temperature", "top_p", "top_k", "max_tokens", "effort", "speed"},
+			MutuallyExclusive: [][]string{},
+		},
+		SupportedEfforts: []Effort{EffortLow, EffortMedium, EffortHigh, EffortXHigh, EffortMax},
+		SupportedSpeeds:  []Speed{SpeedStandard, SpeedFast},
+		AdaptiveThinking: true,
+	},
 	ModelClaudeSonnet46: {
 		Name:  ModelClaudeSonnet46,
 		Label: "Claude Sonnet 4.6",

--- a/providers/bedrock/bedrocktest/constants.go
+++ b/providers/bedrock/bedrocktest/constants.go
@@ -18,6 +18,9 @@ const (
 	// TestModelName is the model to use for integration tests.
 	TestModelName = "anthropic.claude-sonnet-4-5-20250929-v1:0"
 	// TestReasoningModelName is the model for reasoning tests.
+	// Uses a model with forced (non-adaptive) extended thinking. Opus 4.7
+	// supports adaptive thinking only, which Bedrock's WithThinking helper
+	// cannot yet request.
 	TestReasoningModelName = "anthropic.claude-opus-4-5-20251101-v1:0"
 	// TestRegion is the default AWS region for tests, overridable via AWS_REGION.
 	TestRegion = "us-east-1"

--- a/providers/bedrock/models.go
+++ b/providers/bedrock/models.go
@@ -26,6 +26,7 @@ const (
 	ModelClaudeSonnet46 = "anthropic.claude-sonnet-4-6"
 	ModelClaudeSonnet45 = "anthropic.claude-sonnet-4-5-20250929-v1:0"
 	ModelClaudeHaiku45  = "anthropic.claude-haiku-4-5-20251001-v1:0"
+	ModelClaudeOpus47   = "anthropic.claude-opus-4-7"
 	ModelClaudeOpus46   = "anthropic.claude-opus-4-6-v1"
 	ModelClaudeOpus45   = "anthropic.claude-opus-4-5-20251101-v1:0"
 )
@@ -83,6 +84,24 @@ func lookupModel(modelName string) (ModelDefinition, bool) {
 // supportedModels defines Claude models available on Bedrock via the Converse API.
 // Standard features only — no Anthropic-specific thinking/effort/speed.
 var supportedModels = map[string]ModelDefinition{
+	ModelClaudeOpus47: {
+		Name:  ModelClaudeOpus47,
+		Label: "Claude Opus 4.7",
+		Capabilities: llm.ModelCapabilities{
+			Streaming:     true,
+			Tools:         true,
+			Vision:        false,
+			MultiTurn:     true,
+			SystemPrompts: true,
+			Reasoning:     true,
+		},
+		Constraints: llm.ModelConstraints{
+			TemperatureRange: [2]float64{0.0, 1.0},
+			MaxInputTokens:   1000000,
+			MaxOutputTokens:  128000,
+			SupportedParams:  []string{"temperature", "top_p", "max_tokens", "stop"},
+		},
+	},
 	ModelClaudeSonnet46: {
 		Name:  ModelClaudeSonnet46,
 		Label: "Claude Sonnet 4.6",

--- a/terraform/ai-sdk-ci/README.md
+++ b/terraform/ai-sdk-ci/README.md
@@ -82,6 +82,7 @@ Repeat for each model needed. The following models are currently enabled:
 - `anthropic.claude-haiku-4-5-20251001-v1:0`
 - `anthropic.claude-opus-4-5-20251101-v1:0`
 - `anthropic.claude-opus-4-6-v1`
+- `anthropic.claude-opus-4-7`
 
 ### 4. Update the GitHub Actions workflow
 


### PR DESCRIPTION
## What

Register Claude Opus 4.7 on the `anthropic` provider (`claude-opus-4-7`) and `bedrock` provider (`anthropic.claude-opus-4-7`). Add a new `EffortXHigh` tier that Opus 4.7 exposes between `high` and `max`. Bump the anthropic reasoning conformance target from Opus 4.1 to Opus 4.5.

## Why

Opus 4.7 is the current flagship. Downstream consumers of this SDK need to select it without resorting to `WithCustomModelName`, and want to see its capability constraints and effort levels validated at `NewModel` time.

## Implementation details

**Opus 4.7 is adaptive-thinking only.** The Anthropic API explicitly rejects `thinking.type.enabled` on this model:

> `thinking.type.enabled` is not supported for this model. Use `thinking.type.adaptive` and `output_config.effort` to control thinking behavior.

Consequences encoded in the model definition:

- `thinking_budget` is **not** in `SupportedParams`, so `WithThinkingBudget(...)` is rejected at option-validation time rather than failing with a 400 at request time.
- `AdaptiveThinking: true` is set. `WithThinking(true)` routes to the `OfAdaptive` request branch. Reasoning depth is controlled via `WithEffort`.
- `SupportedEfforts` is `low, medium, high, xhigh, max`. `EffortXHigh` is a new Effort constant - Opus 4.7 is the first model that exposes this tier.

**Bedrock model ID** was verified against the live `ListFoundationModels` API. The correct ID is `anthropic.claude-opus-4-7` (bare, same shape as `anthropic.claude-sonnet-4-6`), not `anthropic.claude-opus-4-7-v1` as a first pass assumed.

**Context and output shape** match Opus 4.6: 1M input context, 128K output. The AWS announcement did not publish numbers and the Anthropic announcement did not give a context window size; using Opus 4.6's numbers is the defensible default until Anthropic documents otherwise.

**Test coverage of the new endpoint in CI:**

- `providers/anthropic/alias_test.go` - verifies family-name + timestamped-snapshot resolution for `claude-opus-4-7`.
- `providers/anthropic/anthropictest/constants.go` - `TestReasoningModelName` moved from `claude-opus-4-1` to `claude-opus-4-5`. This is strictly newer and still supports forced thinking, which the reasoning conformance test requires. Opus 4.7 cannot be the reasoning test target: the test asserts deterministic reasoning traces, and adaptive thinking does not emit traces on every call even at `effort=max`.
- `providers/bedrock/bedrocktest/constants.go` - stays on Opus 4.5 for the same reason. `providers/bedrock`'s `WithThinking` helper builds `thinking.type=enabled` via `additionalModelRequestFields`, which Opus 4.7 also rejects. Follow-up work will add adaptive + effort support on Bedrock and switch the reasoning target then.
- `terraform/ai-sdk-ci/README.md` - lists the new Bedrock model ID for the model-access allowlist.

**What is not in this PR, and why:**

- Bedrock adaptive-thinking support. Adding it means extending `bedrock.WithThinking` or adding a new option that emits `additionalModelRequestFields: {thinking: {type: adaptive}, output_config: {effort: ...}}`, plus a mapper path for adaptive traces. Out of scope for a model-add PR.
- Rewriting the reasoning conformance test to tolerate adaptive-thinking models. Same reason.

## References

- https://www.anthropic.com/news/claude-opus-4-7
- https://aws.amazon.com/about-aws/whats-new/2026/04/claude-opus-4.7-amazon-bedrock/