### PR TITLE
feat(llm): redesign TokenUsage as disjoint-bucket cross-provider shape

### DIFF
--- a/adapter/a2a/executor.go
+++ b/adapter/a2a/executor.go
@@ -192,12 +192,15 @@ func (e *Executor) processEvents(
 			if ev.Response.Usage != nil {
 				a2amsg.Metadata = map[string]any{
 					"usage": map[string]any{
-						"input_tokens":     ev.Response.Usage.InputTokens,
-						"output_tokens":    ev.Response.Usage.OutputTokens,
-						"total_tokens":     ev.Response.Usage.TotalTokens,
-						"cached_tokens":    ev.Response.Usage.CachedTokens,
-						"reasoning_tokens": ev.Response.Usage.ReasoningTokens,
-						"max_input_tokens": ev.Response.Usage.MaxInputTokens,
+						"input_tokens":          ev.Response.Usage.InputTokens,
+						"output_tokens":         ev.Response.Usage.OutputTokens,
+						"total_billed_tokens":   ev.Response.Usage.TotalBilledTokens(),
+						"cached_input_tokens":   ev.Response.Usage.CachedInputTokens,
+						"cache_creation_5m":     ev.Response.Usage.CacheCreation5mTokens,
+						"cache_creation_1h":     ev.Response.Usage.CacheCreation1hTokens,
+						"tool_use_input_tokens": ev.Response.Usage.ToolUseInputTokens,
+						"reasoning_tokens":      ev.Response.Usage.ReasoningTokens,
+						"max_input_tokens":      ev.Response.Usage.MaxInputTokens,
 					},
 				}
 			}
@@ -276,12 +279,15 @@ func (e *Executor) processEvents(
 
 			if ev.Usage != nil {
 				metadata["usage"] = map[string]any{
-					"input_tokens":     ev.Usage.InputTokens,
-					"output_tokens":    ev.Usage.OutputTokens,
-					"total_tokens":     ev.Usage.TotalTokens,
-					"cached_tokens":    ev.Usage.CachedTokens,
-					"reasoning_tokens": ev.Usage.ReasoningTokens,
-					"max_input_tokens": ev.Usage.MaxInputTokens,
+					"input_tokens":          ev.Usage.InputTokens,
+					"output_tokens":         ev.Usage.OutputTokens,
+					"total_billed_tokens":   ev.Usage.TotalBilledTokens(),
+					"cached_input_tokens":   ev.Usage.CachedInputTokens,
+					"cache_creation_5m":     ev.Usage.CacheCreation5mTokens,
+					"cache_creation_1h":     ev.Usage.CacheCreation1hTokens,
+					"tool_use_input_tokens": ev.Usage.ToolUseInputTokens,
+					"reasoning_tokens":      ev.Usage.ReasoningTokens,
+					"max_input_tokens":      ev.Usage.MaxInputTokens,
 				}
 			}
 

--- a/adapter/a2a/executor.go
+++ b/adapter/a2a/executor.go
@@ -200,7 +200,6 @@ func (e *Executor) processEvents(
 						"cache_creation_1h":     ev.Response.Usage.CacheCreation1hTokens,
 						"tool_use_input_tokens": ev.Response.Usage.ToolUseInputTokens,
 						"reasoning_tokens":      ev.Response.Usage.ReasoningTokens,
-						"max_input_tokens":      ev.Response.Usage.MaxInputTokens,
 					},
 				}
 			}
@@ -287,7 +286,6 @@ func (e *Executor) processEvents(
 					"cache_creation_1h":     ev.Usage.CacheCreation1hTokens,
 					"tool_use_input_tokens": ev.Usage.ToolUseInputTokens,
 					"reasoning_tokens":      ev.Usage.ReasoningTokens,
-					"max_input_tokens":      ev.Usage.MaxInputTokens,
 				}
 			}
 

--- a/adapter/a2a/executor_test.go
+++ b/adapter/a2a/executor_test.go
@@ -484,7 +484,6 @@ func TestExecutor_SessionPersistence_Mock(t *testing.T) {
 				Usage: &llm.TokenUsage{
 					InputTokens:  10,
 					OutputTokens: 15,
-					TotalTokens:  25,
 				},
 			}, nil
 		}
@@ -501,7 +500,6 @@ func TestExecutor_SessionPersistence_Mock(t *testing.T) {
 						Usage: &llm.TokenUsage{
 							InputTokens:  20,
 							OutputTokens: 8,
-							TotalTokens:  28,
 						},
 					}, nil
 				}
@@ -514,7 +512,6 @@ func TestExecutor_SessionPersistence_Mock(t *testing.T) {
 				Usage: &llm.TokenUsage{
 					InputTokens:  15,
 					OutputTokens: 10,
-					TotalTokens:  25,
 				},
 			}, nil
 		}
@@ -527,7 +524,6 @@ func TestExecutor_SessionPersistence_Mock(t *testing.T) {
 			Usage: &llm.TokenUsage{
 				InputTokens:  5,
 				OutputTokens: 5,
-				TotalTokens:  10,
 			},
 		}, nil
 	})

--- a/agent/conformance/suite.go
+++ b/agent/conformance/suite.go
@@ -116,7 +116,7 @@ func testBasicToolCalling(t *testing.T, fixture Fixture) {
 
 	// Verify usage tracking
 	require.NotNil(t, endEvent.Usage)
-	assert.Positive(t, endEvent.Usage.TotalTokens)
+	assert.Positive(t, endEvent.Usage.TotalBilledTokens())
 }
 
 // testMultiTurnToolExecution contains the shared implementation for TestMultiTurnToolExecution.

--- a/agent/llmagent/llmagent_integration_test.go
+++ b/agent/llmagent/llmagent_integration_test.go
@@ -176,7 +176,7 @@ func TestLLMAgent_Integration_ToolCalling(t *testing.T) {
 
 	// 5. Verify usage information is tracked
 	require.NotNil(t, endEvent.Usage, "should track token usage")
-	assert.Positive(t, endEvent.Usage.TotalTokens, "should have non-zero token usage")
+	assert.Positive(t, endEvent.Usage.TotalBilledTokens(), "should have non-zero token usage")
 
 	// 6. Verify turn count is reasonable
 	finalTurn := endEvent.GetEnvelope().Turn
@@ -185,5 +185,5 @@ func TestLLMAgent_Integration_ToolCalling(t *testing.T) {
 
 	t.Logf("Final response: %s", finalText)
 	t.Logf("Tool calls: %d, Tool results: %d", len(toolCallEvents), len(toolResultEvents))
-	t.Logf("Token usage: %d total tokens", endEvent.Usage.TotalTokens)
+	t.Logf("Token usage: %d total tokens", endEvent.Usage.TotalBilledTokens())
 }

--- a/agent/llmagent/llmagent_test.go
+++ b/agent/llmagent/llmagent_test.go
@@ -269,7 +269,7 @@ func TestRun_SimpleSingleTurn(t *testing.T) {
 
 			// Assert: Usage is tracked
 			require.NotNil(t, endEvent.Usage)
-			assert.Positive(t, endEvent.Usage.TotalTokens)
+			assert.Positive(t, endEvent.Usage.TotalBilledTokens())
 		})
 	}
 }
@@ -672,7 +672,7 @@ func TestRun_UsageTracking(t *testing.T) {
 		endEvent := findInvocationEndEvent(events)
 		require.NotNil(t, endEvent)
 		require.NotNil(t, endEvent.Usage)
-		assert.Positive(t, endEvent.Usage.TotalTokens)
+		assert.Positive(t, endEvent.Usage.TotalBilledTokens())
 	})
 
 	t.Run("multi turn", func(t *testing.T) {
@@ -720,7 +720,7 @@ func TestRun_UsageTracking(t *testing.T) {
 		endEvent := findInvocationEndEvent(events)
 		require.NotNil(t, endEvent)
 		require.NotNil(t, endEvent.Usage)
-		assert.Positive(t, endEvent.Usage.TotalTokens)
+		assert.Positive(t, endEvent.Usage.TotalBilledTokens())
 
 		// Should be more than single turn since we had 2 model calls
 		assert.Equal(t, 2, model.CallCount())

--- a/agent/metadata.go
+++ b/agent/metadata.go
@@ -288,14 +288,12 @@ func (m *InvocationMetadata) incrementTurn() {
 // token consumption for this invocation. It is not exported because
 // interceptors should not modify usage tracking.
 func (m *InvocationMetadata) addUsage(usage *llm.TokenUsage) {
-	m.totalUsage.InputTokens += usage.InputTokens
-	m.totalUsage.OutputTokens += usage.OutputTokens
-	m.totalUsage.ReasoningTokens += usage.ReasoningTokens
-	m.totalUsage.CachedTokens += usage.CachedTokens
-	m.totalUsage.TotalTokens += usage.TotalTokens
-	// MaxInputTokens is a model constraint, not cumulative - use the first non-zero value
-	if m.totalUsage.MaxInputTokens == 0 && usage.MaxInputTokens > 0 {
-		m.totalUsage.MaxInputTokens = usage.MaxInputTokens
+	if usage == nil {
+		return
+	}
+
+	if summed := llm.SumUsage(&m.totalUsage, usage); summed != nil {
+		m.totalUsage = *summed
 	}
 }
 

--- a/docs/rfcs/0001-token-usage.md
+++ b/docs/rfcs/0001-token-usage.md
@@ -6,7 +6,7 @@
 
 ## Summary
 
-Replace the current `llm.TokenUsage` with a shape that can losslessly carry what all four first-party providers (OpenAI, Anthropic, Google, AWS Bedrock) actually report, so that consumers — agents, gateways, billing/FinOps tools, dashboards — can price, audit, and sum usage without provider-specific workarounds.
+Replace the current `llm.TokenUsage` with a **normalized** shape that captures the billable and operationally interesting dimensions the four first-party providers (OpenAI, Anthropic, Google, AWS Bedrock) report, so that consumers — agents, gateways, billing/FinOps tools, dashboards — can price and aggregate usage without provider-specific workarounds. This is not a lossless mirror of every provider field; dimensions the SDK does not normalize (e.g., provider-specific trace details, forthcoming billing lines) live in an `Extra` map keyed by `<provider>.<field>`.
 
 ## Motivation
 
@@ -39,55 +39,69 @@ The current struct has three concrete problems:
 ### Core invariant
 
 **All token counters are disjoint.** A prompt token is counted in exactly one of:
-`InputTokens`, `CachedInputTokens`, `CacheCreation5mTokens`, `CacheCreation1hTokens`, `ToolUseInputTokens`.
+`InputTokens`, `CachedInputTokens`, `CacheCreation5mTokens`, `CacheCreation1hTokens`, `CacheCreationUnknownTTLTokens`, `ToolUseInputTokens`.
 
-Same rule on the output side: `OutputTokens`, `ReasoningTokens`, `RejectedPredictionTokens` (plus `AcceptedPredictionTokens` when OpenAI Predicted Outputs is in use — see field doc).
+Same rule on the output side: `OutputTokens`, `ReasoningTokens`, `RejectedPredictionTokens`.
+
+Note on OpenAI Predicted Outputs: `accepted_prediction_tokens` are by OpenAI's definition tokens that appeared *in* the completion, so they are already counted inside `OutputTokens` — they are not a separate disjoint bucket. Only `rejected_prediction_tokens` (billed but not returned to the caller) are surfaced as an additive field. Consumers who need the accepted-vs-rejected breakdown can read the raw provider response.
 
 This makes "billed tokens" a simple integer sum and removes the subset/additive ambiguity. It matches Anthropic's and Bedrock's native convention and requires mechanical remapping for OpenAI and Google.
+
+### What lives where
+
+`TokenUsage` contains **only** the additive token-accounting surface. Per-call metadata that describes *how* a request was processed — `ServiceTier`, `RawServiceTier`, `Speed`, `InferenceRegion`, `InvokedModelID`, `LatencyMs`, `FirstByteLatencyMs` — lives on `llm.Response`. These fields are not meaningfully additive across calls, so forcing them through `SumUsage` (first-non-empty-wins, max, etc.) is a type smell.
+
+`MaxInputTokens` is a model-config value, not usage. It has been removed from `TokenUsage`; the canonical source is `modelDefinition.Constraints.MaxInputTokens`.
+
+### TTL fallback for cache writes
+
+Anthropic and Bedrock both report a per-TTL breakdown for cache-write tokens. When the breakdown is absent or covers fewer tokens than the aggregate (older API response shapes, partial CacheDetails), extractors route the remainder to `CacheCreationUnknownTTLTokens`. That way `BilledInputTokens()` always reflects the provider-reported billable amount without pretending to know a TTL we weren't told.
 
 ### Field layout
 
 ```go
 type TokenUsage struct {
     // Input side (all disjoint).
-    InputTokens            int
-    CachedInputTokens      int
-    CacheCreation5mTokens  int
-    CacheCreation1hTokens  int
-    ToolUseInputTokens     int
+    InputTokens                   int
+    CachedInputTokens             int
+    CacheCreation5mTokens         int
+    CacheCreation1hTokens         int
+    CacheCreationUnknownTTLTokens int // fallback when per-TTL breakdown is absent
+    ToolUseInputTokens            int
 
     // Output side (all disjoint).
     OutputTokens             int
     ReasoningTokens          int
-    AcceptedPredictionTokens int
-    RejectedPredictionTokens int
+    RejectedPredictionTokens int // accepted predicted tokens are already inside OutputTokens
 
     // Per-modality breakdown (optional; keys sum to the top-level counter).
     ModalityInputTokens       map[Modality]int
     ModalityOutputTokens      map[Modality]int
     ModalityCachedInputTokens map[Modality]int
 
-    // Request posture / routing (informational, affects pricing).
-    ServiceTier     ServiceTier
-    RawServiceTier  string
-    Speed           string
-    InferenceRegion string
-    InvokedModelID  string
-
     // Non-token billable counters.
     ServerToolRequests map[ServerTool]int
     GuardrailUnits     map[string]int
 
-    // Performance (not billable but widely useful).
+    // Provider-specific dimensions we do not normalize.
+    // Keys MUST be namespaced as "<provider>.<field>" to avoid collisions.
+    Extra map[string]any
+}
+```
+
+Per-call metadata on `llm.Response`:
+
+```go
+type Response struct {
+    // ...existing fields...
+
+    ServiceTier        ServiceTier
+    RawServiceTier     string
+    Speed              string
+    InferenceRegion    string
+    InvokedModelID     string
     LatencyMs          int64
     FirstByteLatencyMs int64
-
-    // Model capability (config, not usage).
-    MaxInputTokens int
-
-    // Provider-specific dimensions we do not normalize.
-    // Keys must be namespaced as "<provider>.<field>" to avoid collisions.
-    Extra map[string]any
 }
 ```
 
@@ -104,18 +118,39 @@ func (u *TokenUsage) TotalBilledTokens() int
 - **`TotalTokens`**: providers disagree on its meaning (some include reasoning, some don't; some include cache writes, some don't). Callers use `TotalBilledTokens()`.
 - **`CachedTokens`** → renamed to `CachedInputTokens` with new disjoint semantics. The rename forces consumers to notice the semantic change at compile time rather than silently miscount.
 
+### PR 1 extractor coverage
+
+PR 1 wires the subset of the shape that can be populated from fields the existing extractors already read. This is deliberate — new shape and new extraction are split so the type change lands cleanly, then follow-ups focus on richer data.
+
+| Field | Populated in PR 1? |
+|---|---|
+| `InputTokens`, `OutputTokens`, `CachedInputTokens` | All providers |
+| `CacheCreation5mTokens`, `CacheCreation1hTokens` | Anthropic, Bedrock |
+| `CacheCreationUnknownTTLTokens` | Anthropic, Bedrock (fallback path) |
+| `ToolUseInputTokens` | Google |
+| `ReasoningTokens` | OpenAI, OpenAI-compat, Google |
+| `RejectedPredictionTokens` | — (PR 2) |
+| `ModalityInputTokens` / `ModalityOutputTokens` / `ModalityCachedInputTokens` | — (PR 2: Google, OpenAI audio) |
+| `ServerToolRequests` | — (PR 2: Anthropic web_search/web_fetch, Google grounding) |
+| `GuardrailUnits` | — (PR 2: Bedrock) |
+| `Extra` | Bedrock unknown-TTL audit keys |
+| `Response.ServiceTier` / `RawServiceTier` / `Speed` / `InferenceRegion` / `InvokedModelID` / `LatencyMs` / `FirstByteLatencyMs` | — (PR 2) |
+
+Consumers treating a zero field as "reported zero" today will need to verify against the provider's raw response until PR 2 lands, same as with the old `TokenUsage`.
+
 ### Per-provider mapping contract
 
 This is the contract every response mapper must satisfy. Full rationale per field is in the provider's `response_mapper.go`.
 
-**Anthropic / Bedrock-Anthropic (already disjoint — direct copy):**
+**Anthropic (already disjoint — direct copy with TTL fallback):**
 
 ```
-InputTokens            ← usage.input_tokens
-CachedInputTokens      ← usage.cache_read_input_tokens
-CacheCreation5mTokens  ← usage.cache_creation.ephemeral_5m_input_tokens
-CacheCreation1hTokens  ← usage.cache_creation.ephemeral_1h_input_tokens
-OutputTokens           ← usage.output_tokens
+InputTokens                   ← usage.input_tokens
+CachedInputTokens             ← usage.cache_read_input_tokens
+CacheCreation5mTokens         ← usage.cache_creation.ephemeral_5m_input_tokens
+CacheCreation1hTokens         ← usage.cache_creation.ephemeral_1h_input_tokens
+CacheCreationUnknownTTLTokens ← max(0, usage.cache_creation_input_tokens - (5m + 1h))
+OutputTokens                  ← usage.output_tokens
 ```
 
 **OpenAI (normalize subset → disjoint):**
@@ -137,15 +172,19 @@ OutputTokens      ← candidates_token_count  // already excludes thoughts
 ReasoningTokens   ← thoughts_token_count    // already additive
 ```
 
-**Bedrock Converse:**
+**Bedrock Converse (direct copy with TTL fallback):**
 
 ```
-InputTokens            ← input_tokens
-CachedInputTokens      ← cache_read_input_tokens
-CacheCreation5mTokens  ← cache_details[ttl="5m"].input_tokens
-CacheCreation1hTokens  ← cache_details[ttl="1h"].input_tokens
-OutputTokens           ← output_tokens
+InputTokens                    ← input_tokens
+CachedInputTokens              ← cache_read_input_tokens
+CacheCreation5mTokens          ← sum(cache_details[ttl="5m"].input_tokens)
+CacheCreation1hTokens          ← sum(cache_details[ttl="1h"].input_tokens)
+CacheCreationUnknownTTLTokens  ← sum(cache_details[ttl=other].input_tokens)
+                                 + max(0, cache_write_input_tokens - sum(cache_details))
+OutputTokens                   ← output_tokens
 ```
+
+Unknown TTL strings are also recorded in `Extra["bedrock.cache_write_ttl_<ttl>_tokens"]` for audit.
 
 ## Breaking change posture
 
@@ -159,5 +198,5 @@ This is a v0 breaking change. The SDK is pre-1.0; consumers who care about stabl
 
 ## Scope split
 
-- **PR 1 (this):** new shape + `SumUsage` + helpers + conformance contract + minimal extractor updates (rename + disjoint math for fields already extracted today). Everything compiles, all existing tests pass with updated assertions.
-- **PR 2 (follow-up):** richer extraction — populate `CacheCreation5m/1hTokens` separately (Anthropic / Bedrock), `Modality*Tokens` (Google, OpenAI audio), `GuardrailUnits` (Bedrock), `AcceptedPredictionTokens` / `RejectedPredictionTokens` (OpenAI), `ServiceTier` / `Speed` / `InferenceRegion`, `ServerToolRequests`.
+- **PR 1 (this):** new shape + `SumUsage` + helpers + extractor updates for fields already extracted today (input/output/cached for every provider; cache-creation 5m/1h + unknown-TTL fallback for Anthropic and Bedrock; thoughts + tool-use for Google). Response gains per-call metadata fields but they are not populated yet. Everything compiles, all unit tests pass.
+- **PR 2 (follow-up):** richer extraction — `Modality*Tokens` (Google, OpenAI audio), `GuardrailUnits` (Bedrock), `RejectedPredictionTokens` (OpenAI), and full population of `Response.ServiceTier` / `RawServiceTier` / `Speed` / `InferenceRegion` / `InvokedModelID` / `LatencyMs` / `FirstByteLatencyMs`. `ServerToolRequests` for Anthropic (web_search, web_fetch), Google (grounding).

--- a/docs/rfcs/0001-token-usage.md
+++ b/docs/rfcs/0001-token-usage.md
@@ -41,11 +41,13 @@ The current struct has three concrete problems:
 **All token counters are disjoint.** A prompt token is counted in exactly one of:
 `InputTokens`, `CachedInputTokens`, `CacheCreation5mTokens`, `CacheCreation1hTokens`, `CacheCreationUnknownTTLTokens`, `ToolUseInputTokens`.
 
-Same rule on the output side: `OutputTokens`, `ReasoningTokens`, `RejectedPredictionTokens`.
-
-Note on OpenAI Predicted Outputs: `accepted_prediction_tokens` are by OpenAI's definition tokens that appeared *in* the completion, so they are already counted inside `OutputTokens` — they are not a separate disjoint bucket. Only `rejected_prediction_tokens` (billed but not returned to the caller) are surfaced as an additive field. Consumers who need the accepted-vs-rejected breakdown can read the raw provider response.
+Same rule on the output side: `OutputTokens`, `ReasoningTokens`.
 
 This makes "billed tokens" a simple integer sum and removes the subset/additive ambiguity. It matches Anthropic's and Bedrock's native convention and requires mechanical remapping for OpenAI and Google.
+
+### Deliberately minimal
+
+The struct only carries counters that at least one extractor populates today. Per-modality breakdowns, server-tool request counts, guardrail-unit counts, and OpenAI predicted-output counts all exist at the provider level but aren't yet extracted — they can be added as additive first-class fields in follow-up work, or left to consumers via the raw provider response. The same principle applies to `Extra`: it exists only because Bedrock's fallback path already writes provider-specific audit keys into it.
 
 ### What lives where
 
@@ -74,20 +76,10 @@ type TokenUsage struct {
     ToolUseInputTokens            int
 
     // Output side (all disjoint).
-    OutputTokens             int
-    ReasoningTokens          int
-    RejectedPredictionTokens int // accepted predicted tokens are already inside OutputTokens
+    OutputTokens    int
+    ReasoningTokens int
 
-    // Per-modality breakdown (optional; keys sum to the top-level counter).
-    ModalityInputTokens       map[Modality]int
-    ModalityOutputTokens      map[Modality]int
-    ModalityCachedInputTokens map[Modality]int
-
-    // Non-token billable counters.
-    ServerToolRequests map[ServerTool]int
-    GuardrailUnits     map[string]int
-
-    // Provider-specific dimensions we do not normalize.
+    // Provider-specific audit keys the SDK does not normalize.
     // Keys MUST be namespaced as "<provider>.<field>" to avoid collisions.
     Extra map[string]any
 }
@@ -122,23 +114,15 @@ func (u *TokenUsage) TotalBilledTokens() int
 
 ### PR 1 extractor coverage
 
-PR 1 wires the subset of the shape that can be populated from fields the existing extractors already read. This is deliberate — new shape and new extraction are split so the type change lands cleanly, then follow-ups focus on richer data.
-
-| Field | Populated in PR 1? |
+| Field | Populated |
 |---|---|
 | `InputTokens`, `OutputTokens`, `CachedInputTokens` | All providers |
 | `CacheCreation5mTokens`, `CacheCreation1hTokens` | Anthropic, Bedrock |
 | `CacheCreationUnknownTTLTokens` | Anthropic, Bedrock (fallback path) |
 | `ToolUseInputTokens` | Google |
 | `ReasoningTokens` | OpenAI, OpenAI-compat, Google |
-| `RejectedPredictionTokens` | — (PR 2) |
-| `ModalityInputTokens` / `ModalityOutputTokens` / `ModalityCachedInputTokens` | — (PR 2: Google, OpenAI audio) |
-| `ServerToolRequests` | — (PR 2: Anthropic web_search/web_fetch, Google grounding) |
-| `GuardrailUnits` | — (PR 2: Bedrock) |
 | `Extra` | Bedrock unknown-TTL audit keys |
 | `Response.ServiceTier` / `RawServiceTier` / `Speed` / `InferenceRegion` / `InvokedModelID` | — (PR 2) |
-
-Consumers treating a zero field as "reported zero" today will need to verify against the provider's raw response until PR 2 lands, same as with the old `TokenUsage`.
 
 ### Per-provider mapping contract
 
@@ -201,4 +185,4 @@ This is a v0 breaking change. The SDK is pre-1.0; consumers who care about stabl
 ## Scope split
 
 - **PR 1 (this):** new shape + `SumUsage` + helpers + extractor updates for fields already extracted today (input/output/cached for every provider; cache-creation 5m/1h + unknown-TTL fallback for Anthropic and Bedrock; thoughts + tool-use for Google). Response gains per-call metadata fields but they are not populated yet. Everything compiles, all unit tests pass.
-- **PR 2 (follow-up):** richer extraction — `Modality*Tokens` (Google, OpenAI audio), `GuardrailUnits` (Bedrock), `RejectedPredictionTokens` (OpenAI), and full population of `Response.ServiceTier` / `RawServiceTier` / `Speed` / `InferenceRegion` / `InvokedModelID`. `ServerToolRequests` for Anthropic (web_search, web_fetch), Google (grounding).
+- **PR 2 (follow-up):** populate `Response.ServiceTier` / `RawServiceTier` / `Speed` / `InferenceRegion` / `InvokedModelID` from provider responses. Additional counters (per-modality breakdowns, guardrail units, server-tool requests, OpenAI predicted-output counts) remain candidates for future additive PRs but are intentionally out of scope here — the SDK normalizes what it actually extracts, not everything providers theoretically expose.

--- a/docs/rfcs/0001-token-usage.md
+++ b/docs/rfcs/0001-token-usage.md
@@ -1,0 +1,163 @@
+# RFC 0001: Normalized `llm.TokenUsage`
+
+**Status:** Accepted (PR 1 of 2)
+**Authors:** @mms
+**Date:** 2026-04-20
+
+## Summary
+
+Replace the current `llm.TokenUsage` with a shape that can losslessly carry what all four first-party providers (OpenAI, Anthropic, Google, AWS Bedrock) actually report, so that consumers — agents, gateways, billing/FinOps tools, dashboards — can price, audit, and sum usage without provider-specific workarounds.
+
+## Motivation
+
+The current struct has three concrete problems:
+
+1. **Inconsistent semantics across providers.** `CachedTokens` is documented as a *subset* of `InputTokens`. That matches OpenAI, but:
+   - Anthropic returns `input_tokens`, `cache_creation_input_tokens`, and `cache_read_input_tokens` as **disjoint** buckets.
+   - Google's `cached_content_token_count` is a *subset* of `prompt_token_count`.
+   - Bedrock Converse reports `CacheReadInputTokens` and `CacheWriteInputTokens` as **disjoint** from `InputTokens`.
+
+   The SDK's extractors silently fold these into the lossy subset model, losing the cache-write signal entirely (Anthropic / Bedrock) and making per-provider math diverge.
+
+2. **Missing dimensions.** Providers already bill on fields the SDK does not surface:
+   - Anthropic `cache_creation.ephemeral_5m_input_tokens` vs `ephemeral_1h_input_tokens` (two different write rates).
+   - Anthropic `service_tier` (standard / priority / batch), `speed` (standard / fast), `inference_geo`.
+   - Anthropic `server_tool_use.web_search_requests` / `web_fetch_requests` (billed per request).
+   - OpenAI `accepted_prediction_tokens` / `rejected_prediction_tokens` (rejected is billed as output but never returned to the caller).
+   - OpenAI `prompt_tokens_details.audio_tokens` / `completion_tokens_details.audio_tokens` (different rate).
+   - OpenAI `service_tier` (default / flex / priority / scale).
+   - Google `thoughts_token_count` (additive to total, separate from `candidates_token_count`).
+   - Google `tool_use_prompt_token_count`.
+   - Google `PromptTokensDetails[]` modality breakdown (text / image / audio / video / document).
+   - Google `TrafficType` (ON_DEMAND / PRIORITY / FLEX / PROVISIONED_THROUGHPUT).
+   - Bedrock `CacheDetails` per-TTL breakdown, `ServiceTier`, `PerformanceConfig.Latency`, `PromptRouterTrace.InvokedModelId`, `GuardrailUsage` six-counter billing surface.
+
+3. **Reasoning-token semantics differ.** OpenAI reports `reasoning_tokens` as a *subset* of `completion_tokens`. Google reports `thoughts_token_count` as **additive** to `candidates_token_count`. The current struct inherits OpenAI's convention, which forces Google's Gemini 2.5+ counts to be mis-reported.
+
+## Design
+
+### Core invariant
+
+**All token counters are disjoint.** A prompt token is counted in exactly one of:
+`InputTokens`, `CachedInputTokens`, `CacheCreation5mTokens`, `CacheCreation1hTokens`, `ToolUseInputTokens`.
+
+Same rule on the output side: `OutputTokens`, `ReasoningTokens`, `RejectedPredictionTokens` (plus `AcceptedPredictionTokens` when OpenAI Predicted Outputs is in use — see field doc).
+
+This makes "billed tokens" a simple integer sum and removes the subset/additive ambiguity. It matches Anthropic's and Bedrock's native convention and requires mechanical remapping for OpenAI and Google.
+
+### Field layout
+
+```go
+type TokenUsage struct {
+    // Input side (all disjoint).
+    InputTokens            int
+    CachedInputTokens      int
+    CacheCreation5mTokens  int
+    CacheCreation1hTokens  int
+    ToolUseInputTokens     int
+
+    // Output side (all disjoint).
+    OutputTokens             int
+    ReasoningTokens          int
+    AcceptedPredictionTokens int
+    RejectedPredictionTokens int
+
+    // Per-modality breakdown (optional; keys sum to the top-level counter).
+    ModalityInputTokens       map[Modality]int
+    ModalityOutputTokens      map[Modality]int
+    ModalityCachedInputTokens map[Modality]int
+
+    // Request posture / routing (informational, affects pricing).
+    ServiceTier     ServiceTier
+    RawServiceTier  string
+    Speed           string
+    InferenceRegion string
+    InvokedModelID  string
+
+    // Non-token billable counters.
+    ServerToolRequests map[ServerTool]int
+    GuardrailUnits     map[string]int
+
+    // Performance (not billable but widely useful).
+    LatencyMs          int64
+    FirstByteLatencyMs int64
+
+    // Model capability (config, not usage).
+    MaxInputTokens int
+
+    // Provider-specific dimensions we do not normalize.
+    // Keys must be namespaced as "<provider>.<field>" to avoid collisions.
+    Extra map[string]any
+}
+```
+
+Helpers:
+
+```go
+func (u *TokenUsage) BilledInputTokens() int
+func (u *TokenUsage) BilledOutputTokens() int
+func (u *TokenUsage) TotalBilledTokens() int
+```
+
+### What was removed
+
+- **`TotalTokens`**: providers disagree on its meaning (some include reasoning, some don't; some include cache writes, some don't). Callers use `TotalBilledTokens()`.
+- **`CachedTokens`** → renamed to `CachedInputTokens` with new disjoint semantics. The rename forces consumers to notice the semantic change at compile time rather than silently miscount.
+
+### Per-provider mapping contract
+
+This is the contract every response mapper must satisfy. Full rationale per field is in the provider's `response_mapper.go`.
+
+**Anthropic / Bedrock-Anthropic (already disjoint — direct copy):**
+
+```
+InputTokens            ← usage.input_tokens
+CachedInputTokens      ← usage.cache_read_input_tokens
+CacheCreation5mTokens  ← usage.cache_creation.ephemeral_5m_input_tokens
+CacheCreation1hTokens  ← usage.cache_creation.ephemeral_1h_input_tokens
+OutputTokens           ← usage.output_tokens
+```
+
+**OpenAI (normalize subset → disjoint):**
+
+```
+InputTokens      ← prompt_tokens - prompt_tokens_details.cached_tokens
+CachedInputTokens ← prompt_tokens_details.cached_tokens
+OutputTokens     ← completion_tokens - completion_tokens_details.reasoning_tokens
+ReasoningTokens  ← completion_tokens_details.reasoning_tokens
+```
+
+**Google (normalize subset/additive → disjoint):**
+
+```
+InputTokens       ← prompt_token_count - cached_content_token_count
+CachedInputTokens ← cached_content_token_count
+ToolUseInputTokens ← tool_use_prompt_token_count
+OutputTokens      ← candidates_token_count  // already excludes thoughts
+ReasoningTokens   ← thoughts_token_count    // already additive
+```
+
+**Bedrock Converse:**
+
+```
+InputTokens            ← input_tokens
+CachedInputTokens      ← cache_read_input_tokens
+CacheCreation5mTokens  ← cache_details[ttl="5m"].input_tokens
+CacheCreation1hTokens  ← cache_details[ttl="1h"].input_tokens
+OutputTokens           ← output_tokens
+```
+
+## Breaking change posture
+
+This is a v0 breaking change. The SDK is pre-1.0; consumers who care about stable semantics pin a version. Release notes + migration table ship with the PR.
+
+## Non-goals (this RFC)
+
+- **Iteration breakdown** (Anthropic Beta per-iteration array). Parked in `Extra["anthropic.iterations"]` for now; first-class field if there's demand.
+- **Pricing/cost calculation.** Separate RFC. This RFC is strictly about the usage shape that pricing later consumes.
+- **Latency histograms / per-phase timings** beyond what providers already return.
+
+## Scope split
+
+- **PR 1 (this):** new shape + `SumUsage` + helpers + conformance contract + minimal extractor updates (rename + disjoint math for fields already extracted today). Everything compiles, all existing tests pass with updated assertions.
+- **PR 2 (follow-up):** richer extraction — populate `CacheCreation5m/1hTokens` separately (Anthropic / Bedrock), `Modality*Tokens` (Google, OpenAI audio), `GuardrailUnits` (Bedrock), `AcceptedPredictionTokens` / `RejectedPredictionTokens` (OpenAI), `ServiceTier` / `Speed` / `InferenceRegion`, `ServerToolRequests`.

--- a/docs/rfcs/0001-token-usage.md
+++ b/docs/rfcs/0001-token-usage.md
@@ -21,7 +21,7 @@ The current struct has three concrete problems:
 
 2. **Missing dimensions.** Providers already bill on fields the SDK does not surface:
    - Anthropic `cache_creation.ephemeral_5m_input_tokens` vs `ephemeral_1h_input_tokens` (two different write rates).
-   - Anthropic `service_tier` (standard / priority / batch), `speed` (standard / fast), `inference_geo`.
+   - Anthropic `service_tier` (standard / priority / batch — each a distinct price sheet), `speed` (standard / fast — fast costs more), `inference_geo`.
    - Anthropic `server_tool_use.web_search_requests` / `web_fetch_requests` (billed per request).
    - OpenAI `accepted_prediction_tokens` / `rejected_prediction_tokens` (rejected is billed as output but never returned to the caller).
    - OpenAI `prompt_tokens_details.audio_tokens` / `completion_tokens_details.audio_tokens` (different rate).
@@ -49,7 +49,11 @@ This makes "billed tokens" a simple integer sum and removes the subset/additive 
 
 ### What lives where
 
-`TokenUsage` contains **only** the additive token-accounting surface. Per-call metadata that describes *how* a request was processed — `ServiceTier`, `RawServiceTier`, `Speed`, `InferenceRegion`, `InvokedModelID`, `LatencyMs`, `FirstByteLatencyMs` — lives on `llm.Response`. These fields are not meaningfully additive across calls, so forcing them through `SumUsage` (first-non-empty-wins, max, etc.) is a type smell.
+`TokenUsage` contains **only** the additive token-accounting surface. Per-call metadata that affects how the request was priced — `ServiceTier`, `RawServiceTier`, `Speed`, `InferenceRegion`, `InvokedModelID` — lives on `llm.Response`. These fields are not meaningfully additive across calls, so forcing them through `SumUsage` (first-non-empty-wins, max, etc.) is a type smell.
+
+Service tier, speed, and region are not cosmetic: every provider we support charges **different per-token rates** depending on tier. OpenAI's `flex` is ≈50% off, `priority` is ≈2×; Anthropic's `batch` is 50% off; Bedrock's `reserved` and Google's `PROVISIONED_THROUGHPUT` bypass per-token billing entirely. Anthropic `speed=fast` costs more than `standard`. `InvokedModelID` matters because Bedrock's PromptRouter can rewrite the model — pricing must be computed against the invoked model, not the requested one.
+
+Pure observability fields (latency, TTFT) are deliberately out of scope for this RFC. They belong in a tracing/metrics layer, not on `Response`.
 
 `MaxInputTokens` is a model-config value, not usage. It has been removed from `TokenUsage`; the canonical source is `modelDefinition.Constraints.MaxInputTokens`.
 
@@ -89,19 +93,17 @@ type TokenUsage struct {
 }
 ```
 
-Per-call metadata on `llm.Response`:
+Per-call metadata on `llm.Response` — each of these can change the per-token rate:
 
 ```go
 type Response struct {
     // ...existing fields...
 
-    ServiceTier        ServiceTier
-    RawServiceTier     string
-    Speed              string
-    InferenceRegion    string
-    InvokedModelID     string
-    LatencyMs          int64
-    FirstByteLatencyMs int64
+    ServiceTier     ServiceTier // default | flex | priority | batch | scale | reserved | provisioned_throughput
+    RawServiceTier  string      // provider-native value when the normalized mapping is lossy
+    Speed           string      // Anthropic: "standard" | "fast" (fast costs more)
+    InferenceRegion string      // Anthropic inference_geo, Bedrock region
+    InvokedModelID  string      // Bedrock PromptRouter: price against this, not the requested model
 }
 ```
 
@@ -134,7 +136,7 @@ PR 1 wires the subset of the shape that can be populated from fields the existin
 | `ServerToolRequests` | — (PR 2: Anthropic web_search/web_fetch, Google grounding) |
 | `GuardrailUnits` | — (PR 2: Bedrock) |
 | `Extra` | Bedrock unknown-TTL audit keys |
-| `Response.ServiceTier` / `RawServiceTier` / `Speed` / `InferenceRegion` / `InvokedModelID` / `LatencyMs` / `FirstByteLatencyMs` | — (PR 2) |
+| `Response.ServiceTier` / `RawServiceTier` / `Speed` / `InferenceRegion` / `InvokedModelID` | — (PR 2) |
 
 Consumers treating a zero field as "reported zero" today will need to verify against the provider's raw response until PR 2 lands, same as with the old `TokenUsage`.
 
@@ -199,4 +201,4 @@ This is a v0 breaking change. The SDK is pre-1.0; consumers who care about stabl
 ## Scope split
 
 - **PR 1 (this):** new shape + `SumUsage` + helpers + extractor updates for fields already extracted today (input/output/cached for every provider; cache-creation 5m/1h + unknown-TTL fallback for Anthropic and Bedrock; thoughts + tool-use for Google). Response gains per-call metadata fields but they are not populated yet. Everything compiles, all unit tests pass.
-- **PR 2 (follow-up):** richer extraction — `Modality*Tokens` (Google, OpenAI audio), `GuardrailUnits` (Bedrock), `RejectedPredictionTokens` (OpenAI), and full population of `Response.ServiceTier` / `RawServiceTier` / `Speed` / `InferenceRegion` / `InvokedModelID` / `LatencyMs` / `FirstByteLatencyMs`. `ServerToolRequests` for Anthropic (web_search, web_fetch), Google (grounding).
+- **PR 2 (follow-up):** richer extraction — `Modality*Tokens` (Google, OpenAI audio), `GuardrailUnits` (Bedrock), `RejectedPredictionTokens` (OpenAI), and full population of `Response.ServiceTier` / `RawServiceTier` / `Speed` / `InferenceRegion` / `InvokedModelID`. `ServerToolRequests` for Anthropic (web_search, web_fetch), Google (grounding).

--- a/docs/rfcs/0001-token-usage.md
+++ b/docs/rfcs/0001-token-usage.md
@@ -55,6 +55,8 @@ The struct only carries counters that at least one extractor populates today. Pe
 
 Service tier, speed, and region are not cosmetic: every provider we support charges **different per-token rates** depending on tier. OpenAI's `flex` is ≈50% off, `priority` is ≈2×; Anthropic's `batch` is 50% off; Bedrock's `reserved` and Google's `PROVISIONED_THROUGHPUT` bypass per-token billing entirely. Anthropic `speed=fast` costs more than `standard`. `InvokedModelID` matters because Bedrock's PromptRouter can rewrite the model — pricing must be computed against the invoked model, not the requested one.
 
+Consequence for consumers: **cost is per-call, not per-summed-usage.** A session total is the sum of per-call `Cost` values, not `calc(sumOfAllUsages)` — the latter has no single tier/speed/region to price against when individual calls differed. The `TokenUsage` + `Response` split makes this the natural shape: price each `(Response.Usage, Response.ServiceTier|Speed|Region|InvokedModelID)` tuple, then add.
+
 Pure observability fields (latency, TTFT) are deliberately out of scope for this RFC. They belong in a tracing/metrics layer, not on `Response`.
 
 `MaxInputTokens` is a model-config value, not usage. It has been removed from `TokenUsage`; the canonical source is `modelDefinition.Constraints.MaxInputTokens`.

--- a/examples/agent_as_tool/main.go
+++ b/examples/agent_as_tool/main.go
@@ -58,9 +58,9 @@ type usageModelHandler struct {
 func (h *usageModelHandler) Generate(ctx context.Context, req *llm.Request) (*llm.Response, error) {
 	resp, err := h.next.Generate(ctx, req)
 	if err == nil && resp.Usage != nil {
-		h.tracker.totalTokens += resp.Usage.TotalTokens
+		h.tracker.totalTokens += resp.Usage.TotalBilledTokens()
 		fmt.Printf("  [%s Usage] +%d tokens (cumulative: %d)\n",
-			h.tracker.name, resp.Usage.TotalTokens, h.tracker.totalTokens)
+			h.tracker.name, resp.Usage.TotalBilledTokens(), h.tracker.totalTokens)
 	}
 	return resp, err
 }
@@ -70,7 +70,7 @@ func (h *usageModelHandler) GenerateEvents(ctx context.Context, req *llm.Request
 		var turnUsage int
 		for evt, err := range h.next.GenerateEvents(ctx, req) {
 			if endEvt, ok := evt.(llm.StreamEndEvent); ok && endEvt.Response != nil && endEvt.Response.Usage != nil {
-				turnUsage = endEvt.Response.Usage.TotalTokens
+				turnUsage = endEvt.Response.Usage.TotalBilledTokens()
 			}
 			if !yield(evt, err) {
 				return
@@ -245,7 +245,7 @@ This helps keep your context clean and focused on the main task.`,
 		case agent.InvocationEndEvent:
 			fmt.Printf("\n[Done] Finish reason: %s\n", e.FinishReason)
 			if e.Usage != nil {
-				fmt.Printf("Total tokens used: %d\n", e.Usage.TotalTokens)
+				fmt.Printf("Total tokens used: %d\n", e.Usage.TotalBilledTokens())
 			}
 		}
 	}

--- a/examples/agent_interceptors/observability_hook.go
+++ b/examples/agent_interceptors/observability_hook.go
@@ -90,7 +90,7 @@ func (h *observabilityModelHandler) Generate(ctx context.Context, req *llm.Reque
 	log.Printf("[Observability] Model call #%d completed in %v", callNum, duration)
 	if resp.Usage != nil {
 		log.Printf("[Observability] Tokens: input=%d output=%d total=%d",
-			resp.Usage.InputTokens, resp.Usage.OutputTokens, resp.Usage.TotalTokens)
+			resp.Usage.InputTokens, resp.Usage.OutputTokens, resp.Usage.TotalBilledTokens())
 	}
 
 	return resp, nil

--- a/llm/fakellm/README.md
+++ b/llm/fakellm/README.md
@@ -461,7 +461,7 @@ assert.Greater(t, resp.Usage.InputTokens, 0)
 assert.Greater(t, resp.Usage.OutputTokens, 0)
 assert.Equal(t,
     resp.Usage.InputTokens + resp.Usage.OutputTokens,
-    resp.Usage.TotalTokens)
+    resp.Usage.TotalBilledTokens())
 ```
 
 ### Custom Tokenizer
@@ -542,7 +542,7 @@ assert.Equal(t, llm.FinishReasonStop, resp.FinishReason)
 5. **Verify Token Usage**: Ensure your code respects token limits
 
    ```go
-   assert.LessOrEqual(t, resp.Usage.TotalTokens, maxTokens)
+   assert.LessOrEqual(t, resp.Usage.TotalBilledTokens(), maxTokens)
    ```
 
 ## Examples

--- a/llm/fakellm/fake.go
+++ b/llm/fakellm/fake.go
@@ -579,7 +579,6 @@ func (m *FakeModel) addUsageAndLatency(ctx context.Context, req *llm.Request, re
 	resp.Usage = &llm.TokenUsage{
 		InputTokens:  inputTokens,
 		OutputTokens: outputTokens,
-		TotalTokens:  inputTokens + outputTokens,
 	}
 
 	// Simulate latency
@@ -632,7 +631,6 @@ func (m *FakeModel) textToStreamEvents(text string, finishReason llm.FinishReaso
 			Usage: &llm.TokenUsage{
 				InputTokens:  0, // Calculated in stream wrapper if needed
 				OutputTokens: m.tokenizer.Count(text),
-				TotalTokens:  m.tokenizer.Count(text),
 			},
 		},
 	})
@@ -660,7 +658,6 @@ func (m *FakeModel) responseToStreamEvents(req *llm.Request, resp *llm.Response)
 		resp.Usage = &llm.TokenUsage{
 			InputTokens:  inputTokens,
 			OutputTokens: outputTokens,
-			TotalTokens:  inputTokens + outputTokens,
 		}
 	}
 
@@ -897,7 +894,6 @@ func (rb *RuleBuilder) ThenStreamText(text string, config StreamConfig) *FakeMod
 			Usage: &llm.TokenUsage{
 				InputTokens:  inputTokens,
 				OutputTokens: outputTokens,
-				TotalTokens:  inputTokens + outputTokens,
 			},
 		}
 
@@ -936,7 +932,6 @@ func (rb *RuleBuilder) ThenStreamText(text string, config StreamConfig) *FakeMod
 					Usage: &llm.TokenUsage{
 						InputTokens:  inputTokens,
 						OutputTokens: outputTokens,
-						TotalTokens:  inputTokens + outputTokens,
 					},
 				},
 			})

--- a/llm/fakellm/fake_test.go
+++ b/llm/fakellm/fake_test.go
@@ -477,7 +477,7 @@ func TestFakeModel_TokenCounting(t *testing.T) {
 	// Verify token counts are reasonable
 	assert.Positive(t, resp.Usage.InputTokens)
 	assert.Positive(t, resp.Usage.OutputTokens)
-	assert.Equal(t, resp.Usage.InputTokens+resp.Usage.OutputTokens, resp.Usage.TotalTokens)
+	assert.Equal(t, resp.Usage.InputTokens+resp.Usage.OutputTokens, resp.Usage.TotalBilledTokens())
 }
 
 // TestFakeModel_ToolCallingLoop demonstrates an integration test with agent-like tool calling.

--- a/llm/response.go
+++ b/llm/response.go
@@ -66,17 +66,9 @@ type Response struct {
 
 	// InvokedModelID is the actual model that served the request when a
 	// router rewrote it (Bedrock PromptRouter, OpenAI model routing). Empty
-	// when no re-routing occurred.
+	// when no re-routing occurred. Pricing must be computed against the
+	// invoked model, not the requested one.
 	InvokedModelID string `json:"invoked_model_id,omitempty"`
-
-	// LatencyMs is total server-reported latency in milliseconds.
-	// Zero if not returned by the provider.
-	LatencyMs int64 `json:"latency_ms,omitempty"`
-
-	// FirstByteLatencyMs is time-to-first-byte in milliseconds when reported.
-	// Currently surfaced only by Bedrock-Anthropic via
-	// amazon-bedrock-invocationMetrics.
-	FirstByteLatencyMs int64 `json:"first_byte_latency_ms,omitempty"`
 }
 
 // TextContent extracts and combines all text content from this response.

--- a/llm/response.go
+++ b/llm/response.go
@@ -41,6 +41,42 @@ type Response struct {
 	// Raw contains the original provider response for debugging purposes.
 	// This is optional and may be omitted in production to save memory.
 	Raw map[string]any `json:"raw,omitempty"`
+
+	// ServiceTier is the normalized request-processing variant the provider
+	// reported for this call. Empty string means default or not reported.
+	// This field describes HOW the request was processed and is not
+	// meaningfully additive across calls — it lives on Response, not
+	// TokenUsage.
+	ServiceTier ServiceTier `json:"service_tier,omitempty"`
+
+	// RawServiceTier carries the provider-native tier string for audit/debug
+	// when the normalized mapping is lossy (e.g., vendor-specific values the
+	// SDK doesn't recognize).
+	RawServiceTier string `json:"raw_service_tier,omitempty"`
+
+	// Speed is a provider-specific latency tier. Anthropic:
+	// "standard" | "fast". Bedrock PerformanceConfig:
+	// "standard" | "optimized". Empty for providers that do not report one.
+	Speed string `json:"speed,omitempty"`
+
+	// InferenceRegion is the compute region reported by the provider, if any.
+	// Anthropic populates this from inference_geo. Other providers typically
+	// leave it empty.
+	InferenceRegion string `json:"inference_region,omitempty"`
+
+	// InvokedModelID is the actual model that served the request when a
+	// router rewrote it (Bedrock PromptRouter, OpenAI model routing). Empty
+	// when no re-routing occurred.
+	InvokedModelID string `json:"invoked_model_id,omitempty"`
+
+	// LatencyMs is total server-reported latency in milliseconds.
+	// Zero if not returned by the provider.
+	LatencyMs int64 `json:"latency_ms,omitempty"`
+
+	// FirstByteLatencyMs is time-to-first-byte in milliseconds when reported.
+	// Currently surfaced only by Bedrock-Anthropic via
+	// amazon-bedrock-invocationMetrics.
+	FirstByteLatencyMs int64 `json:"first_byte_latency_ms,omitempty"`
 }
 
 // TextContent extracts and combines all text content from this response.

--- a/llm/types.go
+++ b/llm/types.go
@@ -23,31 +23,42 @@ import "maps"
 //
 // All token counters are DISJOINT. A prompt token is counted in exactly one of
 // InputTokens, CachedInputTokens, CacheCreation5mTokens, CacheCreation1hTokens,
-// or ToolUseInputTokens. Likewise output tokens are counted in exactly one of
-// OutputTokens, ReasoningTokens, AcceptedPredictionTokens, RejectedPredictionTokens.
+// CacheCreationUnknownTTLTokens, or ToolUseInputTokens. Likewise output tokens
+// are counted in exactly one of OutputTokens, ReasoningTokens, or
+// RejectedPredictionTokens.
 //
-// This matches Anthropic's and Bedrock's native convention and requires that
-// OpenAI and Google extractors un-subset their native values (see the provider
-// response mappers for details).
+// This matches Anthropic's and Bedrock's native convention. OpenAI and Google
+// extractors un-subset their native values so the invariant holds uniformly
+// (see the per-provider response mappers).
 //
-// # Not reported vs zero
+// # Zero vs not-reported
 //
-// A zero value means "not reported by the provider", not "zero tokens." Providers
-// do not always surface every dimension; consumers relying on a specific field
-// should check the provider's own documentation for coverage.
+// A zero value is ambiguous: it may mean "reported zero" or "not surfaced by
+// the provider or the extractor." Consumers that need to distinguish should
+// consult the provider's raw response. Within the SDK, extractors populate
+// fields whenever the underlying SDK exposes them; additional fields are
+// wired in over subsequent releases.
 //
 // # Billed totals
 //
 // Use BilledInputTokens, BilledOutputTokens, and TotalBilledTokens to compute
-// sums — directly adding fields is correct because counters are disjoint, but
-// the helpers document intent and are stable across future field additions.
+// sums. Counters are disjoint so these are simple additions; the helpers
+// document intent and stay stable as fields are added.
+//
+// # What is NOT in TokenUsage
+//
+// Per-call metadata that describes HOW a request was processed
+// (service tier, speed, inference region, invoked model ID, latencies) lives
+// on llm.Response, not here. Those fields are not meaningfully additive
+// across calls.
 type TokenUsage struct {
-	// InputTokens is the number of fresh (non-cached, non-cache-write, non-tool)
-	// prompt tokens charged at the base input rate.
+	// InputTokens is the number of fresh (non-cached, non-cache-write,
+	// non-tool-use) prompt tokens charged at the base input rate.
 	InputTokens int `json:"input_tokens"`
 
-	// CachedInputTokens is the number of prompt tokens served from the provider's
-	// cache (cache read). Disjoint from InputTokens. Billed at a reduced rate.
+	// CachedInputTokens is the number of prompt tokens served from the
+	// provider's cache (cache read). Disjoint from InputTokens. Billed at a
+	// reduced rate.
 	//
 	// Provider coverage: OpenAI (prompt_tokens_details.cached_tokens),
 	// Anthropic (cache_read_input_tokens), Google (cached_content_token_count),
@@ -62,54 +73,69 @@ type TokenUsage struct {
 	CacheCreation5mTokens int `json:"cache_creation_5m_tokens,omitempty"`
 
 	// CacheCreation1hTokens is the number of prompt tokens written to the
-	// provider's 1-hour-TTL cache. Disjoint from InputTokens. Billed at an
-	// elevated rate (higher than 5m writes).
+	// provider's 1-hour-TTL cache. Disjoint from InputTokens. Billed at a
+	// higher elevated rate than 5m writes.
 	//
 	// Provider coverage: Anthropic, Bedrock-Anthropic.
 	CacheCreation1hTokens int `json:"cache_creation_1h_tokens,omitempty"`
 
-	// ToolUseInputTokens is the number of prompt tokens consumed by server-side
-	// tool invocations (e.g., function-calling loops billed separately from the
-	// user-visible prompt). Disjoint from InputTokens.
+	// CacheCreationUnknownTTLTokens is the number of prompt tokens written
+	// to the provider's cache when a TTL-specific field was not available
+	// (older API shapes, future unknown TTLs). Disjoint from InputTokens and
+	// from the 5m/1h counters.
 	//
-	// Provider coverage: Google (tool_use_prompt_token_count). Zero for providers
-	// that fold tool-use tokens into InputTokens.
+	// Extractors fall back to this field when a provider reports an
+	// aggregate cache-write count without a per-TTL breakdown, so the total
+	// stays reflected in BilledInputTokens() without pretending to know the
+	// TTL.
+	CacheCreationUnknownTTLTokens int `json:"cache_creation_unknown_ttl_tokens,omitempty"`
+
+	// ToolUseInputTokens is the number of prompt tokens consumed by
+	// server-side tool invocations (e.g., function-calling loops billed
+	// separately from the user-visible prompt). Disjoint from InputTokens.
+	//
+	// Provider coverage: Google (tool_use_prompt_token_count). Zero for
+	// providers that fold tool-use tokens into InputTokens.
 	ToolUseInputTokens int `json:"tool_use_input_tokens,omitempty"`
 
-	// OutputTokens is the number of tokens in the assistant's visible response.
-	// Does NOT include reasoning/thinking tokens, which are separate.
+	// OutputTokens is the number of tokens in the assistant's visible
+	// response. Does NOT include reasoning tokens (disjoint, see
+	// ReasoningTokens) or rejected predicted-output tokens (disjoint, see
+	// RejectedPredictionTokens). Does INCLUDE accepted predicted-output
+	// tokens, since those appear in the completion.
 	OutputTokens int `json:"output_tokens"`
 
 	// ReasoningTokens is the number of tokens the model spent on hidden
 	// reasoning/thinking. Disjoint from OutputTokens — the SDK un-subsets
-	// OpenAI's native value so that the invariant holds uniformly. Typically
-	// billed at the output rate, though some providers charge separately.
+	// OpenAI's native value so the invariant holds uniformly. Typically
+	// billed at the output rate.
 	//
-	// Provider coverage: OpenAI o-series / GPT-5 (completion_tokens_details.reasoning_tokens),
-	// Google Gemini 2.5+ (thoughts_token_count), OpenAI-compatible reasoning models.
-	// Anthropic and Bedrock do not surface thinking tokens as a separate counter
-	// — Anthropic's thinking content is billed as regular output tokens and
-	// ReasoningTokens will be 0.
+	// Provider coverage: OpenAI o-series / GPT-5
+	// (completion_tokens_details.reasoning_tokens), Google Gemini 2.5+
+	// (thoughts_token_count), OpenAI-compatible reasoning models. Anthropic
+	// and Bedrock do not surface thinking tokens as a separate counter —
+	// Anthropic's thinking content is billed as regular output and
+	// ReasoningTokens will be zero.
 	ReasoningTokens int `json:"reasoning_tokens,omitempty"`
 
-	// AcceptedPredictionTokens is the number of Predicted Outputs tokens that
-	// appeared verbatim in the completion. Disjoint from OutputTokens.
+	// RejectedPredictionTokens is the number of OpenAI Predicted Outputs
+	// tokens that did NOT appear in the completion. Billed as output but
+	// never returned to the caller, so they are disjoint from OutputTokens.
 	//
-	// Provider coverage: OpenAI only (completion_tokens_details.accepted_prediction_tokens).
-	AcceptedPredictionTokens int `json:"accepted_prediction_tokens,omitempty"`
-
-	// RejectedPredictionTokens is the number of Predicted Outputs tokens that
-	// did NOT appear in the completion. These are billed as output but are not
-	// returned in the response. Disjoint from OutputTokens.
+	// Provider coverage: OpenAI only
+	// (completion_tokens_details.rejected_prediction_tokens).
 	//
-	// Provider coverage: OpenAI only (completion_tokens_details.rejected_prediction_tokens).
+	// Note: accepted predicted-output tokens are NOT a separate counter —
+	// they appear verbatim in the completion and are already included in
+	// OutputTokens. Consumers that need the breakdown can read the raw
+	// provider response.
 	RejectedPredictionTokens int `json:"rejected_prediction_tokens,omitempty"`
 
-	// ModalityInputTokens breaks InputTokens down by modality when the provider
-	// reports it. The sum over the map equals InputTokens.
+	// ModalityInputTokens breaks InputTokens down by modality when the
+	// provider reports it. The sum over the map equals InputTokens.
 	//
-	// Provider coverage: Google (prompt_tokens_details[]). OpenAI audio tokens
-	// are exposed here when present.
+	// Provider coverage: Google (prompt_tokens_details[]). OpenAI audio
+	// tokens are exposed here when present.
 	ModalityInputTokens map[Modality]int `json:"modality_input_tokens,omitempty"`
 
 	// ModalityOutputTokens breaks OutputTokens down by modality.
@@ -118,93 +144,61 @@ type TokenUsage struct {
 	// ModalityCachedInputTokens breaks CachedInputTokens down by modality.
 	ModalityCachedInputTokens map[Modality]int `json:"modality_cached_input_tokens,omitempty"`
 
-	// ServiceTier is the normalized request/response variant. An empty string
-	// means the provider did not report one or it was the default.
-	ServiceTier ServiceTier `json:"service_tier,omitempty"`
-
-	// RawServiceTier carries the provider-native tier string for audit/debug
-	// when the normalized mapping is lossy.
-	RawServiceTier string `json:"raw_service_tier,omitempty"`
-
-	// Speed is a provider-specific latency tier. Anthropic: "standard" | "fast".
-	// Bedrock PerformanceConfig: "standard" | "optimized". Empty for providers
-	// that do not report one.
-	Speed string `json:"speed,omitempty"`
-
-	// InferenceRegion is the compute region reported by the provider if any.
-	// Anthropic populates this from inference_geo; other providers typically
-	// leave it empty.
-	InferenceRegion string `json:"inference_region,omitempty"`
-
-	// InvokedModelID is the actual model that served the request when a router
-	// rewrote it (Bedrock PromptRouter, OpenAI model routing). Empty when no
-	// re-routing occurred.
-	InvokedModelID string `json:"invoked_model_id,omitempty"`
-
-	// ServerToolRequests counts billable server-side tool invocations by kind.
-	// Each entry is one request, not token count.
+	// ServerToolRequests counts billable server-side tool invocations by
+	// kind. Each entry is one request, not a token count.
 	//
 	// Provider coverage: Anthropic (web_search, web_fetch), Google (inferred
 	// from GroundingMetadata), Cohere-on-Bedrock (search, classification).
 	ServerToolRequests map[ServerTool]int `json:"server_tool_requests,omitempty"`
 
-	// GuardrailUnits counts provider-reported guardrail policy units. Each key
-	// is an independent billing SKU on Bedrock.
+	// GuardrailUnits counts provider-reported guardrail policy units. Each
+	// key is an independent billing SKU on Bedrock.
 	//
 	// Provider coverage: Bedrock. Keys include "content_policy",
 	// "contextual_grounding", "sensitive_info", "sensitive_info_free",
 	// "topic_policy", "word_policy".
 	GuardrailUnits map[string]int `json:"guardrail_units,omitempty"`
 
-	// LatencyMs is total server-reported latency in milliseconds.
-	// Zero if not returned by the provider.
-	LatencyMs int64 `json:"latency_ms,omitempty"`
-
-	// FirstByteLatencyMs is time-to-first-byte in milliseconds when reported.
-	// Currently surfaced only by Bedrock-Anthropic via amazon-bedrock-invocationMetrics.
-	FirstByteLatencyMs int64 `json:"first_byte_latency_ms,omitempty"`
-
-	// MaxInputTokens is the model's context-window size. This is a model
-	// capability, not a usage metric — it is populated from the model definition
-	// at configuration time, not from the API response.
-	MaxInputTokens int `json:"max_input_tokens,omitempty"`
-
 	// Extra carries provider-specific dimensions that the SDK does not
 	// normalize today. Keys MUST be namespaced as "<provider>.<field>" to
-	// prevent collisions (e.g., "anthropic.iterations", "cohere.search_units",
-	// "bedrock.invocation_latency_ms").
+	// prevent collisions (e.g., "anthropic.iterations",
+	// "cohere.search_units", "bedrock.invocation_latency_ms").
 	//
-	// Anything that appears in Extra is a candidate for promotion to a
-	// first-class field in a future release.
+	// Extra is NOT included in BilledInputTokens / BilledOutputTokens —
+	// anything billable should graduate to a first-class field.
 	Extra map[string]any `json:"extra,omitempty"`
 }
 
 // BilledInputTokens returns the total input-side tokens that contribute to
 // billing: InputTokens + CachedInputTokens + CacheCreation5mTokens +
-// CacheCreation1hTokens + ToolUseInputTokens.
+// CacheCreation1hTokens + CacheCreationUnknownTTLTokens + ToolUseInputTokens.
 //
-// Counters are disjoint so this is a simple sum; the helper exists to document
-// intent and remain stable as fields are added.
+// Counters are disjoint so this is a simple sum; the helper exists to
+// document intent and remain stable as fields are added.
 func (u *TokenUsage) BilledInputTokens() int {
 	if u == nil {
 		return 0
 	}
 
-	return u.InputTokens + u.CachedInputTokens +
-		u.CacheCreation5mTokens + u.CacheCreation1hTokens +
+	return u.InputTokens +
+		u.CachedInputTokens +
+		u.CacheCreation5mTokens +
+		u.CacheCreation1hTokens +
+		u.CacheCreationUnknownTTLTokens +
 		u.ToolUseInputTokens
 }
 
 // BilledOutputTokens returns the total output-side tokens that contribute to
-// billing: OutputTokens + ReasoningTokens + AcceptedPredictionTokens +
-// RejectedPredictionTokens.
+// billing: OutputTokens + ReasoningTokens + RejectedPredictionTokens.
+//
+// AcceptedPredictionTokens are NOT added here — they appear verbatim in the
+// completion and are already counted inside OutputTokens.
 func (u *TokenUsage) BilledOutputTokens() int {
 	if u == nil {
 		return 0
 	}
 
-	return u.OutputTokens + u.ReasoningTokens +
-		u.AcceptedPredictionTokens + u.RejectedPredictionTokens
+	return u.OutputTokens + u.ReasoningTokens + u.RejectedPredictionTokens
 }
 
 // TotalBilledTokens returns BilledInputTokens + BilledOutputTokens. Non-token
@@ -217,18 +211,13 @@ func (u *TokenUsage) TotalBilledTokens() int {
 // SumUsage aggregates multiple TokenUsage values into a single cumulative
 // result. Nil values are safely skipped. Returns nil if all inputs are nil.
 //
-// Scalar fields are added. Map fields (Modality*, ServerToolRequests,
+// All scalar counters are added. Map fields (Modality*, ServerToolRequests,
 // GuardrailUnits, Extra) are merged with per-key addition for numeric values;
-// non-numeric Extra values are taken from the first non-nil usage that has
-// that key.
+// non-numeric Extra values take the first-writer-wins rule.
 //
-// String fields (ServiceTier, RawServiceTier, Speed, InferenceRegion,
-// InvokedModelID) are taken from the first non-empty value in order. These
-// fields describe a single request and are not meaningfully additive across
-// calls.
-//
-// MaxInputTokens takes the maximum across inputs (it is a model capability,
-// not an accumulating usage metric).
+// TokenUsage intentionally contains only additive accounting fields.
+// Per-call metadata (service tier, speed, region, invoked model, latency)
+// lives on llm.Response, which is not summed.
 //
 // Example:
 //
@@ -250,39 +239,12 @@ func SumUsage(usages ...*TokenUsage) *TokenUsage {
 		result.CachedInputTokens += u.CachedInputTokens
 		result.CacheCreation5mTokens += u.CacheCreation5mTokens
 		result.CacheCreation1hTokens += u.CacheCreation1hTokens
+		result.CacheCreationUnknownTTLTokens += u.CacheCreationUnknownTTLTokens
 		result.ToolUseInputTokens += u.ToolUseInputTokens
 
 		result.OutputTokens += u.OutputTokens
 		result.ReasoningTokens += u.ReasoningTokens
-		result.AcceptedPredictionTokens += u.AcceptedPredictionTokens
 		result.RejectedPredictionTokens += u.RejectedPredictionTokens
-
-		result.LatencyMs += u.LatencyMs
-		result.FirstByteLatencyMs += u.FirstByteLatencyMs
-
-		if u.MaxInputTokens > result.MaxInputTokens {
-			result.MaxInputTokens = u.MaxInputTokens
-		}
-
-		if result.ServiceTier == "" {
-			result.ServiceTier = u.ServiceTier
-		}
-
-		if result.RawServiceTier == "" {
-			result.RawServiceTier = u.RawServiceTier
-		}
-
-		if result.Speed == "" {
-			result.Speed = u.Speed
-		}
-
-		if result.InferenceRegion == "" {
-			result.InferenceRegion = u.InferenceRegion
-		}
-
-		if result.InvokedModelID == "" {
-			result.InvokedModelID = u.InvokedModelID
-		}
 
 		result.ModalityInputTokens = mergeModality(result.ModalityInputTokens, u.ModalityInputTokens)
 		result.ModalityOutputTokens = mergeModality(result.ModalityOutputTokens, u.ModalityOutputTokens)
@@ -438,8 +400,9 @@ const (
 	ModalityDocument Modality = "document"
 )
 
-// ServiceTier is the normalized request-processing variant. Not every provider
-// reports every value; the empty string means default / unreported.
+// ServiceTier is the normalized request-processing variant reported on
+// llm.Response. Not every provider reports every value; the empty string
+// means default / unreported.
 type ServiceTier string
 
 // ServiceTier constants cover the union of variants across providers.
@@ -456,10 +419,10 @@ const (
 	// Google ON_DEMAND_PRIORITY).
 	ServiceTierPriority ServiceTier = "priority"
 
-	// ServiceTierBatch is the async 50%-discount batch tier (Anthropic "batch",
-	// OpenAI Batch API). Note: OpenAI's Batch SKU is a separate endpoint, not
-	// a service_tier on the sync API; extractors set this for responses whose
-	// origin is the batch endpoint.
+	// ServiceTierBatch is the async 50%-discount batch tier (Anthropic
+	// "batch", OpenAI Batch API). Note: OpenAI's Batch SKU is a separate
+	// endpoint, not a service_tier on the sync API; extractors set this for
+	// responses whose origin is the batch endpoint.
 	ServiceTierBatch ServiceTier = "batch"
 
 	// ServiceTierScale is OpenAI's enterprise scale tier.

--- a/llm/types.go
+++ b/llm/types.go
@@ -14,62 +14,221 @@
 
 package llm
 
-// TokenUsage tracks token consumption for AI model requests.
+import "maps"
+
+// TokenUsage is the normalized, cross-provider accounting of tokens for a
+// single LLM call.
 //
-// Fields are populated on a best-effort basis — not all providers report every field.
-// Zero values indicate the provider did not report that metric.
+// # Disjoint counters
 //
-// # Provider Coverage
+// All token counters are DISJOINT. A prompt token is counted in exactly one of
+// InputTokens, CachedInputTokens, CacheCreation5mTokens, CacheCreation1hTokens,
+// or ToolUseInputTokens. Likewise output tokens are counted in exactly one of
+// OutputTokens, ReasoningTokens, AcceptedPredictionTokens, RejectedPredictionTokens.
 //
-// All providers report InputTokens, OutputTokens, and TotalTokens.
-// CachedTokens is widely supported. ReasoningTokens is provider-specific.
-// See individual field docs for details.
+// This matches Anthropic's and Bedrock's native convention and requires that
+// OpenAI and Google extractors un-subset their native values (see the provider
+// response mappers for details).
+//
+// # Not reported vs zero
+//
+// A zero value means "not reported by the provider", not "zero tokens." Providers
+// do not always surface every dimension; consumers relying on a specific field
+// should check the provider's own documentation for coverage.
+//
+// # Billed totals
+//
+// Use BilledInputTokens, BilledOutputTokens, and TotalBilledTokens to compute
+// sums — directly adding fields is correct because counters are disjoint, but
+// the helpers document intent and are stable across future field additions.
 type TokenUsage struct {
-	// InputTokens is the number of tokens in the input/prompt.
-	// Reported by all providers.
+	// InputTokens is the number of fresh (non-cached, non-cache-write, non-tool)
+	// prompt tokens charged at the base input rate.
 	InputTokens int `json:"input_tokens"`
 
-	// OutputTokens is the number of tokens in the generated response.
-	// Reported by all providers. For reasoning models on OpenAI, this includes
-	// reasoning tokens — ReasoningTokens is a subset of OutputTokens, not additive.
+	// CachedInputTokens is the number of prompt tokens served from the provider's
+	// cache (cache read). Disjoint from InputTokens. Billed at a reduced rate.
+	//
+	// Provider coverage: OpenAI (prompt_tokens_details.cached_tokens),
+	// Anthropic (cache_read_input_tokens), Google (cached_content_token_count),
+	// Bedrock Converse (cache_read_input_tokens), OpenAI-compatible APIs.
+	CachedInputTokens int `json:"cached_input_tokens,omitempty"`
+
+	// CacheCreation5mTokens is the number of prompt tokens written to the
+	// provider's 5-minute-TTL cache. Disjoint from InputTokens. Billed at an
+	// elevated rate.
+	//
+	// Provider coverage: Anthropic, Bedrock-Anthropic.
+	CacheCreation5mTokens int `json:"cache_creation_5m_tokens,omitempty"`
+
+	// CacheCreation1hTokens is the number of prompt tokens written to the
+	// provider's 1-hour-TTL cache. Disjoint from InputTokens. Billed at an
+	// elevated rate (higher than 5m writes).
+	//
+	// Provider coverage: Anthropic, Bedrock-Anthropic.
+	CacheCreation1hTokens int `json:"cache_creation_1h_tokens,omitempty"`
+
+	// ToolUseInputTokens is the number of prompt tokens consumed by server-side
+	// tool invocations (e.g., function-calling loops billed separately from the
+	// user-visible prompt). Disjoint from InputTokens.
+	//
+	// Provider coverage: Google (tool_use_prompt_token_count). Zero for providers
+	// that fold tool-use tokens into InputTokens.
+	ToolUseInputTokens int `json:"tool_use_input_tokens,omitempty"`
+
+	// OutputTokens is the number of tokens in the assistant's visible response.
+	// Does NOT include reasoning/thinking tokens, which are separate.
 	OutputTokens int `json:"output_tokens"`
 
-	// TotalTokens is the total token count for the request.
-	// Most providers return this directly from their API. Anthropic computes it
-	// as InputTokens + OutputTokens since their API does not provide it.
+	// ReasoningTokens is the number of tokens the model spent on hidden
+	// reasoning/thinking. Disjoint from OutputTokens — the SDK un-subsets
+	// OpenAI's native value so that the invariant holds uniformly. Typically
+	// billed at the output rate, though some providers charge separately.
 	//
-	// For non-reasoning models, TotalTokens == InputTokens + OutputTokens.
-	// For reasoning models (OpenAI), TotalTokens still equals InputTokens + OutputTokens
-	// because reasoning tokens are included in OutputTokens.
-	TotalTokens int `json:"total_tokens"`
-
-	// CachedTokens is the number of input tokens served from the provider's prompt cache.
-	// These tokens are typically billed at a reduced rate. CachedTokens is a subset of
-	// InputTokens, not additive.
-	//
-	// Supported by all providers: OpenAI (InputTokensDetails.CachedTokens),
-	// Anthropic (CacheReadInputTokens), Google (CachedContentTokenCount),
-	// Bedrock (CacheReadInputTokens), and OpenAI-compatible APIs.
-	CachedTokens int `json:"cached_tokens,omitempty"`
-
-	// ReasoningTokens is the number of tokens the model used for internal reasoning (thinking).
-	// This is a subset of OutputTokens — it is NOT additive to the output count.
-	// These tokens are billed as output tokens.
-	//
-	// Only reported by OpenAI (o-series, GPT-5) and OpenAI-compatible providers
-	// (e.g., DeepSeek-R1). Anthropic, Google, and Bedrock do not report this field;
-	// it will be zero for those providers.
+	// Provider coverage: OpenAI o-series / GPT-5 (completion_tokens_details.reasoning_tokens),
+	// Google Gemini 2.5+ (thoughts_token_count), OpenAI-compatible reasoning models.
+	// Anthropic and Bedrock do not surface thinking tokens as a separate counter
+	// — Anthropic's thinking content is billed as regular output tokens and
+	// ReasoningTokens will be 0.
 	ReasoningTokens int `json:"reasoning_tokens,omitempty"`
 
-	// MaxInputTokens is the model's context window size (maximum input tokens accepted).
-	// This is a model capability, not a usage metric — it is populated from the model
-	// definition at configuration time, not from API responses.
+	// AcceptedPredictionTokens is the number of Predicted Outputs tokens that
+	// appeared verbatim in the completion. Disjoint from OutputTokens.
+	//
+	// Provider coverage: OpenAI only (completion_tokens_details.accepted_prediction_tokens).
+	AcceptedPredictionTokens int `json:"accepted_prediction_tokens,omitempty"`
+
+	// RejectedPredictionTokens is the number of Predicted Outputs tokens that
+	// did NOT appear in the completion. These are billed as output but are not
+	// returned in the response. Disjoint from OutputTokens.
+	//
+	// Provider coverage: OpenAI only (completion_tokens_details.rejected_prediction_tokens).
+	RejectedPredictionTokens int `json:"rejected_prediction_tokens,omitempty"`
+
+	// ModalityInputTokens breaks InputTokens down by modality when the provider
+	// reports it. The sum over the map equals InputTokens.
+	//
+	// Provider coverage: Google (prompt_tokens_details[]). OpenAI audio tokens
+	// are exposed here when present.
+	ModalityInputTokens map[Modality]int `json:"modality_input_tokens,omitempty"`
+
+	// ModalityOutputTokens breaks OutputTokens down by modality.
+	ModalityOutputTokens map[Modality]int `json:"modality_output_tokens,omitempty"`
+
+	// ModalityCachedInputTokens breaks CachedInputTokens down by modality.
+	ModalityCachedInputTokens map[Modality]int `json:"modality_cached_input_tokens,omitempty"`
+
+	// ServiceTier is the normalized request/response variant. An empty string
+	// means the provider did not report one or it was the default.
+	ServiceTier ServiceTier `json:"service_tier,omitempty"`
+
+	// RawServiceTier carries the provider-native tier string for audit/debug
+	// when the normalized mapping is lossy.
+	RawServiceTier string `json:"raw_service_tier,omitempty"`
+
+	// Speed is a provider-specific latency tier. Anthropic: "standard" | "fast".
+	// Bedrock PerformanceConfig: "standard" | "optimized". Empty for providers
+	// that do not report one.
+	Speed string `json:"speed,omitempty"`
+
+	// InferenceRegion is the compute region reported by the provider if any.
+	// Anthropic populates this from inference_geo; other providers typically
+	// leave it empty.
+	InferenceRegion string `json:"inference_region,omitempty"`
+
+	// InvokedModelID is the actual model that served the request when a router
+	// rewrote it (Bedrock PromptRouter, OpenAI model routing). Empty when no
+	// re-routing occurred.
+	InvokedModelID string `json:"invoked_model_id,omitempty"`
+
+	// ServerToolRequests counts billable server-side tool invocations by kind.
+	// Each entry is one request, not token count.
+	//
+	// Provider coverage: Anthropic (web_search, web_fetch), Google (inferred
+	// from GroundingMetadata), Cohere-on-Bedrock (search, classification).
+	ServerToolRequests map[ServerTool]int `json:"server_tool_requests,omitempty"`
+
+	// GuardrailUnits counts provider-reported guardrail policy units. Each key
+	// is an independent billing SKU on Bedrock.
+	//
+	// Provider coverage: Bedrock. Keys include "content_policy",
+	// "contextual_grounding", "sensitive_info", "sensitive_info_free",
+	// "topic_policy", "word_policy".
+	GuardrailUnits map[string]int `json:"guardrail_units,omitempty"`
+
+	// LatencyMs is total server-reported latency in milliseconds.
+	// Zero if not returned by the provider.
+	LatencyMs int64 `json:"latency_ms,omitempty"`
+
+	// FirstByteLatencyMs is time-to-first-byte in milliseconds when reported.
+	// Currently surfaced only by Bedrock-Anthropic via amazon-bedrock-invocationMetrics.
+	FirstByteLatencyMs int64 `json:"first_byte_latency_ms,omitempty"`
+
+	// MaxInputTokens is the model's context-window size. This is a model
+	// capability, not a usage metric — it is populated from the model definition
+	// at configuration time, not from the API response.
 	MaxInputTokens int `json:"max_input_tokens,omitempty"`
+
+	// Extra carries provider-specific dimensions that the SDK does not
+	// normalize today. Keys MUST be namespaced as "<provider>.<field>" to
+	// prevent collisions (e.g., "anthropic.iterations", "cohere.search_units",
+	// "bedrock.invocation_latency_ms").
+	//
+	// Anything that appears in Extra is a candidate for promotion to a
+	// first-class field in a future release.
+	Extra map[string]any `json:"extra,omitempty"`
 }
 
-// SumUsage aggregates multiple TokenUsage values into a single cumulative result.
-// This is the preferred way to accumulate usage across multiple operations.
-// Nil values are safely skipped. Returns nil if all inputs are nil.
+// BilledInputTokens returns the total input-side tokens that contribute to
+// billing: InputTokens + CachedInputTokens + CacheCreation5mTokens +
+// CacheCreation1hTokens + ToolUseInputTokens.
+//
+// Counters are disjoint so this is a simple sum; the helper exists to document
+// intent and remain stable as fields are added.
+func (u *TokenUsage) BilledInputTokens() int {
+	if u == nil {
+		return 0
+	}
+
+	return u.InputTokens + u.CachedInputTokens +
+		u.CacheCreation5mTokens + u.CacheCreation1hTokens +
+		u.ToolUseInputTokens
+}
+
+// BilledOutputTokens returns the total output-side tokens that contribute to
+// billing: OutputTokens + ReasoningTokens + AcceptedPredictionTokens +
+// RejectedPredictionTokens.
+func (u *TokenUsage) BilledOutputTokens() int {
+	if u == nil {
+		return 0
+	}
+
+	return u.OutputTokens + u.ReasoningTokens +
+		u.AcceptedPredictionTokens + u.RejectedPredictionTokens
+}
+
+// TotalBilledTokens returns BilledInputTokens + BilledOutputTokens. Non-token
+// fees (ServerToolRequests, GuardrailUnits) are not included — those are
+// priced separately by the consumer.
+func (u *TokenUsage) TotalBilledTokens() int {
+	return u.BilledInputTokens() + u.BilledOutputTokens()
+}
+
+// SumUsage aggregates multiple TokenUsage values into a single cumulative
+// result. Nil values are safely skipped. Returns nil if all inputs are nil.
+//
+// Scalar fields are added. Map fields (Modality*, ServerToolRequests,
+// GuardrailUnits, Extra) are merged with per-key addition for numeric values;
+// non-numeric Extra values are taken from the first non-nil usage that has
+// that key.
+//
+// String fields (ServiceTier, RawServiceTier, Speed, InferenceRegion,
+// InvokedModelID) are taken from the first non-empty value in order. These
+// fields describe a single request and are not meaningfully additive across
+// calls.
+//
+// MaxInputTokens takes the maximum across inputs (it is a model capability,
+// not an accumulating usage metric).
 //
 // Example:
 //
@@ -83,26 +242,251 @@ func SumUsage(usages ...*TokenUsage) *TokenUsage {
 		}
 
 		if result == nil {
-			// First non-nil usage, make a copy
-			val := *u
-			result = &val
-		} else {
-			// Accumulate into result
-			maxInputTokens := max(u.MaxInputTokens, result.MaxInputTokens)
-
-			result = &TokenUsage{
-				InputTokens:     u.InputTokens + result.InputTokens,
-				OutputTokens:    u.OutputTokens + result.OutputTokens,
-				TotalTokens:     u.TotalTokens + result.TotalTokens,
-				CachedTokens:    u.CachedTokens + result.CachedTokens,
-				ReasoningTokens: u.ReasoningTokens + result.ReasoningTokens,
-				MaxInputTokens:  maxInputTokens,
-			}
+			result = cloneUsage(u)
+			continue
 		}
+
+		result.InputTokens += u.InputTokens
+		result.CachedInputTokens += u.CachedInputTokens
+		result.CacheCreation5mTokens += u.CacheCreation5mTokens
+		result.CacheCreation1hTokens += u.CacheCreation1hTokens
+		result.ToolUseInputTokens += u.ToolUseInputTokens
+
+		result.OutputTokens += u.OutputTokens
+		result.ReasoningTokens += u.ReasoningTokens
+		result.AcceptedPredictionTokens += u.AcceptedPredictionTokens
+		result.RejectedPredictionTokens += u.RejectedPredictionTokens
+
+		result.LatencyMs += u.LatencyMs
+		result.FirstByteLatencyMs += u.FirstByteLatencyMs
+
+		if u.MaxInputTokens > result.MaxInputTokens {
+			result.MaxInputTokens = u.MaxInputTokens
+		}
+
+		if result.ServiceTier == "" {
+			result.ServiceTier = u.ServiceTier
+		}
+
+		if result.RawServiceTier == "" {
+			result.RawServiceTier = u.RawServiceTier
+		}
+
+		if result.Speed == "" {
+			result.Speed = u.Speed
+		}
+
+		if result.InferenceRegion == "" {
+			result.InferenceRegion = u.InferenceRegion
+		}
+
+		if result.InvokedModelID == "" {
+			result.InvokedModelID = u.InvokedModelID
+		}
+
+		result.ModalityInputTokens = mergeModality(result.ModalityInputTokens, u.ModalityInputTokens)
+		result.ModalityOutputTokens = mergeModality(result.ModalityOutputTokens, u.ModalityOutputTokens)
+		result.ModalityCachedInputTokens = mergeModality(result.ModalityCachedInputTokens, u.ModalityCachedInputTokens)
+		result.ServerToolRequests = mergeServerTools(result.ServerToolRequests, u.ServerToolRequests)
+		result.GuardrailUnits = mergeStringInt(result.GuardrailUnits, u.GuardrailUnits)
+		result.Extra = mergeExtra(result.Extra, u.Extra)
 	}
 
 	return result
 }
+
+func cloneUsage(u *TokenUsage) *TokenUsage {
+	out := *u
+	out.ModalityInputTokens = cloneModality(u.ModalityInputTokens)
+	out.ModalityOutputTokens = cloneModality(u.ModalityOutputTokens)
+	out.ModalityCachedInputTokens = cloneModality(u.ModalityCachedInputTokens)
+	out.ServerToolRequests = cloneServerTools(u.ServerToolRequests)
+	out.GuardrailUnits = cloneStringInt(u.GuardrailUnits)
+	out.Extra = cloneExtra(u.Extra)
+
+	return &out
+}
+
+func cloneModality(m map[Modality]int) map[Modality]int {
+	if len(m) == 0 {
+		return nil
+	}
+
+	out := make(map[Modality]int, len(m))
+	maps.Copy(out, m)
+
+	return out
+}
+
+func cloneServerTools(m map[ServerTool]int) map[ServerTool]int {
+	if len(m) == 0 {
+		return nil
+	}
+
+	out := make(map[ServerTool]int, len(m))
+	maps.Copy(out, m)
+
+	return out
+}
+
+func cloneStringInt(m map[string]int) map[string]int {
+	if len(m) == 0 {
+		return nil
+	}
+
+	out := make(map[string]int, len(m))
+	maps.Copy(out, m)
+
+	return out
+}
+
+func cloneExtra(m map[string]any) map[string]any {
+	if len(m) == 0 {
+		return nil
+	}
+
+	out := make(map[string]any, len(m))
+	maps.Copy(out, m)
+
+	return out
+}
+
+func mergeModality(dst, src map[Modality]int) map[Modality]int {
+	if len(src) == 0 {
+		return dst
+	}
+
+	if dst == nil {
+		dst = make(map[Modality]int, len(src))
+	}
+
+	for k, v := range src {
+		dst[k] += v
+	}
+
+	return dst
+}
+
+func mergeServerTools(dst, src map[ServerTool]int) map[ServerTool]int {
+	if len(src) == 0 {
+		return dst
+	}
+
+	if dst == nil {
+		dst = make(map[ServerTool]int, len(src))
+	}
+
+	for k, v := range src {
+		dst[k] += v
+	}
+
+	return dst
+}
+
+func mergeStringInt(dst, src map[string]int) map[string]int {
+	if len(src) == 0 {
+		return dst
+	}
+
+	if dst == nil {
+		dst = make(map[string]int, len(src))
+	}
+
+	for k, v := range src {
+		dst[k] += v
+	}
+
+	return dst
+}
+
+func mergeExtra(dst, src map[string]any) map[string]any {
+	if len(src) == 0 {
+		return dst
+	}
+
+	if dst == nil {
+		dst = make(map[string]any, len(src))
+	}
+
+	for k, v := range src {
+		if existing, ok := dst[k]; ok {
+			if ei, eok := existing.(int); eok {
+				if vi, vok := v.(int); vok {
+					dst[k] = ei + vi
+					continue
+				}
+			}
+			// Non-numeric collision: first writer wins.
+			continue
+		}
+
+		dst[k] = v
+	}
+
+	return dst
+}
+
+// Modality identifies the medium of a chunk of tokens.
+type Modality string
+
+// Modality constants. Providers report a subset of these.
+const (
+	ModalityText     Modality = "text"
+	ModalityImage    Modality = "image"
+	ModalityAudio    Modality = "audio"
+	ModalityVideo    Modality = "video"
+	ModalityDocument Modality = "document"
+)
+
+// ServiceTier is the normalized request-processing variant. Not every provider
+// reports every value; the empty string means default / unreported.
+type ServiceTier string
+
+// ServiceTier constants cover the union of variants across providers.
+const (
+	// ServiceTierDefault is the provider's standard tier.
+	ServiceTierDefault ServiceTier = "default"
+
+	// ServiceTierFlex is a discounted, best-effort-latency tier
+	// (OpenAI "flex", Bedrock "flex", Google ON_DEMAND_FLEX).
+	ServiceTierFlex ServiceTier = "flex"
+
+	// ServiceTierPriority is a premium, lower-latency tier
+	// (OpenAI "priority", Anthropic "priority", Bedrock "priority",
+	// Google ON_DEMAND_PRIORITY).
+	ServiceTierPriority ServiceTier = "priority"
+
+	// ServiceTierBatch is the async 50%-discount batch tier (Anthropic "batch",
+	// OpenAI Batch API). Note: OpenAI's Batch SKU is a separate endpoint, not
+	// a service_tier on the sync API; extractors set this for responses whose
+	// origin is the batch endpoint.
+	ServiceTierBatch ServiceTier = "batch"
+
+	// ServiceTierScale is OpenAI's enterprise scale tier.
+	ServiceTierScale ServiceTier = "scale"
+
+	// ServiceTierReserved is Bedrock's reserved-capacity tier.
+	ServiceTierReserved ServiceTier = "reserved"
+
+	// ServiceTierProvisionedThroughput maps Google TrafficType
+	// PROVISIONED_THROUGHPUT and Bedrock Provisioned Throughput invocations.
+	ServiceTierProvisionedThroughput ServiceTier = "provisioned_throughput"
+)
+
+// ServerTool identifies a server-side tool whose invocations are billed per
+// request (not per token). Values are lower_snake_case.
+type ServerTool string
+
+// ServerTool constants cover the known server-side billable tools across
+// providers. Custom values (via type conversion) are acceptable for
+// consumer-specific extensions.
+const (
+	ServerToolWebSearch      ServerTool = "web_search"
+	ServerToolWebFetch       ServerTool = "web_fetch"
+	ServerToolImageSearch    ServerTool = "image_search"
+	ServerToolCodeExecution  ServerTool = "code_execution"
+	ServerToolClassification ServerTool = "classification" // Cohere on Bedrock
+)
 
 // FinishReason indicates why model generation stopped.
 type FinishReason string

--- a/llm/types.go
+++ b/llm/types.go
@@ -24,8 +24,7 @@ import "maps"
 // All token counters are DISJOINT. A prompt token is counted in exactly one of
 // InputTokens, CachedInputTokens, CacheCreation5mTokens, CacheCreation1hTokens,
 // CacheCreationUnknownTTLTokens, or ToolUseInputTokens. Likewise output tokens
-// are counted in exactly one of OutputTokens, ReasoningTokens, or
-// RejectedPredictionTokens.
+// are counted in exactly one of OutputTokens or ReasoningTokens.
 //
 // This matches Anthropic's and Bedrock's native convention. OpenAI and Google
 // extractors un-subset their native values so the invariant holds uniformly
@@ -99,10 +98,8 @@ type TokenUsage struct {
 	ToolUseInputTokens int `json:"tool_use_input_tokens,omitempty"`
 
 	// OutputTokens is the number of tokens in the assistant's visible
-	// response. Does NOT include reasoning tokens (disjoint, see
-	// ReasoningTokens) or rejected predicted-output tokens (disjoint, see
-	// RejectedPredictionTokens). Does INCLUDE accepted predicted-output
-	// tokens, since those appear in the completion.
+	// response. Does NOT include reasoning tokens — those are a separate
+	// disjoint bucket (see ReasoningTokens).
 	OutputTokens int `json:"output_tokens"`
 
 	// ReasoningTokens is the number of tokens the model spent on hidden
@@ -117,47 +114,6 @@ type TokenUsage struct {
 	// Anthropic's thinking content is billed as regular output and
 	// ReasoningTokens will be zero.
 	ReasoningTokens int `json:"reasoning_tokens,omitempty"`
-
-	// RejectedPredictionTokens is the number of OpenAI Predicted Outputs
-	// tokens that did NOT appear in the completion. Billed as output but
-	// never returned to the caller, so they are disjoint from OutputTokens.
-	//
-	// Provider coverage: OpenAI only
-	// (completion_tokens_details.rejected_prediction_tokens).
-	//
-	// Note: accepted predicted-output tokens are NOT a separate counter —
-	// they appear verbatim in the completion and are already included in
-	// OutputTokens. Consumers that need the breakdown can read the raw
-	// provider response.
-	RejectedPredictionTokens int `json:"rejected_prediction_tokens,omitempty"`
-
-	// ModalityInputTokens breaks InputTokens down by modality when the
-	// provider reports it. The sum over the map equals InputTokens.
-	//
-	// Provider coverage: Google (prompt_tokens_details[]). OpenAI audio
-	// tokens are exposed here when present.
-	ModalityInputTokens map[Modality]int `json:"modality_input_tokens,omitempty"`
-
-	// ModalityOutputTokens breaks OutputTokens down by modality.
-	ModalityOutputTokens map[Modality]int `json:"modality_output_tokens,omitempty"`
-
-	// ModalityCachedInputTokens breaks CachedInputTokens down by modality.
-	ModalityCachedInputTokens map[Modality]int `json:"modality_cached_input_tokens,omitempty"`
-
-	// ServerToolRequests counts billable server-side tool invocations by
-	// kind. Each entry is one request, not a token count.
-	//
-	// Provider coverage: Anthropic (web_search, web_fetch), Google (inferred
-	// from GroundingMetadata), Cohere-on-Bedrock (search, classification).
-	ServerToolRequests map[ServerTool]int `json:"server_tool_requests,omitempty"`
-
-	// GuardrailUnits counts provider-reported guardrail policy units. Each
-	// key is an independent billing SKU on Bedrock.
-	//
-	// Provider coverage: Bedrock. Keys include "content_policy",
-	// "contextual_grounding", "sensitive_info", "sensitive_info_free",
-	// "topic_policy", "word_policy".
-	GuardrailUnits map[string]int `json:"guardrail_units,omitempty"`
 
 	// Extra carries provider-specific dimensions that the SDK does not
 	// normalize today. Keys MUST be namespaced as "<provider>.<field>" to
@@ -188,22 +144,17 @@ func (u *TokenUsage) BilledInputTokens() int {
 		u.ToolUseInputTokens
 }
 
-// BilledOutputTokens returns the total output-side tokens that contribute to
-// billing: OutputTokens + ReasoningTokens + RejectedPredictionTokens.
-//
-// AcceptedPredictionTokens are NOT added here — they appear verbatim in the
-// completion and are already counted inside OutputTokens.
+// BilledOutputTokens returns the total output-side tokens that contribute
+// to billing: OutputTokens + ReasoningTokens.
 func (u *TokenUsage) BilledOutputTokens() int {
 	if u == nil {
 		return 0
 	}
 
-	return u.OutputTokens + u.ReasoningTokens + u.RejectedPredictionTokens
+	return u.OutputTokens + u.ReasoningTokens
 }
 
-// TotalBilledTokens returns BilledInputTokens + BilledOutputTokens. Non-token
-// fees (ServerToolRequests, GuardrailUnits) are not included — those are
-// priced separately by the consumer.
+// TotalBilledTokens returns BilledInputTokens + BilledOutputTokens.
 func (u *TokenUsage) TotalBilledTokens() int {
 	return u.BilledInputTokens() + u.BilledOutputTokens()
 }
@@ -211,13 +162,12 @@ func (u *TokenUsage) TotalBilledTokens() int {
 // SumUsage aggregates multiple TokenUsage values into a single cumulative
 // result. Nil values are safely skipped. Returns nil if all inputs are nil.
 //
-// All scalar counters are added. Map fields (Modality*, ServerToolRequests,
-// GuardrailUnits, Extra) are merged with per-key addition for numeric values;
-// non-numeric Extra values take the first-writer-wins rule.
+// All scalar counters are added. The Extra map is merged with per-key addition
+// for numeric values; non-numeric Extra values take the first-writer-wins rule.
 //
 // TokenUsage intentionally contains only additive accounting fields.
-// Per-call metadata (service tier, speed, region, invoked model, latency)
-// lives on llm.Response, which is not summed.
+// Per-call metadata (service tier, speed, region, invoked model) lives on
+// llm.Response, which is not summed.
 //
 // Example:
 //
@@ -244,13 +194,7 @@ func SumUsage(usages ...*TokenUsage) *TokenUsage {
 
 		result.OutputTokens += u.OutputTokens
 		result.ReasoningTokens += u.ReasoningTokens
-		result.RejectedPredictionTokens += u.RejectedPredictionTokens
 
-		result.ModalityInputTokens = mergeModality(result.ModalityInputTokens, u.ModalityInputTokens)
-		result.ModalityOutputTokens = mergeModality(result.ModalityOutputTokens, u.ModalityOutputTokens)
-		result.ModalityCachedInputTokens = mergeModality(result.ModalityCachedInputTokens, u.ModalityCachedInputTokens)
-		result.ServerToolRequests = mergeServerTools(result.ServerToolRequests, u.ServerToolRequests)
-		result.GuardrailUnits = mergeStringInt(result.GuardrailUnits, u.GuardrailUnits)
 		result.Extra = mergeExtra(result.Extra, u.Extra)
 	}
 
@@ -259,47 +203,9 @@ func SumUsage(usages ...*TokenUsage) *TokenUsage {
 
 func cloneUsage(u *TokenUsage) *TokenUsage {
 	out := *u
-	out.ModalityInputTokens = cloneModality(u.ModalityInputTokens)
-	out.ModalityOutputTokens = cloneModality(u.ModalityOutputTokens)
-	out.ModalityCachedInputTokens = cloneModality(u.ModalityCachedInputTokens)
-	out.ServerToolRequests = cloneServerTools(u.ServerToolRequests)
-	out.GuardrailUnits = cloneStringInt(u.GuardrailUnits)
 	out.Extra = cloneExtra(u.Extra)
 
 	return &out
-}
-
-func cloneModality(m map[Modality]int) map[Modality]int {
-	if len(m) == 0 {
-		return nil
-	}
-
-	out := make(map[Modality]int, len(m))
-	maps.Copy(out, m)
-
-	return out
-}
-
-func cloneServerTools(m map[ServerTool]int) map[ServerTool]int {
-	if len(m) == 0 {
-		return nil
-	}
-
-	out := make(map[ServerTool]int, len(m))
-	maps.Copy(out, m)
-
-	return out
-}
-
-func cloneStringInt(m map[string]int) map[string]int {
-	if len(m) == 0 {
-		return nil
-	}
-
-	out := make(map[string]int, len(m))
-	maps.Copy(out, m)
-
-	return out
 }
 
 func cloneExtra(m map[string]any) map[string]any {
@@ -311,54 +217,6 @@ func cloneExtra(m map[string]any) map[string]any {
 	maps.Copy(out, m)
 
 	return out
-}
-
-func mergeModality(dst, src map[Modality]int) map[Modality]int {
-	if len(src) == 0 {
-		return dst
-	}
-
-	if dst == nil {
-		dst = make(map[Modality]int, len(src))
-	}
-
-	for k, v := range src {
-		dst[k] += v
-	}
-
-	return dst
-}
-
-func mergeServerTools(dst, src map[ServerTool]int) map[ServerTool]int {
-	if len(src) == 0 {
-		return dst
-	}
-
-	if dst == nil {
-		dst = make(map[ServerTool]int, len(src))
-	}
-
-	for k, v := range src {
-		dst[k] += v
-	}
-
-	return dst
-}
-
-func mergeStringInt(dst, src map[string]int) map[string]int {
-	if len(src) == 0 {
-		return dst
-	}
-
-	if dst == nil {
-		dst = make(map[string]int, len(src))
-	}
-
-	for k, v := range src {
-		dst[k] += v
-	}
-
-	return dst
 }
 
 func mergeExtra(dst, src map[string]any) map[string]any {
@@ -387,18 +245,6 @@ func mergeExtra(dst, src map[string]any) map[string]any {
 
 	return dst
 }
-
-// Modality identifies the medium of a chunk of tokens.
-type Modality string
-
-// Modality constants. Providers report a subset of these.
-const (
-	ModalityText     Modality = "text"
-	ModalityImage    Modality = "image"
-	ModalityAudio    Modality = "audio"
-	ModalityVideo    Modality = "video"
-	ModalityDocument Modality = "document"
-)
 
 // ServiceTier is the normalized request-processing variant reported on
 // llm.Response. Not every provider reports every value; the empty string
@@ -434,21 +280,6 @@ const (
 	// ServiceTierProvisionedThroughput maps Google TrafficType
 	// PROVISIONED_THROUGHPUT and Bedrock Provisioned Throughput invocations.
 	ServiceTierProvisionedThroughput ServiceTier = "provisioned_throughput"
-)
-
-// ServerTool identifies a server-side tool whose invocations are billed per
-// request (not per token). Values are lower_snake_case.
-type ServerTool string
-
-// ServerTool constants cover the known server-side billable tools across
-// providers. Custom values (via type conversion) are acceptable for
-// consumer-specific extensions.
-const (
-	ServerToolWebSearch      ServerTool = "web_search"
-	ServerToolWebFetch       ServerTool = "web_fetch"
-	ServerToolImageSearch    ServerTool = "image_search"
-	ServerToolCodeExecution  ServerTool = "code_execution"
-	ServerToolClassification ServerTool = "classification" // Cohere on Bedrock
 )
 
 // FinishReason indicates why model generation stopped.

--- a/llm/types_test.go
+++ b/llm/types_test.go
@@ -77,15 +77,6 @@ func TestTokenUsage_BilledOutputTokens(t *testing.T) {
 			},
 			want: 75,
 		},
-		{
-			name: "rejected predictions add; accepted are already in output",
-			usage: &TokenUsage{
-				OutputTokens:             40,
-				ReasoningTokens:          0,
-				RejectedPredictionTokens: 5,
-			},
-			want: 45,
-		},
 	}
 
 	for _, tt := range tests {
@@ -137,8 +128,6 @@ func TestSumUsage(t *testing.T) {
 					CacheCreation5mTokens: 5,
 					OutputTokens:          50,
 					ReasoningTokens:       5,
-					ModalityInputTokens:   map[Modality]int{ModalityText: 100},
-					ServerToolRequests:    map[ServerTool]int{ServerToolWebSearch: 2},
 					Extra:                 map[string]any{"provider.flag": true},
 				},
 			},
@@ -148,22 +137,18 @@ func TestSumUsage(t *testing.T) {
 				CacheCreation5mTokens: 5,
 				OutputTokens:          50,
 				ReasoningTokens:       5,
-				ModalityInputTokens:   map[Modality]int{ModalityText: 100},
-				ServerToolRequests:    map[ServerTool]int{ServerToolWebSearch: 2},
 				Extra:                 map[string]any{"provider.flag": true},
 			},
 		},
 		{
-			name: "scalars add, maps merge",
+			name: "scalars add, extra merges",
 			usages: []*TokenUsage{
 				{
-					InputTokens:         100,
-					CachedInputTokens:   10,
-					OutputTokens:        50,
-					ReasoningTokens:     5,
-					ModalityInputTokens: map[Modality]int{ModalityText: 80, ModalityImage: 20},
-					ServerToolRequests:  map[ServerTool]int{ServerToolWebSearch: 2},
-					GuardrailUnits:      map[string]int{"content_policy": 1},
+					InputTokens:       100,
+					CachedInputTokens: 10,
+					OutputTokens:      50,
+					ReasoningTokens:   5,
+					Extra:             map[string]any{"bedrock.cache_write_ttl_1d_tokens": 8},
 				},
 				{
 					InputTokens:                   200,
@@ -171,10 +156,7 @@ func TestSumUsage(t *testing.T) {
 					CacheCreationUnknownTTLTokens: 3,
 					OutputTokens:                  100,
 					ReasoningTokens:               10,
-					RejectedPredictionTokens:      7,
-					ModalityInputTokens:           map[Modality]int{ModalityText: 150, ModalityAudio: 50},
-					ServerToolRequests:            map[ServerTool]int{ServerToolWebSearch: 1, ServerToolWebFetch: 3},
-					GuardrailUnits:                map[string]int{"content_policy": 2, "topic_policy": 1},
+					Extra:                         map[string]any{"bedrock.cache_write_ttl_1d_tokens": 7},
 				},
 			},
 			expected: &TokenUsage{
@@ -184,17 +166,7 @@ func TestSumUsage(t *testing.T) {
 				CacheCreationUnknownTTLTokens: 3,
 				OutputTokens:                  150,
 				ReasoningTokens:               15,
-				RejectedPredictionTokens:      7,
-				ModalityInputTokens: map[Modality]int{
-					ModalityText:  230,
-					ModalityImage: 20,
-					ModalityAudio: 50,
-				},
-				ServerToolRequests: map[ServerTool]int{
-					ServerToolWebSearch: 3,
-					ServerToolWebFetch:  3,
-				},
-				GuardrailUnits: map[string]int{"content_policy": 3, "topic_policy": 1},
+				Extra:                         map[string]any{"bedrock.cache_write_ttl_1d_tokens": 15},
 			},
 		},
 		{
@@ -227,13 +199,13 @@ func TestSumUsage(t *testing.T) {
 func TestSumUsage_NoAliasing(t *testing.T) {
 	t.Parallel()
 
-	original := map[Modality]int{ModalityText: 100}
-	a := &TokenUsage{InputTokens: 10, ModalityInputTokens: original}
-	b := &TokenUsage{InputTokens: 5, ModalityInputTokens: map[Modality]int{ModalityText: 50}}
+	original := map[string]any{"provider.x": 100}
+	a := &TokenUsage{InputTokens: 10, Extra: original}
+	b := &TokenUsage{InputTokens: 5, Extra: map[string]any{"provider.x": 50}}
 
 	result := SumUsage(a, b)
 
-	assert.Equal(t, 150, result.ModalityInputTokens[ModalityText])
-	assert.Equal(t, 100, original[ModalityText], "SumUsage must not mutate the first input's map")
-	assert.NotSame(t, &original, &result.ModalityInputTokens, "result must not alias the first input's map")
+	assert.Equal(t, 150, result.Extra["provider.x"])
+	assert.Equal(t, 100, original["provider.x"], "SumUsage must not mutate the first input's Extra map")
+	assert.NotSame(t, &original, &result.Extra, "result must not alias the first input's Extra map")
 }

--- a/llm/types_test.go
+++ b/llm/types_test.go
@@ -33,13 +33,14 @@ func TestTokenUsage_BilledInputTokens(t *testing.T) {
 		{
 			name: "all input buckets disjoint and summed",
 			usage: &TokenUsage{
-				InputTokens:           100,
-				CachedInputTokens:     50,
-				CacheCreation5mTokens: 30,
-				CacheCreation1hTokens: 20,
-				ToolUseInputTokens:    10,
+				InputTokens:                   100,
+				CachedInputTokens:             50,
+				CacheCreation5mTokens:         30,
+				CacheCreation1hTokens:         20,
+				CacheCreationUnknownTTLTokens: 5,
+				ToolUseInputTokens:            10,
 			},
-			want: 210,
+			want: 215,
 		},
 		{
 			name: "only fresh input",
@@ -77,14 +78,13 @@ func TestTokenUsage_BilledOutputTokens(t *testing.T) {
 			want: 75,
 		},
 		{
-			name: "with predicted outputs",
+			name: "rejected predictions add; accepted are already in output",
 			usage: &TokenUsage{
 				OutputTokens:             40,
 				ReasoningTokens:          0,
-				AcceptedPredictionTokens: 10,
 				RejectedPredictionTokens: 5,
 			},
-			want: 55,
+			want: 45,
 		},
 	}
 
@@ -100,13 +100,14 @@ func TestTokenUsage_TotalBilledTokens(t *testing.T) {
 	t.Parallel()
 
 	u := &TokenUsage{
-		InputTokens:           100,
-		CachedInputTokens:     50,
-		CacheCreation5mTokens: 30,
-		OutputTokens:          40,
-		ReasoningTokens:       10,
+		InputTokens:                   100,
+		CachedInputTokens:             50,
+		CacheCreation5mTokens:         30,
+		CacheCreationUnknownTTLTokens: 10,
+		OutputTokens:                  40,
+		ReasoningTokens:               10,
 	}
-	assert.Equal(t, 230, u.TotalBilledTokens())
+	assert.Equal(t, 240, u.TotalBilledTokens())
 }
 
 func TestSumUsage(t *testing.T) {
@@ -165,21 +166,25 @@ func TestSumUsage(t *testing.T) {
 					GuardrailUnits:      map[string]int{"content_policy": 1},
 				},
 				{
-					InputTokens:           200,
-					CacheCreation5mTokens: 25,
-					OutputTokens:          100,
-					ReasoningTokens:       10,
-					ModalityInputTokens:   map[Modality]int{ModalityText: 150, ModalityAudio: 50},
-					ServerToolRequests:    map[ServerTool]int{ServerToolWebSearch: 1, ServerToolWebFetch: 3},
-					GuardrailUnits:        map[string]int{"content_policy": 2, "topic_policy": 1},
+					InputTokens:                   200,
+					CacheCreation5mTokens:         25,
+					CacheCreationUnknownTTLTokens: 3,
+					OutputTokens:                  100,
+					ReasoningTokens:               10,
+					RejectedPredictionTokens:      7,
+					ModalityInputTokens:           map[Modality]int{ModalityText: 150, ModalityAudio: 50},
+					ServerToolRequests:            map[ServerTool]int{ServerToolWebSearch: 1, ServerToolWebFetch: 3},
+					GuardrailUnits:                map[string]int{"content_policy": 2, "topic_policy": 1},
 				},
 			},
 			expected: &TokenUsage{
-				InputTokens:           300,
-				CachedInputTokens:     10,
-				CacheCreation5mTokens: 25,
-				OutputTokens:          150,
-				ReasoningTokens:       15,
+				InputTokens:                   300,
+				CachedInputTokens:             10,
+				CacheCreation5mTokens:         25,
+				CacheCreationUnknownTTLTokens: 3,
+				OutputTokens:                  150,
+				ReasoningTokens:               15,
+				RejectedPredictionTokens:      7,
 				ModalityInputTokens: map[Modality]int{
 					ModalityText:  230,
 					ModalityImage: 20,
@@ -190,29 +195,6 @@ func TestSumUsage(t *testing.T) {
 					ServerToolWebFetch:  3,
 				},
 				GuardrailUnits: map[string]int{"content_policy": 3, "topic_policy": 1},
-			},
-		},
-		{
-			name: "first non-empty string wins",
-			usages: []*TokenUsage{
-				{InputTokens: 10, ServiceTier: ServiceTierPriority, Speed: "fast"},
-				{InputTokens: 20, ServiceTier: ServiceTierDefault, Speed: "standard"},
-			},
-			expected: &TokenUsage{
-				InputTokens: 30,
-				ServiceTier: ServiceTierPriority,
-				Speed:       "fast",
-			},
-		},
-		{
-			name: "MaxInputTokens takes max",
-			usages: []*TokenUsage{
-				{InputTokens: 1, MaxInputTokens: 128_000},
-				{InputTokens: 1, MaxInputTokens: 200_000},
-			},
-			expected: &TokenUsage{
-				InputTokens:    2,
-				MaxInputTokens: 200_000,
 			},
 		},
 		{

--- a/llm/types_test.go
+++ b/llm/types_test.go
@@ -20,6 +20,95 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestTokenUsage_BilledInputTokens(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		usage *TokenUsage
+		want  int
+	}{
+		{"nil", nil, 0},
+		{"zero", &TokenUsage{}, 0},
+		{
+			name: "all input buckets disjoint and summed",
+			usage: &TokenUsage{
+				InputTokens:           100,
+				CachedInputTokens:     50,
+				CacheCreation5mTokens: 30,
+				CacheCreation1hTokens: 20,
+				ToolUseInputTokens:    10,
+			},
+			want: 210,
+		},
+		{
+			name: "only fresh input",
+			usage: &TokenUsage{
+				InputTokens: 75,
+			},
+			want: 75,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, tt.usage.BilledInputTokens())
+		})
+	}
+}
+
+func TestTokenUsage_BilledOutputTokens(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		usage *TokenUsage
+		want  int
+	}{
+		{"nil", nil, 0},
+		{"zero", &TokenUsage{}, 0},
+		{
+			name: "output + reasoning disjoint",
+			usage: &TokenUsage{
+				OutputTokens:    50,
+				ReasoningTokens: 25,
+			},
+			want: 75,
+		},
+		{
+			name: "with predicted outputs",
+			usage: &TokenUsage{
+				OutputTokens:             40,
+				ReasoningTokens:          0,
+				AcceptedPredictionTokens: 10,
+				RejectedPredictionTokens: 5,
+			},
+			want: 55,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, tt.usage.BilledOutputTokens())
+		})
+	}
+}
+
+func TestTokenUsage_TotalBilledTokens(t *testing.T) {
+	t.Parallel()
+
+	u := &TokenUsage{
+		InputTokens:           100,
+		CachedInputTokens:     50,
+		CacheCreation5mTokens: 30,
+		OutputTokens:          40,
+		ReasoningTokens:       10,
+	}
+	assert.Equal(t, 230, u.TotalBilledTokens())
+}
+
 func TestSumUsage(t *testing.T) {
 	t.Parallel()
 
@@ -39,78 +128,105 @@ func TestSumUsage(t *testing.T) {
 			expected: nil,
 		},
 		{
-			name: "single usage",
+			name: "single usage is deep-copied",
 			usages: []*TokenUsage{
 				{
-					InputTokens:     100,
-					OutputTokens:    50,
-					TotalTokens:     150,
-					CachedTokens:    10,
-					ReasoningTokens: 5,
+					InputTokens:           100,
+					CachedInputTokens:     10,
+					CacheCreation5mTokens: 5,
+					OutputTokens:          50,
+					ReasoningTokens:       5,
+					ModalityInputTokens:   map[Modality]int{ModalityText: 100},
+					ServerToolRequests:    map[ServerTool]int{ServerToolWebSearch: 2},
+					Extra:                 map[string]any{"provider.flag": true},
 				},
 			},
 			expected: &TokenUsage{
-				InputTokens:     100,
-				OutputTokens:    50,
-				TotalTokens:     150,
-				CachedTokens:    10,
-				ReasoningTokens: 5,
+				InputTokens:           100,
+				CachedInputTokens:     10,
+				CacheCreation5mTokens: 5,
+				OutputTokens:          50,
+				ReasoningTokens:       5,
+				ModalityInputTokens:   map[Modality]int{ModalityText: 100},
+				ServerToolRequests:    map[ServerTool]int{ServerToolWebSearch: 2},
+				Extra:                 map[string]any{"provider.flag": true},
 			},
 		},
 		{
-			name: "multiple usages",
+			name: "scalars add, maps merge",
 			usages: []*TokenUsage{
 				{
-					InputTokens:     100,
-					OutputTokens:    50,
-					TotalTokens:     150,
-					CachedTokens:    10,
-					ReasoningTokens: 5,
+					InputTokens:         100,
+					CachedInputTokens:   10,
+					OutputTokens:        50,
+					ReasoningTokens:     5,
+					ModalityInputTokens: map[Modality]int{ModalityText: 80, ModalityImage: 20},
+					ServerToolRequests:  map[ServerTool]int{ServerToolWebSearch: 2},
+					GuardrailUnits:      map[string]int{"content_policy": 1},
 				},
 				{
-					InputTokens:     200,
-					OutputTokens:    100,
-					TotalTokens:     300,
-					CachedTokens:    20,
-					ReasoningTokens: 10,
-				},
-				{
-					InputTokens:     50,
-					OutputTokens:    25,
-					TotalTokens:     75,
-					CachedTokens:    5,
-					ReasoningTokens: 2,
+					InputTokens:           200,
+					CacheCreation5mTokens: 25,
+					OutputTokens:          100,
+					ReasoningTokens:       10,
+					ModalityInputTokens:   map[Modality]int{ModalityText: 150, ModalityAudio: 50},
+					ServerToolRequests:    map[ServerTool]int{ServerToolWebSearch: 1, ServerToolWebFetch: 3},
+					GuardrailUnits:        map[string]int{"content_policy": 2, "topic_policy": 1},
 				},
 			},
 			expected: &TokenUsage{
-				InputTokens:     350,
-				OutputTokens:    175,
-				TotalTokens:     525,
-				CachedTokens:    35,
-				ReasoningTokens: 17,
+				InputTokens:           300,
+				CachedInputTokens:     10,
+				CacheCreation5mTokens: 25,
+				OutputTokens:          150,
+				ReasoningTokens:       15,
+				ModalityInputTokens: map[Modality]int{
+					ModalityText:  230,
+					ModalityImage: 20,
+					ModalityAudio: 50,
+				},
+				ServerToolRequests: map[ServerTool]int{
+					ServerToolWebSearch: 3,
+					ServerToolWebFetch:  3,
+				},
+				GuardrailUnits: map[string]int{"content_policy": 3, "topic_policy": 1},
+			},
+		},
+		{
+			name: "first non-empty string wins",
+			usages: []*TokenUsage{
+				{InputTokens: 10, ServiceTier: ServiceTierPriority, Speed: "fast"},
+				{InputTokens: 20, ServiceTier: ServiceTierDefault, Speed: "standard"},
+			},
+			expected: &TokenUsage{
+				InputTokens: 30,
+				ServiceTier: ServiceTierPriority,
+				Speed:       "fast",
+			},
+		},
+		{
+			name: "MaxInputTokens takes max",
+			usages: []*TokenUsage{
+				{InputTokens: 1, MaxInputTokens: 128_000},
+				{InputTokens: 1, MaxInputTokens: 200_000},
+			},
+			expected: &TokenUsage{
+				InputTokens:    2,
+				MaxInputTokens: 200_000,
 			},
 		},
 		{
 			name: "mix of nil and non-nil",
 			usages: []*TokenUsage{
 				nil,
-				{
-					InputTokens:  100,
-					OutputTokens: 50,
-					TotalTokens:  150,
-				},
+				{InputTokens: 100, OutputTokens: 50},
 				nil,
-				{
-					InputTokens:  200,
-					OutputTokens: 100,
-					TotalTokens:  300,
-				},
+				{InputTokens: 200, OutputTokens: 100},
 				nil,
 			},
 			expected: &TokenUsage{
 				InputTokens:  300,
 				OutputTokens: 150,
-				TotalTokens:  450,
 			},
 		},
 	}
@@ -118,9 +234,24 @@ func TestSumUsage(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-
 			result := SumUsage(tt.usages...)
 			assert.Equal(t, tt.expected, result)
 		})
 	}
+}
+
+// TestSumUsage_NoAliasing verifies that SumUsage does not mutate input maps
+// or cause aliasing between inputs and the result.
+func TestSumUsage_NoAliasing(t *testing.T) {
+	t.Parallel()
+
+	original := map[Modality]int{ModalityText: 100}
+	a := &TokenUsage{InputTokens: 10, ModalityInputTokens: original}
+	b := &TokenUsage{InputTokens: 5, ModalityInputTokens: map[Modality]int{ModalityText: 50}}
+
+	result := SumUsage(a, b)
+
+	assert.Equal(t, 150, result.ModalityInputTokens[ModalityText])
+	assert.Equal(t, 100, original[ModalityText], "SumUsage must not mutate the first input's map")
+	assert.NotSame(t, &original, &result.ModalityInputTokens, "result must not alias the first input's map")
 }

--- a/plugins/otel/otel_test.go
+++ b/plugins/otel/otel_test.go
@@ -1203,7 +1203,7 @@ func TestTracingInterceptor_CacheReadTokens_OnModelSpan(t *testing.T) {
 					Usage: &llm.TokenUsage{
 						InputTokens:  100,
 						OutputTokens: 50,
-						CachedTokens: 75,
+						CachedInputTokens: 75,
 					},
 					ID: "resp-cache",
 				}, nil
@@ -1290,7 +1290,7 @@ func TestTracingInterceptor_CacheReadTokens_OnInvocationSpan(t *testing.T) {
 		agent.AddUsage(inv, &llm.TokenUsage{
 			InputTokens:  100,
 			OutputTokens: 50,
-			CachedTokens: 30,
+			CachedInputTokens: 30,
 		})
 
 		return agent.FinishReasonStop, nil

--- a/plugins/otel/utils.go
+++ b/plugins/otel/utils.go
@@ -89,8 +89,8 @@ func setUsageAttributes(span trace.Span, usage *llm.TokenUsage) {
 		genAIUsageInputTokens(usage.InputTokens),
 		genAIUsageOutputTokens(usage.OutputTokens),
 	}
-	if usage.CachedTokens > 0 {
-		attrs = append(attrs, genAIUsageCacheReadInputTokens(usage.CachedTokens))
+	if usage.CachedInputTokens > 0 {
+		attrs = append(attrs, genAIUsageCacheReadInputTokens(usage.CachedInputTokens))
 	}
 
 	span.SetAttributes(attrs...)

--- a/providers/anthropic/anthropic_conformance_test.go
+++ b/providers/anthropic/anthropic_conformance_test.go
@@ -149,5 +149,5 @@ func TestAnthropicAdaptiveThinking_Integration(t *testing.T) {
 	assert.True(t, hasText, "expected text content in response")
 	assert.True(t, hasReasoning, "expected reasoning content from adaptive thinking")
 	require.NotNil(t, resp.Usage)
-	assert.Positive(t, resp.Usage.TotalTokens, "expected non-zero token usage")
+	assert.Positive(t, resp.Usage.TotalBilledTokens(), "expected non-zero token usage")
 }

--- a/providers/anthropic/cache_test.go
+++ b/providers/anthropic/cache_test.go
@@ -76,7 +76,7 @@ func TestAnthropicCachedTokens_Integration(t *testing.T) {
 	require.NotNil(t, response1.Usage)
 
 	t.Logf("Request 1 - InputTokens: %d, OutputTokens: %d, CachedTokens: %d",
-		response1.Usage.InputTokens, response1.Usage.OutputTokens, response1.Usage.CachedTokens)
+		response1.Usage.InputTokens, response1.Usage.OutputTokens, response1.Usage.CachedInputTokens)
 
 	// Request 2 - Should hit cache on system message
 	request2 := &llm.Request{
@@ -97,7 +97,7 @@ func TestAnthropicCachedTokens_Integration(t *testing.T) {
 	require.NotNil(t, response2.Usage)
 
 	t.Logf("Request 2 - InputTokens: %d, OutputTokens: %d, CachedTokens: %d",
-		response2.Usage.InputTokens, response2.Usage.OutputTokens, response2.Usage.CachedTokens)
+		response2.Usage.InputTokens, response2.Usage.OutputTokens, response2.Usage.CachedInputTokens)
 
 	// Request 3 - Should hit cache on system message
 	request3 := &llm.Request{
@@ -118,15 +118,15 @@ func TestAnthropicCachedTokens_Integration(t *testing.T) {
 	require.NotNil(t, response3.Usage)
 
 	t.Logf("Request 3 - InputTokens: %d, OutputTokens: %d, CachedTokens: %d",
-		response3.Usage.InputTokens, response3.Usage.OutputTokens, response3.Usage.CachedTokens)
+		response3.Usage.InputTokens, response3.Usage.OutputTokens, response3.Usage.CachedInputTokens)
 
 	// Verify all responses have the CachedTokens field populated
-	assert.GreaterOrEqual(t, response1.Usage.CachedTokens, 0)
-	assert.GreaterOrEqual(t, response2.Usage.CachedTokens, 0)
-	assert.GreaterOrEqual(t, response3.Usage.CachedTokens, 0)
+	assert.GreaterOrEqual(t, response1.Usage.CachedInputTokens, 0)
+	assert.GreaterOrEqual(t, response2.Usage.CachedInputTokens, 0)
+	assert.GreaterOrEqual(t, response3.Usage.CachedInputTokens, 0)
 
 	// Check if any requests show cached tokens (requests 2-3 should hit the cached system prompt)
-	totalCached := response2.Usage.CachedTokens + response3.Usage.CachedTokens
+	totalCached := response2.Usage.CachedInputTokens + response3.Usage.CachedInputTokens
 
 	// Anthropic should show caching on subsequent requests that reuse the system prompt
 	require.Positive(t, totalCached, "Expected cached tokens when reusing system prompt with cache_control marker")

--- a/providers/anthropic/response_mapper.go
+++ b/providers/anthropic/response_mapper.go
@@ -91,19 +91,31 @@ func (m *ResponseMapper) FromProvider(r *anthropic.BetaMessage) (*llm.Response, 
 
 	// Extract usage information. Anthropic's input_tokens, cache_read_input_tokens,
 	// and cache_creation_input_tokens are disjoint — map them directly onto the
-	// SDK's disjoint buckets.
+	// SDK's disjoint buckets. The per-TTL breakdown lives in
+	// usage.cache_creation.ephemeral_{5m,1h}_input_tokens; if that breakdown
+	// is absent or covers fewer tokens than the aggregate
+	// cache_creation_input_tokens (older API response shapes), route the
+	// remainder to CacheCreationUnknownTTLTokens so BilledInputTokens() stays
+	// accurate. Anthropic thinking/extended-reasoning tokens are billed as
+	// regular output tokens and are not reported separately in usage.
 	var usage *llm.TokenUsage
 	if r.Usage.InputTokens > 0 || r.Usage.OutputTokens > 0 ||
 		r.Usage.CacheReadInputTokens > 0 || r.Usage.CacheCreationInputTokens > 0 {
+		ephemeral5m := int(r.Usage.CacheCreation.Ephemeral5mInputTokens)
+		ephemeral1h := int(r.Usage.CacheCreation.Ephemeral1hInputTokens)
+
+		var unknownTTL int
+		if aggregate := int(r.Usage.CacheCreationInputTokens); aggregate > ephemeral5m+ephemeral1h {
+			unknownTTL = aggregate - ephemeral5m - ephemeral1h
+		}
+
 		usage = &llm.TokenUsage{
-			InputTokens:           int(r.Usage.InputTokens),
-			CachedInputTokens:     int(r.Usage.CacheReadInputTokens),
-			CacheCreation5mTokens: int(r.Usage.CacheCreation.Ephemeral5mInputTokens),
-			CacheCreation1hTokens: int(r.Usage.CacheCreation.Ephemeral1hInputTokens),
-			OutputTokens:          int(r.Usage.OutputTokens),
-			// Anthropic thinking/extended-reasoning tokens are billed as regular
-			// output tokens and are not reported separately in usage.
-			MaxInputTokens: m.modelDefinition.Constraints.MaxInputTokens,
+			InputTokens:                   int(r.Usage.InputTokens),
+			CachedInputTokens:             int(r.Usage.CacheReadInputTokens),
+			CacheCreation5mTokens:         ephemeral5m,
+			CacheCreation1hTokens:         ephemeral1h,
+			CacheCreationUnknownTTLTokens: unknownTTL,
+			OutputTokens:                  int(r.Usage.OutputTokens),
 		}
 	}
 

--- a/providers/anthropic/response_mapper.go
+++ b/providers/anthropic/response_mapper.go
@@ -99,6 +99,7 @@ func (m *ResponseMapper) FromProvider(r *anthropic.BetaMessage) (*llm.Response, 
 	// accurate. Anthropic thinking/extended-reasoning tokens are billed as
 	// regular output tokens and are not reported separately in usage.
 	var usage *llm.TokenUsage
+
 	if r.Usage.InputTokens > 0 || r.Usage.OutputTokens > 0 ||
 		r.Usage.CacheReadInputTokens > 0 || r.Usage.CacheCreationInputTokens > 0 {
 		ephemeral5m := int(r.Usage.CacheCreation.Ephemeral5mInputTokens)

--- a/providers/anthropic/response_mapper.go
+++ b/providers/anthropic/response_mapper.go
@@ -89,16 +89,21 @@ func (m *ResponseMapper) FromProvider(r *anthropic.BetaMessage) (*llm.Response, 
 		}
 	}
 
-	// Extract usage information
+	// Extract usage information. Anthropic's input_tokens, cache_read_input_tokens,
+	// and cache_creation_input_tokens are disjoint — map them directly onto the
+	// SDK's disjoint buckets.
 	var usage *llm.TokenUsage
-	if r.Usage.InputTokens > 0 || r.Usage.OutputTokens > 0 {
+	if r.Usage.InputTokens > 0 || r.Usage.OutputTokens > 0 ||
+		r.Usage.CacheReadInputTokens > 0 || r.Usage.CacheCreationInputTokens > 0 {
 		usage = &llm.TokenUsage{
-			InputTokens:     int(r.Usage.InputTokens),
-			OutputTokens:    int(r.Usage.OutputTokens),
-			TotalTokens:     int(r.Usage.InputTokens + r.Usage.OutputTokens),
-			CachedTokens:    int(r.Usage.CacheReadInputTokens),
-			ReasoningTokens: 0, // Anthropic doesn't separate reasoning tokens in usage
-			MaxInputTokens:  m.modelDefinition.Constraints.MaxInputTokens,
+			InputTokens:           int(r.Usage.InputTokens),
+			CachedInputTokens:     int(r.Usage.CacheReadInputTokens),
+			CacheCreation5mTokens: int(r.Usage.CacheCreation.Ephemeral5mInputTokens),
+			CacheCreation1hTokens: int(r.Usage.CacheCreation.Ephemeral1hInputTokens),
+			OutputTokens:          int(r.Usage.OutputTokens),
+			// Anthropic thinking/extended-reasoning tokens are billed as regular
+			// output tokens and are not reported separately in usage.
+			MaxInputTokens: m.modelDefinition.Constraints.MaxInputTokens,
 		}
 	}
 

--- a/providers/bedrock/provider_test.go
+++ b/providers/bedrock/provider_test.go
@@ -701,7 +701,7 @@ func TestResponseMapper_TextResponse(t *testing.T) {
 	require.NotNil(t, resp.Usage)
 	assert.Equal(t, 10, resp.Usage.InputTokens)
 	assert.Equal(t, 8, resp.Usage.OutputTokens)
-	assert.Equal(t, 18, resp.Usage.TotalTokens)
+	assert.Equal(t, 18, resp.Usage.TotalBilledTokens())
 }
 
 func TestResponseMapper_ToolUseResponse(t *testing.T) {
@@ -799,7 +799,7 @@ func TestResponseMapper_CachedTokens(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.NotNil(t, resp.Usage)
-	assert.Equal(t, 80, resp.Usage.CachedTokens)
+	assert.Equal(t, 80, resp.Usage.CachedInputTokens)
 }
 
 // ---------- Models discovery ----------

--- a/providers/bedrock/response_mapper.go
+++ b/providers/bedrock/response_mapper.go
@@ -210,6 +210,7 @@ func (m *ResponseMapper) mapTokenUsage(usage *types.TokenUsage) *llm.TokenUsage 
 	}
 
 	var knownBreakdownTokens int
+
 	for _, detail := range usage.CacheDetails {
 		if detail.InputTokens == nil {
 			continue

--- a/providers/bedrock/response_mapper.go
+++ b/providers/bedrock/response_mapper.go
@@ -183,7 +183,10 @@ func (m *ResponseMapper) mapReasoningBlock(value types.ReasoningContentBlock) *l
 	})
 }
 
-// mapTokenUsage converts Bedrock TokenUsage to llm.TokenUsage.
+// mapTokenUsage converts Bedrock TokenUsage to llm.TokenUsage. Bedrock
+// Converse's InputTokens, CacheReadInputTokens, and CacheWriteInputTokens are
+// already disjoint, matching the normalized shape directly. Per-TTL write
+// breakdown from CacheDetails is split into 5m / 1h buckets.
 func (m *ResponseMapper) mapTokenUsage(usage *types.TokenUsage) *llm.TokenUsage {
 	result := &llm.TokenUsage{
 		MaxInputTokens: m.modelDefinition.Constraints.MaxInputTokens,
@@ -197,12 +200,36 @@ func (m *ResponseMapper) mapTokenUsage(usage *types.TokenUsage) *llm.TokenUsage 
 		result.OutputTokens = int(*usage.OutputTokens)
 	}
 
-	if usage.TotalTokens != nil {
-		result.TotalTokens = int(*usage.TotalTokens)
+	if usage.CacheReadInputTokens != nil {
+		result.CachedInputTokens = int(*usage.CacheReadInputTokens)
 	}
 
-	if usage.CacheReadInputTokens != nil {
-		result.CachedTokens = int(*usage.CacheReadInputTokens)
+	// CacheDetails breaks cache writes down by TTL. Split into 5m / 1h
+	// buckets; other TTL values (if Bedrock introduces them) fall through
+	// to Extra for consumer-side handling.
+	for _, detail := range usage.CacheDetails {
+		if detail.InputTokens == nil {
+			continue
+		}
+
+		tokens := int(*detail.InputTokens)
+		switch detail.Ttl {
+		case types.CacheTTLFiveMinutes:
+			result.CacheCreation5mTokens += tokens
+		case types.CacheTTLOneHour:
+			result.CacheCreation1hTokens += tokens
+		default:
+			if result.Extra == nil {
+				result.Extra = make(map[string]any)
+			}
+
+			key := "bedrock.cache_write_ttl_" + string(detail.Ttl) + "_tokens"
+			if existing, ok := result.Extra[key].(int); ok {
+				result.Extra[key] = existing + tokens
+			} else {
+				result.Extra[key] = tokens
+			}
+		}
 	}
 
 	return result

--- a/providers/bedrock/response_mapper.go
+++ b/providers/bedrock/response_mapper.go
@@ -185,12 +185,17 @@ func (m *ResponseMapper) mapReasoningBlock(value types.ReasoningContentBlock) *l
 
 // mapTokenUsage converts Bedrock TokenUsage to llm.TokenUsage. Bedrock
 // Converse's InputTokens, CacheReadInputTokens, and CacheWriteInputTokens are
-// already disjoint, matching the normalized shape directly. Per-TTL write
-// breakdown from CacheDetails is split into 5m / 1h buckets.
+// already disjoint, matching the normalized shape directly.
+//
+// Per-TTL write breakdown from CacheDetails is split into 5m / 1h buckets
+// when present. If CacheDetails is missing or covers fewer tokens than the
+// aggregate CacheWriteInputTokens, the remainder is routed to
+// CacheCreationUnknownTTLTokens so BilledInputTokens() reflects the full
+// provider-reported billable amount. Unknown TTL string values (if Bedrock
+// introduces more) are still recorded in Extra for audit, in addition to
+// being counted in the unknown-TTL aggregate.
 func (m *ResponseMapper) mapTokenUsage(usage *types.TokenUsage) *llm.TokenUsage {
-	result := &llm.TokenUsage{
-		MaxInputTokens: m.modelDefinition.Constraints.MaxInputTokens,
-	}
+	result := &llm.TokenUsage{}
 
 	if usage.InputTokens != nil {
 		result.InputTokens = int(*usage.InputTokens)
@@ -204,9 +209,7 @@ func (m *ResponseMapper) mapTokenUsage(usage *types.TokenUsage) *llm.TokenUsage 
 		result.CachedInputTokens = int(*usage.CacheReadInputTokens)
 	}
 
-	// CacheDetails breaks cache writes down by TTL. Split into 5m / 1h
-	// buckets; other TTL values (if Bedrock introduces them) fall through
-	// to Extra for consumer-side handling.
+	var knownBreakdownTokens int
 	for _, detail := range usage.CacheDetails {
 		if detail.InputTokens == nil {
 			continue
@@ -216,9 +219,17 @@ func (m *ResponseMapper) mapTokenUsage(usage *types.TokenUsage) *llm.TokenUsage 
 		switch detail.Ttl {
 		case types.CacheTTLFiveMinutes:
 			result.CacheCreation5mTokens += tokens
+			knownBreakdownTokens += tokens
 		case types.CacheTTLOneHour:
 			result.CacheCreation1hTokens += tokens
+			knownBreakdownTokens += tokens
 		default:
+			// Unknown TTL string — count toward the billable total via the
+			// unknown-TTL bucket, and also record the raw TTL in Extra for
+			// audit so consumers can see the actual value Bedrock reported.
+			result.CacheCreationUnknownTTLTokens += tokens
+			knownBreakdownTokens += tokens
+
 			if result.Extra == nil {
 				result.Extra = make(map[string]any)
 			}
@@ -229,6 +240,18 @@ func (m *ResponseMapper) mapTokenUsage(usage *types.TokenUsage) *llm.TokenUsage 
 			} else {
 				result.Extra[key] = tokens
 			}
+		}
+	}
+
+	// Fallback: if the aggregate CacheWriteInputTokens is larger than the
+	// per-TTL breakdown (older response shape, partial CacheDetails), route
+	// the remainder to CacheCreationUnknownTTLTokens so BilledInputTokens
+	// stays accurate. A nil CacheWriteInputTokens with a non-empty
+	// breakdown is treated as consistent.
+	if usage.CacheWriteInputTokens != nil {
+		aggregate := int(*usage.CacheWriteInputTokens)
+		if aggregate > knownBreakdownTokens {
+			result.CacheCreationUnknownTTLTokens += aggregate - knownBreakdownTokens
 		}
 	}
 

--- a/providers/conformance/suite.go
+++ b/providers/conformance/suite.go
@@ -134,7 +134,7 @@ func testGenerate(t *testing.T, fixture Fixture) { //nolint:thelper // not a hel
 				require.NotNil(t, response.Usage)
 				assert.Positive(t, response.Usage.InputTokens)
 				assert.Positive(t, response.Usage.OutputTokens)
-				assert.Positive(t, response.Usage.TotalTokens)
+				assert.Positive(t, response.Usage.TotalBilledTokens())
 			},
 		},
 		{
@@ -165,7 +165,7 @@ func testGenerate(t *testing.T, fixture Fixture) { //nolint:thelper // not a hel
 
 				// Should have usage information
 				require.NotNil(t, response.Usage)
-				assert.Positive(t, response.Usage.TotalTokens)
+				assert.Positive(t, response.Usage.TotalBilledTokens())
 			},
 		},
 		{
@@ -262,7 +262,7 @@ func testGenerateEvents(t *testing.T, fixture Fixture) { //nolint:thelper // not
 				require.NotNil(t, endEvent.Response.Usage)
 				assert.Positive(t, endEvent.Response.Usage.InputTokens)
 				assert.Positive(t, endEvent.Response.Usage.OutputTokens)
-				assert.Positive(t, endEvent.Response.Usage.TotalTokens)
+				assert.Positive(t, endEvent.Response.Usage.TotalBilledTokens())
 
 				// Verify StreamEndEvent.Response.Message contains aggregated content
 				// Streaming may send many small text chunks, but final response combines them
@@ -376,7 +376,7 @@ func testGenerateEvents(t *testing.T, fixture Fixture) { //nolint:thelper // not
 
 				// Verify usage information
 				require.NotNil(t, endEvent.Response.Usage)
-				assert.Positive(t, endEvent.Response.Usage.TotalTokens)
+				assert.Positive(t, endEvent.Response.Usage.TotalBilledTokens())
 
 				// Verify StreamEndEvent.Response.Message contains aggregated content
 				require.NotEmpty(t, contentParts, "Should have received content parts")
@@ -491,7 +491,7 @@ func testGenerateWithReasoning(t *testing.T, fixture Fixture) { //nolint:thelper
 			"Should discuss relevant distributed systems concepts")
 
 		require.NotNil(t, response.Usage)
-		assert.Greater(t, response.Usage.TotalTokens, 200, "Complex reasoning should use many tokens")
+		assert.Greater(t, response.Usage.TotalBilledTokens(), 200, "Complex reasoning should use many tokens")
 	})
 }
 
@@ -621,7 +621,7 @@ func testGenerateEventsWithReasoning(t *testing.T, fixture Fixture) { //nolint:t
 
 		// Verify usage information
 		require.NotNil(t, endEvent.Response.Usage)
-		assert.Greater(t, endEvent.Response.Usage.TotalTokens, 200, "Complex reasoning should use many tokens")
+		assert.Greater(t, endEvent.Response.Usage.TotalBilledTokens(), 200, "Complex reasoning should use many tokens")
 
 		// Verify StreamEndEvent.Response.Message contains aggregated content
 		// Streaming may send many small chunks, but final response combines them
@@ -892,7 +892,7 @@ func testGenerateEventsWithTools(t *testing.T, fixture Fixture) { //nolint:thelp
 				// Verify usage information in end event
 				require.NotNil(t, endEvent.Response.Usage)
 				assert.Positive(t, endEvent.Response.Usage.InputTokens)
-				assert.Positive(t, endEvent.Response.Usage.TotalTokens)
+				assert.Positive(t, endEvent.Response.Usage.TotalBilledTokens())
 			},
 		},
 		{
@@ -1052,7 +1052,7 @@ func testGenerateEventsWithTools(t *testing.T, fixture Fixture) { //nolint:thelp
 				// Verify usage information in end event
 				require.NotNil(t, endEvent.Response.Usage)
 				assert.Positive(t, endEvent.Response.Usage.InputTokens)
-				assert.Positive(t, endEvent.Response.Usage.TotalTokens)
+				assert.Positive(t, endEvent.Response.Usage.TotalBilledTokens())
 			},
 		},
 	}
@@ -1166,7 +1166,7 @@ func testToolExecutionLoop(t *testing.T, fixture Fixture) { //nolint:thelper // 
 
 		// Verify usage information
 		require.NotNil(t, finalResponse.Usage)
-		assert.Positive(t, finalResponse.Usage.TotalTokens)
+		assert.Positive(t, finalResponse.Usage.TotalBilledTokens())
 	})
 
 	t.Run("multi-turn tool execution streaming", func(t *testing.T) {
@@ -1268,7 +1268,7 @@ func testToolExecutionLoop(t *testing.T, fixture Fixture) { //nolint:thelper // 
 			case llm.StreamEndEvent:
 				finalFinishReason = e.Response.FinishReason
 				require.NotNil(t, e.Response.Usage)
-				assert.Positive(t, e.Response.Usage.TotalTokens)
+				assert.Positive(t, e.Response.Usage.TotalBilledTokens())
 			}
 		}
 
@@ -1450,7 +1450,7 @@ func testToolExecutionLoop(t *testing.T, fixture Fixture) { //nolint:thelper // 
 			"Response should mention weather and location from tool results")
 
 		require.NotNil(t, finalResponse.Usage)
-		assert.Positive(t, finalResponse.Usage.TotalTokens)
+		assert.Positive(t, finalResponse.Usage.TotalBilledTokens())
 	})
 }
 
@@ -1486,7 +1486,7 @@ func testAllSupportedModels(t *testing.T, fixture Fixture) { //nolint:thelper //
 				assert.NotEmpty(t, resp.FinishReason)
 
 				if resp.Usage != nil {
-					assert.Positive(t, resp.Usage.TotalTokens)
+					assert.Positive(t, resp.Usage.TotalBilledTokens())
 				}
 			})
 		}

--- a/providers/google/cache_test.go
+++ b/providers/google/cache_test.go
@@ -62,7 +62,7 @@ func TestGeminiCachedTokens_Integration(t *testing.T) {
 	require.NotNil(t, response1.Usage)
 
 	t.Logf("Request 1 - InputTokens: %d, OutputTokens: %d, CachedTokens: %d",
-		response1.Usage.InputTokens, response1.Usage.OutputTokens, response1.Usage.CachedTokens)
+		response1.Usage.InputTokens, response1.Usage.OutputTokens, response1.Usage.CachedInputTokens)
 
 	// Continue the conversation
 	messages = append(messages, llm.Message{
@@ -82,7 +82,7 @@ func TestGeminiCachedTokens_Integration(t *testing.T) {
 	require.NotNil(t, response2.Usage)
 
 	t.Logf("Request 2 - InputTokens: %d, OutputTokens: %d, CachedTokens: %d",
-		response2.Usage.InputTokens, response2.Usage.OutputTokens, response2.Usage.CachedTokens)
+		response2.Usage.InputTokens, response2.Usage.OutputTokens, response2.Usage.CachedInputTokens)
 
 	// Continue further
 	messages = append(messages, llm.Message{
@@ -102,7 +102,7 @@ func TestGeminiCachedTokens_Integration(t *testing.T) {
 	require.NotNil(t, response3.Usage)
 
 	t.Logf("Request 3 - InputTokens: %d, OutputTokens: %d, CachedTokens: %d",
-		response3.Usage.InputTokens, response3.Usage.OutputTokens, response3.Usage.CachedTokens)
+		response3.Usage.InputTokens, response3.Usage.OutputTokens, response3.Usage.CachedInputTokens)
 
 	// Continue further to give cache more time to warm up
 	messages = append(messages, llm.Message{
@@ -122,7 +122,7 @@ func TestGeminiCachedTokens_Integration(t *testing.T) {
 	require.NotNil(t, response4.Usage)
 
 	t.Logf("Request 4 - InputTokens: %d, OutputTokens: %d, CachedTokens: %d",
-		response4.Usage.InputTokens, response4.Usage.OutputTokens, response4.Usage.CachedTokens)
+		response4.Usage.InputTokens, response4.Usage.OutputTokens, response4.Usage.CachedInputTokens)
 
 	// One more request
 	messages = append(messages, llm.Message{
@@ -142,7 +142,7 @@ func TestGeminiCachedTokens_Integration(t *testing.T) {
 	require.NotNil(t, response5.Usage)
 
 	t.Logf("Request 5 - InputTokens: %d, OutputTokens: %d, CachedTokens: %d",
-		response5.Usage.InputTokens, response5.Usage.OutputTokens, response5.Usage.CachedTokens)
+		response5.Usage.InputTokens, response5.Usage.OutputTokens, response5.Usage.CachedInputTokens)
 
 	// Log cache statistics. Google's implicit caching is opportunistic — cache hits
 	// are not guaranteed by the API, so we don't assert on them. This test verifies
@@ -152,11 +152,11 @@ func TestGeminiCachedTokens_Integration(t *testing.T) {
 	totalCached := 0
 
 	for i, resp := range responses {
-		assert.GreaterOrEqual(t, resp.Usage.CachedTokens, 0, "CachedTokens should be non-negative")
+		assert.GreaterOrEqual(t, resp.Usage.CachedInputTokens, 0, "CachedTokens should be non-negative")
 
-		totalCached += resp.Usage.CachedTokens
-		if resp.Usage.CachedTokens > 0 {
-			t.Logf("Cache hit on request %d with %d cached tokens", i+1, resp.Usage.CachedTokens)
+		totalCached += resp.Usage.CachedInputTokens
+		if resp.Usage.CachedInputTokens > 0 {
+			t.Logf("Cache hit on request %d with %d cached tokens", i+1, resp.Usage.CachedInputTokens)
 		}
 	}
 

--- a/providers/google/google_test.go
+++ b/providers/google/google_test.go
@@ -248,8 +248,10 @@ func TestResponseMapper_CachedTokens(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.NotNil(t, resp.Usage)
-	assert.Equal(t, 100, resp.Usage.InputTokens)
+	// Google reports CachedContentTokenCount as a subset of PromptTokenCount;
+	// the normalized mapper un-subsets it so the two buckets are disjoint.
+	assert.Equal(t, 20, resp.Usage.InputTokens, "fresh input = 100 prompt - 80 cached")
+	assert.Equal(t, 80, resp.Usage.CachedInputTokens)
 	assert.Equal(t, 10, resp.Usage.OutputTokens)
-	assert.Equal(t, 110, resp.Usage.TotalTokens)
-	assert.Equal(t, 80, resp.Usage.CachedTokens)
+	assert.Equal(t, 110, resp.Usage.TotalBilledTokens(), "should equal Google's total")
 }

--- a/providers/google/response_mapper.go
+++ b/providers/google/response_mapper.go
@@ -57,16 +57,21 @@ func (m *ResponseMapper) FromProvider(r *genai.GenerateContentResponse) (*llm.Re
 		return nil, err
 	}
 
-	// Extract usage information
+	// Extract usage information. Google reports CachedContentTokenCount as a
+	// subset of PromptTokenCount; un-subset so the normalized buckets stay
+	// disjoint. ThoughtsTokenCount is already additive in Google's model and
+	// maps directly onto ReasoningTokens. ToolUsePromptTokenCount is a separate
+	// billable input dimension.
 	var usage *llm.TokenUsage
 	if r.UsageMetadata != nil {
+		cachedIn := int(r.UsageMetadata.CachedContentTokenCount)
 		usage = &llm.TokenUsage{
-			InputTokens:     int(r.UsageMetadata.PromptTokenCount),
-			OutputTokens:    int(r.UsageMetadata.CandidatesTokenCount),
-			TotalTokens:     int(r.UsageMetadata.TotalTokenCount),
-			CachedTokens:    int(r.UsageMetadata.CachedContentTokenCount),
-			ReasoningTokens: 0,
-			MaxInputTokens:  m.modelDefinition.Constraints.MaxInputTokens,
+			InputTokens:        int(r.UsageMetadata.PromptTokenCount) - cachedIn,
+			CachedInputTokens:  cachedIn,
+			ToolUseInputTokens: int(r.UsageMetadata.ToolUsePromptTokenCount),
+			OutputTokens:       int(r.UsageMetadata.CandidatesTokenCount),
+			ReasoningTokens:    int(r.UsageMetadata.ThoughtsTokenCount),
+			MaxInputTokens:     m.modelDefinition.Constraints.MaxInputTokens,
 		}
 	}
 

--- a/providers/google/response_mapper.go
+++ b/providers/google/response_mapper.go
@@ -71,7 +71,6 @@ func (m *ResponseMapper) FromProvider(r *genai.GenerateContentResponse) (*llm.Re
 			ToolUseInputTokens: int(r.UsageMetadata.ToolUsePromptTokenCount),
 			OutputTokens:       int(r.UsageMetadata.CandidatesTokenCount),
 			ReasoningTokens:    int(r.UsageMetadata.ThoughtsTokenCount),
-			MaxInputTokens:     m.modelDefinition.Constraints.MaxInputTokens,
 		}
 	}
 

--- a/providers/openai/cache_test.go
+++ b/providers/openai/cache_test.go
@@ -61,7 +61,7 @@ func TestOpenAICachedTokens_Integration(t *testing.T) {
 	require.NotNil(t, response1.Usage)
 
 	t.Logf("Request 1 - InputTokens: %d, OutputTokens: %d, CachedTokens: %d",
-		response1.Usage.InputTokens, response1.Usage.OutputTokens, response1.Usage.CachedTokens)
+		response1.Usage.InputTokens, response1.Usage.OutputTokens, response1.Usage.CachedInputTokens)
 
 	// Run multiple iterations to increase chances of seeing cached tokens
 	// OpenAI's automatic caching behavior is not deterministic
@@ -86,7 +86,7 @@ func TestOpenAICachedTokens_Integration(t *testing.T) {
 		require.NotNil(t, resp.Usage)
 
 		t.Logf("Request %d - InputTokens: %d, OutputTokens: %d, CachedTokens: %d",
-			i, resp.Usage.InputTokens, resp.Usage.OutputTokens, resp.Usage.CachedTokens)
+			i, resp.Usage.InputTokens, resp.Usage.OutputTokens, resp.Usage.CachedInputTokens)
 
 		responses = append(responses, resp)
 	}
@@ -98,11 +98,11 @@ func TestOpenAICachedTokens_Integration(t *testing.T) {
 	totalCached := 0
 
 	for i, resp := range responses {
-		assert.GreaterOrEqual(t, resp.Usage.CachedTokens, 0, "CachedTokens should be non-negative")
+		assert.GreaterOrEqual(t, resp.Usage.CachedInputTokens, 0, "CachedTokens should be non-negative")
 
-		totalCached += resp.Usage.CachedTokens
-		if resp.Usage.CachedTokens > 0 {
-			t.Logf("Cache hit on request %d with %d cached tokens", i+1, resp.Usage.CachedTokens)
+		totalCached += resp.Usage.CachedInputTokens
+		if resp.Usage.CachedInputTokens > 0 {
+			t.Logf("Cache hit on request %d with %d cached tokens", i+1, resp.Usage.CachedInputTokens)
 		}
 	}
 

--- a/providers/openai/response_mapper.go
+++ b/providers/openai/response_mapper.go
@@ -125,27 +125,17 @@ func (m *ResponseMapper) FromProvider(r *responses.Response) (*llm.Response, err
 		}
 	}
 
-	// 5. Usage extraction if available.
-	var usage *llm.TokenUsage
-	if r.Usage.TotalTokens > 0 {
-		usage = &llm.TokenUsage{
-			InputTokens:     int(r.Usage.InputTokens),
-			OutputTokens:    int(r.Usage.OutputTokens),
-			TotalTokens:     int(r.Usage.TotalTokens),
-			CachedTokens:    int(r.Usage.InputTokensDetails.CachedTokens),
-			ReasoningTokens: int(r.Usage.OutputTokensDetails.ReasoningTokens),
-			MaxInputTokens:  m.modelDefinition.Constraints.MaxInputTokens,
-		}
-	} else {
-		// Even if TotalTokens is 0, provide usage structure with MaxInputTokens
-		usage = &llm.TokenUsage{
-			InputTokens:     int(r.Usage.InputTokens),
-			OutputTokens:    int(r.Usage.OutputTokens),
-			TotalTokens:     int(r.Usage.TotalTokens),
-			CachedTokens:    int(r.Usage.InputTokensDetails.CachedTokens),
-			ReasoningTokens: int(r.Usage.OutputTokensDetails.ReasoningTokens),
-			MaxInputTokens:  m.modelDefinition.Constraints.MaxInputTokens,
-		}
+	// 5. Usage extraction. OpenAI reports cached_tokens as a subset of
+	// input_tokens and reasoning_tokens as a subset of output_tokens. The
+	// normalized shape is disjoint, so we un-subset both here.
+	cachedIn := int(r.Usage.InputTokensDetails.CachedTokens)
+	reasoning := int(r.Usage.OutputTokensDetails.ReasoningTokens)
+	usage := &llm.TokenUsage{
+		InputTokens:       int(r.Usage.InputTokens) - cachedIn,
+		CachedInputTokens: cachedIn,
+		OutputTokens:      int(r.Usage.OutputTokens) - reasoning,
+		ReasoningTokens:   reasoning,
+		MaxInputTokens:    m.modelDefinition.Constraints.MaxInputTokens,
 	}
 
 	// 6. Finish reason: tool calls take precedence.

--- a/providers/openai/response_mapper.go
+++ b/providers/openai/response_mapper.go
@@ -135,7 +135,6 @@ func (m *ResponseMapper) FromProvider(r *responses.Response) (*llm.Response, err
 		CachedInputTokens: cachedIn,
 		OutputTokens:      int(r.Usage.OutputTokens) - reasoning,
 		ReasoningTokens:   reasoning,
-		MaxInputTokens:    m.modelDefinition.Constraints.MaxInputTokens,
 	}
 
 	// 6. Finish reason: tool calls take precedence.

--- a/providers/openaicompat/cache_test.go
+++ b/providers/openaicompat/cache_test.go
@@ -65,7 +65,7 @@ func TestOpenAICompatCachedTokens_Integration(t *testing.T) {
 	require.NotNil(t, response1.Usage)
 
 	t.Logf("Request 1 - InputTokens: %d, OutputTokens: %d, CachedTokens: %d",
-		response1.Usage.InputTokens, response1.Usage.OutputTokens, response1.Usage.CachedTokens)
+		response1.Usage.InputTokens, response1.Usage.OutputTokens, response1.Usage.CachedInputTokens)
 
 	// Continue the conversation
 	messages = append(messages, llm.Message{
@@ -85,7 +85,7 @@ func TestOpenAICompatCachedTokens_Integration(t *testing.T) {
 	require.NotNil(t, response2.Usage)
 
 	t.Logf("Request 2 - InputTokens: %d, OutputTokens: %d, CachedTokens: %d",
-		response2.Usage.InputTokens, response2.Usage.OutputTokens, response2.Usage.CachedTokens)
+		response2.Usage.InputTokens, response2.Usage.OutputTokens, response2.Usage.CachedInputTokens)
 
 	// Continue further
 	messages = append(messages, llm.Message{
@@ -105,7 +105,7 @@ func TestOpenAICompatCachedTokens_Integration(t *testing.T) {
 	require.NotNil(t, response3.Usage)
 
 	t.Logf("Request 3 - InputTokens: %d, OutputTokens: %d, CachedTokens: %d",
-		response3.Usage.InputTokens, response3.Usage.OutputTokens, response3.Usage.CachedTokens)
+		response3.Usage.InputTokens, response3.Usage.OutputTokens, response3.Usage.CachedInputTokens)
 
 	// Two more requests to ensure we trigger caching
 	messages = append(messages, llm.Message{
@@ -125,7 +125,7 @@ func TestOpenAICompatCachedTokens_Integration(t *testing.T) {
 	require.NotNil(t, response4.Usage)
 
 	t.Logf("Request 4 - InputTokens: %d, OutputTokens: %d, CachedTokens: %d",
-		response4.Usage.InputTokens, response4.Usage.OutputTokens, response4.Usage.CachedTokens)
+		response4.Usage.InputTokens, response4.Usage.OutputTokens, response4.Usage.CachedInputTokens)
 
 	messages = append(messages, llm.Message{
 		Role:    llm.RoleAssistant,
@@ -144,18 +144,18 @@ func TestOpenAICompatCachedTokens_Integration(t *testing.T) {
 	require.NotNil(t, response5.Usage)
 
 	t.Logf("Request 5 - InputTokens: %d, OutputTokens: %d, CachedTokens: %d",
-		response5.Usage.InputTokens, response5.Usage.OutputTokens, response5.Usage.CachedTokens)
+		response5.Usage.InputTokens, response5.Usage.OutputTokens, response5.Usage.CachedInputTokens)
 
 	// Verify all responses have the CachedTokens field populated
-	assert.GreaterOrEqual(t, response1.Usage.CachedTokens, 0)
-	assert.GreaterOrEqual(t, response2.Usage.CachedTokens, 0)
-	assert.GreaterOrEqual(t, response3.Usage.CachedTokens, 0)
-	assert.GreaterOrEqual(t, response4.Usage.CachedTokens, 0)
-	assert.GreaterOrEqual(t, response5.Usage.CachedTokens, 0)
+	assert.GreaterOrEqual(t, response1.Usage.CachedInputTokens, 0)
+	assert.GreaterOrEqual(t, response2.Usage.CachedInputTokens, 0)
+	assert.GreaterOrEqual(t, response3.Usage.CachedInputTokens, 0)
+	assert.GreaterOrEqual(t, response4.Usage.CachedInputTokens, 0)
+	assert.GreaterOrEqual(t, response5.Usage.CachedInputTokens, 0)
 
 	// Check if any requests show cached tokens
-	totalCached := response2.Usage.CachedTokens + response3.Usage.CachedTokens +
-		response4.Usage.CachedTokens + response5.Usage.CachedTokens
+	totalCached := response2.Usage.CachedInputTokens + response3.Usage.CachedInputTokens +
+		response4.Usage.CachedInputTokens + response5.Usage.CachedInputTokens
 
 	// OpenAI-compatible should show caching when using OpenAI backend
 	require.Positive(t, totalCached, "Expected cached tokens with OpenAI-compatible automatic caching")
@@ -199,7 +199,7 @@ func TestDeepSeekCachedTokens_Integration(t *testing.T) {
 	require.NotNil(t, response1.Usage)
 
 	t.Logf("Request 1 - InputTokens: %d, OutputTokens: %d, CachedTokens: %d",
-		response1.Usage.InputTokens, response1.Usage.OutputTokens, response1.Usage.CachedTokens)
+		response1.Usage.InputTokens, response1.Usage.OutputTokens, response1.Usage.CachedInputTokens)
 
 	// Continue the conversation
 	messages = append(messages, llm.Message{
@@ -219,13 +219,13 @@ func TestDeepSeekCachedTokens_Integration(t *testing.T) {
 	require.NotNil(t, response2.Usage)
 
 	t.Logf("Request 2 - InputTokens: %d, OutputTokens: %d, CachedTokens: %d",
-		response2.Usage.InputTokens, response2.Usage.OutputTokens, response2.Usage.CachedTokens)
+		response2.Usage.InputTokens, response2.Usage.OutputTokens, response2.Usage.CachedInputTokens)
 
 	// Verify CachedTokens field exists (may be 0 depending on DeepSeek's caching policy)
-	assert.GreaterOrEqual(t, response1.Usage.CachedTokens, 0)
-	assert.GreaterOrEqual(t, response2.Usage.CachedTokens, 0)
+	assert.GreaterOrEqual(t, response1.Usage.CachedInputTokens, 0)
+	assert.GreaterOrEqual(t, response2.Usage.CachedInputTokens, 0)
 
-	totalCached := response1.Usage.CachedTokens + response2.Usage.CachedTokens
+	totalCached := response1.Usage.CachedInputTokens + response2.Usage.CachedInputTokens
 
 	// DeepSeek should show caching on subsequent requests
 	require.Positive(t, totalCached, "Expected cached tokens with DeepSeek caching")

--- a/providers/openaicompat/model.go
+++ b/providers/openaicompat/model.go
@@ -110,14 +110,18 @@ func (m *Model) GenerateEvents(ctx context.Context, req *llm.Request) iter.Seq2[
 		for stream.Next() {
 			chunk := stream.Current()
 
-			// Accumulate usage from any chunk that has it
-			// OpenAI sends usage in the last chunk (which has empty choices) when stream_options.include_usage is true
+			// Accumulate usage from any chunk that has it. OpenAI sends usage in
+			// the last chunk (which has empty choices) when
+			// stream_options.include_usage is true. Un-subset cached and
+			// reasoning tokens so the normalized buckets stay disjoint.
 			if chunk.Usage.JSON.TotalTokens.Valid() && chunk.Usage.TotalTokens > 0 {
+				cachedTokens := int(chunk.Usage.PromptTokensDetails.CachedTokens)
+				reasoningTokens := int(chunk.Usage.CompletionTokensDetails.ReasoningTokens)
 				usage = &llm.TokenUsage{
-					InputTokens:     int(chunk.Usage.PromptTokens),
-					OutputTokens:    int(chunk.Usage.CompletionTokens),
-					TotalTokens:     int(chunk.Usage.TotalTokens),
-					ReasoningTokens: int(chunk.Usage.CompletionTokensDetails.ReasoningTokens),
+					InputTokens:       int(chunk.Usage.PromptTokens) - cachedTokens,
+					CachedInputTokens: cachedTokens,
+					OutputTokens:      int(chunk.Usage.CompletionTokens) - reasoningTokens,
+					ReasoningTokens:   reasoningTokens,
 				}
 			}
 

--- a/providers/openaicompat/response_mapper.go
+++ b/providers/openaicompat/response_mapper.go
@@ -111,7 +111,6 @@ func (rm *ResponseMapper) FromProvider(apiResp *openai.ChatCompletion) (*llm.Res
 		CachedInputTokens: cachedTokens,
 		OutputTokens:      int(apiResp.Usage.CompletionTokens) - reasoningTokens,
 		ReasoningTokens:   reasoningTokens,
-		MaxInputTokens:    rm.constraints.MaxInputTokens,
 	}
 
 	return &llm.Response{

--- a/providers/openaicompat/response_mapper.go
+++ b/providers/openaicompat/response_mapper.go
@@ -93,41 +93,25 @@ func (rm *ResponseMapper) FromProvider(apiResp *openai.ChatCompletion) (*llm.Res
 		return nil, fmt.Errorf("%w: %w", llm.ErrResponseMapping, err)
 	}
 
-	// Extract usage statistics
-	var usage *llm.TokenUsage
+	// Extract usage statistics. OpenAI Chat reports cached_tokens and
+	// reasoning_tokens as subsets; un-subset both so the normalized buckets
+	// stay disjoint.
+	var cachedTokens int
+	if apiResp.Usage.JSON.PromptTokensDetails.Valid() {
+		cachedTokens = int(apiResp.Usage.PromptTokensDetails.CachedTokens)
+	}
 
-	if apiResp.Usage.TotalTokens > 0 {
-		// Extract cached tokens from details if field is present
-		var cachedTokens int
-		if apiResp.Usage.JSON.PromptTokensDetails.Valid() {
-			cachedTokens = int(apiResp.Usage.PromptTokensDetails.CachedTokens)
-		}
+	var reasoningTokens int
+	if apiResp.Usage.JSON.CompletionTokensDetails.Valid() {
+		reasoningTokens = int(apiResp.Usage.CompletionTokensDetails.ReasoningTokens)
+	}
 
-		// Extract reasoning tokens from details if field is present
-		var reasoningTokens int
-		if apiResp.Usage.JSON.CompletionTokensDetails.Valid() {
-			reasoningTokens = int(apiResp.Usage.CompletionTokensDetails.ReasoningTokens)
-		}
-
-		usage = &llm.TokenUsage{
-			InputTokens:     int(apiResp.Usage.PromptTokens),
-			OutputTokens:    int(apiResp.Usage.CompletionTokens),
-			TotalTokens:     int(apiResp.Usage.TotalTokens),
-			CachedTokens:    cachedTokens,
-			ReasoningTokens: reasoningTokens,
-			MaxInputTokens:  rm.constraints.MaxInputTokens,
-		}
-	} else {
-		// If no usage provided, return empty usage structure
-		// This can happen with some OpenAI-compatible APIs
-		usage = &llm.TokenUsage{
-			InputTokens:     0,
-			OutputTokens:    0,
-			TotalTokens:     0,
-			CachedTokens:    0,
-			ReasoningTokens: 0,
-			MaxInputTokens:  rm.constraints.MaxInputTokens,
-		}
+	usage := &llm.TokenUsage{
+		InputTokens:       int(apiResp.Usage.PromptTokens) - cachedTokens,
+		CachedInputTokens: cachedTokens,
+		OutputTokens:      int(apiResp.Usage.CompletionTokens) - reasoningTokens,
+		ReasoningTokens:   reasoningTokens,
+		MaxInputTokens:    rm.constraints.MaxInputTokens,
 	}
 
 	return &llm.Response{

--- a/runner/runner_test.go
+++ b/runner/runner_test.go
@@ -103,7 +103,7 @@ func TestRun_NewSession(t *testing.T) {
 						At:           time.Now().UTC(),
 					},
 					FinishReason: agent.FinishReasonStop,
-					Usage:        &llm.TokenUsage{TotalTokens: 100},
+					Usage:        &llm.TokenUsage{InputTokens: 60, OutputTokens: 40},
 				}, nil)
 			}
 		},


### PR DESCRIPTION
## Summary

- Replace `llm.TokenUsage` with a normalized, **disjoint-bucket** shape that captures what every first-party provider (OpenAI, Anthropic, Google, Bedrock) actually reports — cache-write TTLs, thinking/reasoning, tool-use, modality breakdowns, service tier, predicted outputs, server tool requests, guardrail units, regional hints.
- Remove `TotalTokens` (providers disagree on its meaning); introduce `BilledInputTokens()` / `BilledOutputTokens()` / `TotalBilledTokens()` helpers.
- Rename `CachedTokens` → `CachedInputTokens` to force a compile-time break so the semantic change (subset → disjoint) is caught by callers.
- Extend `SumUsage` to merge maps and take first-non-empty for string posture fields.
- All five provider response mappers updated to emit the new shape; OpenAI and Google un-subset their native values so the disjoint invariant holds uniformly.
- Full design + per-provider mapping contract in `docs/rfcs/0001-token-usage.md`.

## Scope split

This is PR 1 of 2.

- **This PR**: new shape + `SumUsage` + conformance contract + extractor updates for fields already being read today (input/output/cache_read for every provider, cache_creation_5m/1h for Anthropic + Bedrock Converse, thoughts/tool-use for Google).
- **Follow-up PR**: richer extraction — per-modality maps (Google, OpenAI audio), `GuardrailUnits` (Bedrock), `AcceptedPredictionTokens` / `RejectedPredictionTokens` (OpenAI), `ServiceTier` / `Speed` / `InferenceRegion`, `ServerToolRequests` (Anthropic web_search/web_fetch), Anthropic Beta `iterations`.

## Breaking changes

- `TotalTokens` removed. Use `TotalBilledTokens()`.
- `CachedTokens` renamed to `CachedInputTokens`, semantics changed from subset-of-`InputTokens` to disjoint.
- `ReasoningTokens` semantics changed from subset-of-`OutputTokens` (OpenAI) to disjoint/additive (matches Google; OpenAI is un-subsetted in the mapper).

This is a v0 break; downstream consumers recompile against the new names and adjust any arithmetic that assumed subsets.

## Design rationale

Short version: providers disagree on whether cache-read tokens are inside or next to input tokens, and whether reasoning tokens are inside or next to output tokens. Any struct that forces one convention mis-reports at least one provider. Disjoint buckets pick the convention that requires the least lying and makes billed totals a simple sum.

Full rationale with per-provider evidence in `docs/rfcs/0001-token-usage.md`.