### PR TITLE
fix: reduce Gemini test flakiness and remove deprecated models

### DIFF
--- a/plugins/otel/genai/span_test.go
+++ b/plugins/otel/genai/span_test.go
@@ -83,7 +83,7 @@ func TestStampModelCallSpan(t *testing.T) {
 			name: "zero cached tokens omitted",
 			attrs: &ModelCallAttrs{
 				Provider:     "google",
-				RequestModel: "gemini-2.0-flash",
+				RequestModel: "gemini-2.5-flash",
 				FinishReason: "stop",
 				InputTokens:  50,
 				OutputTokens: 30,
@@ -92,7 +92,7 @@ func TestStampModelCallSpan(t *testing.T) {
 			wantKVs: map[string]any{
 				AttrGenAIOperationName:     OperationChat,
 				AttrGenAIProviderName:      "google",
-				AttrGenAIRequestModel:      "gemini-2.0-flash",
+				AttrGenAIRequestModel:      "gemini-2.5-flash",
 				AttrGenAIUsageInputTokens:  50,
 				AttrGenAIUsageOutputTokens: 30,
 			},

--- a/providers/conformance/suite.go
+++ b/providers/conformance/suite.go
@@ -20,11 +20,13 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/redpanda-data/ai-sdk-go/llm"
+	"github.com/redpanda-data/ai-sdk-go/plugins/retry"
 )
 
 // Suite provides generic conformance tests for any provider implementing the llm.Model interface.
@@ -1460,15 +1462,22 @@ func testAllSupportedModels(t *testing.T, fixture Fixture) { //nolint:thelper //
 		t.Skip("No models available for testing")
 	}
 
+	// Run sequentially (not parallel) to avoid rate limiting across providers.
+	// Each model is wrapped with retry to handle transient errors.
 	t.Run("basic generation works for all supported models", func(t *testing.T) {
 		for _, m := range models {
 			modelName := m.Name
 			t.Run("model_"+modelName, func(t *testing.T) {
-				model, err := fixture.NewModel(modelName)
+				baseModel, err := fixture.NewModel(modelName)
 				if err != nil {
 					t.Skipf("Skipping model %s due to creation error: %v", modelName, err)
 					return
 				}
+
+				model := retry.WrapModel(baseModel,
+					retry.WithMaxRetries(5),
+					retry.WithInitialDelay(2*time.Second),
+				)
 
 				reqObj := &llm.Request{
 					Messages: []llm.Message{{

--- a/providers/google/errors.go
+++ b/providers/google/errors.go
@@ -16,6 +16,7 @@ package google
 
 import (
 	"errors"
+	"net"
 
 	"google.golang.org/genai"
 
@@ -32,6 +33,17 @@ func classifyError(err error) error {
 	var apiErr *genai.APIError
 	if errors.As(err, &apiErr) {
 		return classifyAPIError(apiErr)
+	}
+
+	// Network timeouts (e.g., Client.Timeout exceeded) are retryable.
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return &llm.ProviderError{
+			Base:      llm.ErrServerError,
+			Code:      "TIMEOUT",
+			Message:   err.Error(),
+			Retryable: true,
+		}
 	}
 
 	return err

--- a/providers/google/errors_test.go
+++ b/providers/google/errors_test.go
@@ -16,6 +16,7 @@ package google
 
 import (
 	"errors"
+	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -80,4 +81,33 @@ func TestClassifyAPIError(t *testing.T) {
 			assert.Equal(t, tt.message, pe.Message)
 		})
 	}
+}
+
+// timeoutError is a test helper that implements net.Error with Timeout()=true,
+// mimicking Go's http.httpError produced on Client.Timeout exceeded.
+type timeoutError struct{ msg string }
+
+func (e *timeoutError) Error() string   { return e.msg }
+func (e *timeoutError) Timeout() bool   { return true }
+func (e *timeoutError) Temporary() bool { return true }
+
+func TestClassifyError_NetworkTimeout(t *testing.T) {
+	t.Parallel()
+
+	// Simulate the error chain produced by Go's HTTP client on Client.Timeout:
+	// url.Error -> httpError (timeout=true)
+	timeoutErr := &url.Error{
+		Op:  "Post",
+		URL: "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent",
+		Err: &timeoutError{msg: "context deadline exceeded (Client.Timeout exceeded while awaiting headers)"},
+	}
+
+	result := classifyError(timeoutErr)
+	require.Error(t, result)
+
+	var pe *llm.ProviderError
+	require.ErrorAs(t, result, &pe)
+	require.ErrorIs(t, pe, llm.ErrServerError)
+	assert.True(t, pe.Retryable)
+	assert.Equal(t, "TIMEOUT", pe.Code)
 }

--- a/providers/google/google_conformance_test.go
+++ b/providers/google/google_conformance_test.go
@@ -112,7 +112,6 @@ func TestGoogleConformance_Integration(t *testing.T) {
 	t.Parallel()
 
 	modelsToTest := []string{
-		google.ModelGemini25Flash,       // gemini-2.5-flash
 		google.ModelGemini31ProPreview,  // gemini-3.1-pro-preview
 		google.ModelGemini3FlashPreview, // gemini-3-flash-preview
 	}

--- a/providers/google/google_test.go
+++ b/providers/google/google_test.go
@@ -67,7 +67,6 @@ func TestProviderModels(t *testing.T) {
 		"gemini-2.5-pro",
 		"gemini-2.5-flash",
 		"gemini-2.5-flash-lite",
-		"gemini-2.0-flash",
 	}
 	for _, expected := range expectedModels {
 		assert.Contains(t, modelNames, expected, "Should include %s", expected)
@@ -165,15 +164,6 @@ func TestModelCapabilities(t *testing.T) {
 	assert.True(t, caps.MultiTurn, "Should support multi-turn")
 	assert.True(t, caps.SystemPrompts, "Should support system prompts")
 
-	// Gemini 2.0 Flash (older generation - no structured output)
-	model, err = provider.NewModel(ModelGemini20Flash)
-	require.NoError(t, err)
-
-	caps = model.Capabilities()
-	assert.True(t, caps.Streaming)
-	assert.True(t, caps.Tools)
-	assert.False(t, caps.StructuredOutput, "Older model lacks structured output")
-	assert.False(t, caps.Reasoning, "Older model lacks explicit reasoning")
 }
 
 func TestModelTokenLimits(t *testing.T) {
@@ -202,12 +192,6 @@ func TestModelTokenLimits(t *testing.T) {
 			model:          ModelGemini25Flash,
 			expectedMaxIn:  1048576, // 1M
 			expectedMaxOut: 65535,   // 65K
-		},
-		{
-			name:           "Gemini 2.0 Flash",
-			model:          ModelGemini20Flash,
-			expectedMaxIn:  1048576, // 1M
-			expectedMaxOut: 8192,    // 8K
 		},
 	}
 

--- a/providers/google/googletest/constants.go
+++ b/providers/google/googletest/constants.go
@@ -16,7 +16,7 @@ package googletest
 
 const (
 	// TestModelName is the model to use for integration tests.
-	TestModelName = "gemini-2.5-flash"
+	TestModelName = "gemini-3-flash-preview"
 	// TestReasoningModelName is the model for reasoning tests.
-	TestReasoningModelName = "gemini-2.5-pro"
+	TestReasoningModelName = "gemini-3.1-pro-preview"
 )

--- a/providers/google/models.go
+++ b/providers/google/models.go
@@ -27,7 +27,6 @@ const (
 	ModelGemini25Pro         = "gemini-2.5-pro"
 	ModelGemini25Flash       = "gemini-2.5-flash"
 	ModelGemini25FlashLite   = "gemini-2.5-flash-lite"
-	ModelGemini20Flash       = "gemini-2.0-flash"
 )
 
 // ModelDefinition defines a Gemini model with its capabilities and constraints.
@@ -193,30 +192,6 @@ var supportedModels = map[string]ModelDefinition{
 		},
 		Pricing: pricing.Info{
 			InputPerMillion: 10_000_000, OutputPerMillion: 40_000_000, CachedInputPerMillion: 1_000_000,
-		},
-	},
-	ModelGemini20Flash: {
-		Name:  ModelGemini20Flash,
-		Label: "Gemini 2.0 Flash",
-		Capabilities: llm.ModelCapabilities{
-			Streaming:        true,
-			Tools:            true,
-			JSONMode:         true,
-			StructuredOutput: false, // Previous generation
-			Vision:           true,
-			MultiTurn:        true,
-			SystemPrompts:    true,
-			Reasoning:        false, // Standard model without explicit thinking
-		},
-		Constraints: llm.ModelConstraints{
-			TemperatureRange:  [2]float64{0.0, 2.0},
-			MaxInputTokens:    1048576, // 1M input tokens
-			MaxOutputTokens:   8192,    // 8K output tokens
-			SupportedParams:   []string{"temperature", "top_p", "top_k", "max_tokens", "stop", "presence_penalty", "frequency_penalty"},
-			MutuallyExclusive: [][]string{},
-		},
-		Pricing: pricing.Info{
-			InputPerMillion: 10_000_000, OutputPerMillion: 40_000_000, CachedInputPerMillion: 2_500_000,
 		},
 	},
 }


### PR DESCRIPTION
## Summary
- Remove deprecated `gemini-2.0-flash` model (shutdown June 1, 2026)
- Switch conformance and agent test constants from Gemini 2.5 to 3.x models (`gemini-3-flash-preview`, `gemini-3.1-pro-preview`)
- Classify network timeout errors (`Client.Timeout exceeded`) as retryable in the Google provider
- Wrap models in `TestAllSupportedModels` with retry (5 attempts, 2s exponential backoff) to handle rate limiting

## Context
CI failures show two patterns:
1. **429 RESOURCE_EXHAUSTED** — 3 conformance fixtures run `TestAllSupportedModels` in parallel, all hitting the same models (especially `gemini-2.0-flash`) without retry
2. **504 DEADLINE_EXCEEDED / Client.Timeout** — Go's HTTP timeout produces a `net.Error`, not a `*genai.APIError`, so `classifyError` returned a raw non-retryable error

## Test plan
- [x] Unit test for timeout error classification (`TestClassifyError_NetworkTimeout`)
- [x] All existing unit tests pass
- [ ] CI integration tests should show fewer Gemini failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)