### PR TITLE
fix(bedrock): skip inference profile promotion when region is explicit

### DIFF
--- a/providers/bedrock/provider.go
+++ b/providers/bedrock/provider.go
@@ -30,10 +30,9 @@ import (
 
 // Provider implements the Bedrock model provider using the Converse API.
 type Provider struct {
-	client         *bedrockruntime.Client
-	region         string
-	regionExplicit bool // true when WithRegion was called — disables cross-region inference profiles
-	enableCaching  bool
+	client        *bedrockruntime.Client
+	region        string
+	enableCaching bool
 }
 
 // ProviderOption configures a Provider instance using functional options.
@@ -95,10 +94,9 @@ func NewProvider(ctx context.Context, opts ...ProviderOption) (*Provider, error)
 	client := bedrockruntime.NewFromConfig(awsCfg, clientOpts...)
 
 	return &Provider{
-		client:         client,
-		region:         awsCfg.Region,
-		regionExplicit: cfg.region != "",
-		enableCaching:  cfg.caching,
+		client:        client,
+		region:        awsCfg.Region,
+		enableCaching: cfg.caching,
 	}, nil
 }
 
@@ -167,15 +165,12 @@ func (p *Provider) NewModel(modelName string, opts ...Option) (llm.Model, error)
 	}
 
 	// Build the API model ID. When the caller already provided a region
-	// prefix (e.g. "eu.anthropic.…"), use it as-is. When a specific region
-	// was set via WithRegion, use the bare model ID so the request hits
-	// that region's foundation model directly instead of a cross-region
-	// inference profile. Only promote to an inference profile when no
-	// explicit region was configured (default credential chain picks the
-	// region, so cross-region routing improves availability).
+	// prefix (e.g. "eu.anthropic.…"), use it as-is. Otherwise, promote
+	// to a cross-region inference profile which is required for on-demand
+	// throughput on Bedrock.
 	apiModelID := modelName
 
-	if !hasRegionPrefix(apiModelID) && !p.regionExplicit {
+	if !hasRegionPrefix(apiModelID) {
 		apiModelID = inferenceProfileRegion(p.region) + "." + apiModelID
 	}
 

--- a/providers/bedrock/provider.go
+++ b/providers/bedrock/provider.go
@@ -30,9 +30,10 @@ import (
 
 // Provider implements the Bedrock model provider using the Converse API.
 type Provider struct {
-	client        *bedrockruntime.Client
-	region        string
-	enableCaching bool
+	client         *bedrockruntime.Client
+	region         string
+	regionExplicit bool // true when WithRegion was called — disables cross-region inference profiles
+	enableCaching  bool
 }
 
 // ProviderOption configures a Provider instance using functional options.
@@ -94,9 +95,10 @@ func NewProvider(ctx context.Context, opts ...ProviderOption) (*Provider, error)
 	client := bedrockruntime.NewFromConfig(awsCfg, clientOpts...)
 
 	return &Provider{
-		client:        client,
-		region:        awsCfg.Region,
-		enableCaching: cfg.caching,
+		client:         client,
+		region:         awsCfg.Region,
+		regionExplicit: cfg.region != "",
+		enableCaching:  cfg.caching,
 	}, nil
 }
 
@@ -164,12 +166,16 @@ func (p *Provider) NewModel(modelName string, opts ...Option) (llm.Model, error)
 		return nil, fmt.Errorf("unsupported Bedrock model: %s", modelName)
 	}
 
-	// Build the API model ID with the region inference-profile prefix.
-	// If the caller already provided a region prefix (e.g. "eu.anthropic.…"),
-	// use it as-is. Otherwise prepend the provider's region.
+	// Build the API model ID. When the caller already provided a region
+	// prefix (e.g. "eu.anthropic.…"), use it as-is. When a specific region
+	// was set via WithRegion, use the bare model ID so the request hits
+	// that region's foundation model directly instead of a cross-region
+	// inference profile. Only promote to an inference profile when no
+	// explicit region was configured (default credential chain picks the
+	// region, so cross-region routing improves availability).
 	apiModelID := modelName
 
-	if !hasRegionPrefix(apiModelID) {
+	if !hasRegionPrefix(apiModelID) && !p.regionExplicit {
 		apiModelID = inferenceProfileRegion(p.region) + "." + apiModelID
 	}
 


### PR DESCRIPTION
## Problem

When `WithRegion` is used to configure a specific AWS region, `NewModel` still promotes bare model IDs (e.g. `anthropic.claude-opus-4-7`) to cross-region inference profile IDs (e.g. `us.anthropic.claude-opus-4-7`). This causes:

1. **IAM policy mismatches** — customers with `foundation-model/*` permissions get `AccessDeniedException` because inference profiles use a different ARN namespace (`inference-profile/*`)
2. **Unexpected routing** — the customer explicitly chose a region, but the request may be routed elsewhere via cross-region inference

## Fix

Track whether the region was explicitly set via `WithRegion` (`regionExplicit` field on `Provider`). When true, skip the inference profile prefix — use the bare model ID to hit the foundation model directly in that region.

Cross-region inference profile promotion is preserved when no explicit region is set (default credential chain), where it improves availability.

## Test plan
- All unit tests pass
- Integration/conformance tests skipped (require live AWS credentials)