### PR TITLE
fix(bedrock): map ap-* regions to "apac" inference profile prefix

### DIFF
--- a/providers/bedrock/models.go
+++ b/providers/bedrock/models.go
@@ -41,14 +41,27 @@ type ModelDefinition struct {
 	Pricing      pricing.Info
 }
 
-// inferenceProfileRegion maps an AWS region to the Bedrock inference profile
-// geographic prefix (e.g. "us-east-1" → "us", "eu-west-1" → "eu").
+// inferenceProfileRegion maps an AWS region to the Bedrock cross-region
+// inference profile geographic prefix.
+//
+// AWS uses these prefixes:
+//   - "us"   for US regions        (us-east-1, us-west-2, …)
+//   - "eu"   for European regions  (eu-west-1, eu-central-1, …)
+//   - "apac" for Asia Pacific      (ap-southeast-1, ap-northeast-1, …)
+//
+// See https://docs.aws.amazon.com/bedrock/latest/userguide/cross-region-inference-support.html
 func inferenceProfileRegion(region string) string {
-	if idx := strings.IndexByte(region, '-'); idx > 0 {
-		return region[:idx]
+	idx := strings.IndexByte(region, '-')
+	if idx <= 0 {
+		return "us"
 	}
 
-	return "us"
+	prefix := region[:idx]
+	if prefix == "ap" {
+		return "apac"
+	}
+
+	return prefix
 }
 
 // hasRegionPrefix reports whether a model ID already contains a region

--- a/providers/bedrock/provider_test.go
+++ b/providers/bedrock/provider_test.go
@@ -28,6 +28,59 @@ import (
 	"github.com/redpanda-data/ai-sdk-go/llm"
 )
 
+// ---------- inferenceProfileRegion ----------
+
+func TestInferenceProfileRegion(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		region string
+		want   string
+	}{
+		{"us-east-1", "us"},
+		{"us-west-2", "us"},
+		{"eu-west-1", "eu"},
+		{"eu-central-1", "eu"},
+		{"ap-southeast-1", "apac"},
+		{"ap-northeast-1", "apac"},
+		{"ap-south-1", "apac"},
+		{"", "us"},
+		{"unknown", "us"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.region, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, inferenceProfileRegion(tt.region))
+		})
+	}
+}
+
+// ---------- hasRegionPrefix ----------
+
+func TestHasRegionPrefix(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		modelID string
+		want    bool
+	}{
+		{"anthropic.claude-sonnet-4-6", false},
+		{"us.anthropic.claude-sonnet-4-6", true},
+		{"eu.anthropic.claude-sonnet-4-6", true},
+		{"apac.anthropic.claude-sonnet-4-6", true},
+		{"global.anthropic.claude-sonnet-4-6", true},
+		{"no-dots-here", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.modelID, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, hasRegionPrefix(tt.modelID))
+		})
+	}
+}
+
 // ---------- lookupModel ----------
 
 func TestLookupModel(t *testing.T) {
@@ -232,6 +285,47 @@ func TestNewModel_SupportedModels(t *testing.T) {
 			assert.Equal(t, "aws.bedrock", model.Provider())
 		})
 	}
+}
+
+func TestNewModel_APACRegionPrefix(t *testing.T) {
+	t.Parallel()
+
+	// Provider configured with an Asia Pacific region should produce
+	// "apac." prefix, not "ap." (which AWS does not recognize).
+	p := &Provider{client: nil, region: "ap-southeast-1"}
+
+	model, err := p.NewModel(ModelClaudeSonnet46)
+	require.NoError(t, err)
+
+	m, ok := model.(*Model)
+	require.True(t, ok)
+	assert.Equal(t, "apac."+ModelClaudeSonnet46, m.config.APIModelID)
+}
+
+func TestNewModel_USRegionPrefix(t *testing.T) {
+	t.Parallel()
+
+	p := &Provider{client: nil, region: "us-east-1"}
+
+	model, err := p.NewModel(ModelClaudeSonnet46)
+	require.NoError(t, err)
+
+	m, ok := model.(*Model)
+	require.True(t, ok)
+	assert.Equal(t, "us."+ModelClaudeSonnet46, m.config.APIModelID)
+}
+
+func TestNewModel_EURegionPrefix(t *testing.T) {
+	t.Parallel()
+
+	p := &Provider{client: nil, region: "eu-west-1"}
+
+	model, err := p.NewModel(ModelClaudeSonnet46)
+	require.NoError(t, err)
+
+	m, ok := model.(*Model)
+	require.True(t, ok)
+	assert.Equal(t, "eu."+ModelClaudeSonnet46, m.config.APIModelID)
 }
 
 func TestNewModel_UnsupportedModel(t *testing.T) {


### PR DESCRIPTION
## Summary

- **Bug**: `inferenceProfileRegion("ap-southeast-1")` returned `"ap"` instead of `"apac"`, producing invalid model IDs like `ap.anthropic.claude-sonnet-4-6` for Asia Pacific regions
- **Fix**: Added special-case mapping for `ap` → `apac` in `inferenceProfileRegion()`, matching [AWS's documented prefixes](https://docs.aws.amazon.com/bedrock/latest/userguide/cross-region-inference-support.html)
- **Tests**: Added unit tests for `inferenceProfileRegion`, `hasRegionPrefix`, and end-to-end `NewModel` prefix generation for US, EU, and APAC regions

## Test plan

- [x] `TestInferenceProfileRegion` — verifies all region prefix mappings including `ap-*` → `apac`
- [x] `TestHasRegionPrefix` — verifies detection of existing region prefixes
- [x] `TestNewModel_APACRegionPrefix` — end-to-end: provider with `ap-southeast-1` produces `apac.` prefix
- [x] `TestNewModel_USRegionPrefix` / `TestNewModel_EURegionPrefix` — regression tests for existing behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)