### PR TITLE
feat(bedrock): split models by inference profile

### DIFF
--- a/providers/bedrock/bedrock_conformance_test.go
+++ b/providers/bedrock/bedrock_conformance_test.go
@@ -17,6 +17,7 @@ package bedrock_test
 import (
 	"context"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/redpanda-data/ai-sdk-go/internal/testsuite"
@@ -83,7 +84,34 @@ func (f *BedrockFixture) NewReasoningModel(t *testing.T) llm.Model {
 }
 
 func (f *BedrockFixture) Models() []llm.ModelDiscoveryInfo {
-	return f.provider.Models()
+	all := f.provider.Models()
+
+	// The catalog now exposes one entry per inference profile (base, global.,
+	// us./eu./au./apac.). Conformance runs in a single AWS region with limited
+	// IAM, so only the bare entries are universally reachable: NewModel
+	// auto-prefixes them to the test region's geo profile, which is the only
+	// routing the CI's SCP allows. Geo profiles for other geographies fail with
+	// ValidationException (cross-geography from a single entry-point region),
+	// and the global. profile resolves to foundation-model ARNs that the CI's
+	// SCP explicitly denies. Per-variant catalog correctness is covered by
+	// unit tests in provider_test.go.
+	filtered := make([]llm.ModelDiscoveryInfo, 0, len(all))
+
+	for _, m := range all {
+		if isBareModelID(m.Name) {
+			filtered = append(filtered, m)
+		}
+	}
+
+	return filtered
+}
+
+// isBareModelID reports whether name is a foundation-model ID without an
+// inference-profile prefix (e.g. "anthropic.claude-opus-4-7" yes;
+// "us.anthropic.claude-opus-4-7" no).
+func isBareModelID(name string) bool {
+	return strings.HasPrefix(name, "anthropic.") &&
+		!strings.Contains(strings.TrimPrefix(name, "anthropic."), ".")
 }
 
 func (f *BedrockFixture) NewModel(modelName string) (llm.Model, error) {

--- a/providers/bedrock/bedrock_conformance_test.go
+++ b/providers/bedrock/bedrock_conformance_test.go
@@ -31,6 +31,7 @@ import (
 // BedrockFixture implements the conformance.Fixture interface for the Bedrock provider.
 type BedrockFixture struct {
 	provider *bedrock.Provider
+	region   string
 }
 
 // NewBedrockFixture creates a new Bedrock test fixture.
@@ -53,6 +54,7 @@ func NewBedrockFixture(t *testing.T) *BedrockFixture {
 
 	return &BedrockFixture{
 		provider: provider,
+		region:   region,
 	}
 }
 
@@ -86,32 +88,25 @@ func (f *BedrockFixture) NewReasoningModel(t *testing.T) llm.Model {
 func (f *BedrockFixture) Models() []llm.ModelDiscoveryInfo {
 	all := f.provider.Models()
 
-	// The catalog now exposes one entry per inference profile (base, global.,
-	// us./eu./au./apac.). Conformance runs in a single AWS region with limited
-	// IAM, so only the bare entries are universally reachable: NewModel
-	// auto-prefixes them to the test region's geo profile, which is the only
-	// routing the CI's SCP allows. Geo profiles for other geographies fail with
-	// ValidationException (cross-geography from a single entry-point region),
-	// and the global. profile resolves to foundation-model ARNs that the CI's
-	// SCP explicitly denies. Per-variant catalog correctness is covered by
-	// unit tests in provider_test.go.
+	// The catalog exposes one entry per inference profile (global. and each
+	// geo). Conformance runs in a single AWS region with limited IAM, so we
+	// only iterate the variants reachable from the test region: the matching
+	// geo profile (e.g. "us." when running in us-east-1). Other geo profiles
+	// fail with ValidationException (cross-geography from a single entry-point
+	// region) and the global. profile resolves to foundation-model ARNs that
+	// the CI's SCP explicitly denies. Per-variant catalog correctness is
+	// covered by unit tests in provider_test.go.
+	geoPrefix := bedrock.InferenceProfileRegion(f.region) + "."
+
 	filtered := make([]llm.ModelDiscoveryInfo, 0, len(all))
 
 	for _, m := range all {
-		if isBareModelID(m.Name) {
+		if strings.HasPrefix(m.Name, geoPrefix) {
 			filtered = append(filtered, m)
 		}
 	}
 
 	return filtered
-}
-
-// isBareModelID reports whether name is a foundation-model ID without an
-// inference-profile prefix (e.g. "anthropic.claude-opus-4-7" yes;
-// "us.anthropic.claude-opus-4-7" no).
-func isBareModelID(name string) bool {
-	return strings.HasPrefix(name, "anthropic.") &&
-		!strings.Contains(strings.TrimPrefix(name, "anthropic."), ".")
 }
 
 func (f *BedrockFixture) NewModel(modelName string) (llm.Model, error) {

--- a/providers/bedrock/models.go
+++ b/providers/bedrock/models.go
@@ -24,13 +24,15 @@ import (
 // Model ID constants for Claude models on Bedrock.
 //
 // Each logical Claude model is exposed as multiple Bedrock model IDs, one per
-// inference profile. AWS bills these at different rates: the bare ID and the
-// "global." profile use the headline price, while geo profiles
-// ("us." / "eu." / "au." / "apac.") carry a ~10% cross-region premium.
+// inference profile. AWS bills these at different rates: the bare ID (when
+// invokable) and the "global." profile use the headline price, while geo
+// profiles ("us." / "eu." / "au." / "apac.") carry a ~10% cross-region premium.
 //
-// New 4.6+ models (Sonnet 4.6, Opus 4.6/4.7) are inference-profile-only and
-// can only be invoked via a prefixed ID. Older 4.5 models can be invoked with
-// the bare ID for in-region access.
+// 4.6+ models (Sonnet 4.6, Opus 4.6, Opus 4.7) are inference-profile-only —
+// AWS does not allow on-demand invocation of the bare foundation-model ID, so
+// the bare constant exists only as a building block for the prefixed variants
+// and is not registered in supportedModels. Older 4.5 models can be invoked
+// with the bare ID for in-region access and have a real catalog entry.
 const (
 	// ModelClaudeSonnet46 is the bare Bedrock ID for Claude Sonnet 4.6
 	// (inference-profile-only — invoke via one of the prefixed variants).
@@ -86,7 +88,7 @@ type ModelDefinition struct {
 	Pricing      pricing.Info
 }
 
-// inferenceProfileRegion maps an AWS region to the Bedrock cross-region
+// InferenceProfileRegion maps an AWS region to the Bedrock cross-region
 // inference profile geographic prefix.
 //
 // AWS uses these prefixes:
@@ -95,7 +97,7 @@ type ModelDefinition struct {
 //   - "apac" for Asia Pacific      (ap-southeast-1, ap-northeast-1, …)
 //
 // See https://docs.aws.amazon.com/bedrock/latest/userguide/cross-region-inference-support.html
-func inferenceProfileRegion(region string) string {
+func InferenceProfileRegion(region string) string {
 	idx := strings.IndexByte(region, '-')
 	if idx <= 0 {
 		return "us"
@@ -138,7 +140,8 @@ type claudeModel struct {
 	label        string
 	capabilities llm.ModelCapabilities
 	constraints  llm.ModelConstraints
-	// baseRates apply to the bare ID and the "global." profile.
+	// baseRates apply to the bare ID (when invokable) and the "global."
+	// profile — these share the headline rate.
 	baseRates pricing.Rates
 	// geoRates apply to the geo profiles (us./eu./au./apac.) — the AWS
 	// cross-region inference premium (~10% over baseRates).
@@ -146,28 +149,36 @@ type claudeModel struct {
 	// geoProfiles lists the geo prefixes (without trailing dot) that AWS
 	// publishes for this model.
 	geoProfiles []string
+	// inferenceProfileOnly is true when AWS does not allow on-demand
+	// invocation of the bare foundation-model ID — the only valid calls go
+	// through an inference profile (global. / geo). Anthropic's 4.6+
+	// generation falls into this bucket. When set, expand() omits the bare
+	// catalog entry so Models() does not advertise an ID that cannot be
+	// invoked.
+	inferenceProfileOnly bool
 }
 
 // expand returns one ModelDefinition per inference profile variant.
 func (c claudeModel) expand() []ModelDefinition {
 	defs := make([]ModelDefinition, 0, 2+len(c.geoProfiles))
 
-	defs = append(defs,
-		ModelDefinition{
+	if !c.inferenceProfileOnly {
+		defs = append(defs, ModelDefinition{
 			Name:         c.baseID,
 			Label:        c.label,
 			Capabilities: c.capabilities,
 			Constraints:  c.constraints,
 			Pricing:      pricing.FlatInfoFromRates(c.baseRates),
-		},
-		ModelDefinition{
-			Name:         "global." + c.baseID,
-			Label:        c.label + " (Global)",
-			Capabilities: c.capabilities,
-			Constraints:  c.constraints,
-			Pricing:      pricing.FlatInfoFromRates(c.baseRates),
-		},
-	)
+		})
+	}
+
+	defs = append(defs, ModelDefinition{
+		Name:         "global." + c.baseID,
+		Label:        c.label + " (Global)",
+		Capabilities: c.capabilities,
+		Constraints:  c.constraints,
+		Pricing:      pricing.FlatInfoFromRates(c.baseRates),
+	})
 
 	for _, geo := range c.geoProfiles {
 		defs = append(defs, ModelDefinition{
@@ -229,7 +240,8 @@ var claudeModels = []claudeModel{
 			WithCacheCreation(6.25, 10.00, 0),
 		geoRates: pricing.NewRates(5.50, 27.50, 0.55).
 			WithCacheCreation(6.875, 11.00, 0),
-		geoProfiles: []string{"us", "eu", "au"},
+		geoProfiles:          []string{"us", "eu", "au"},
+		inferenceProfileOnly: true,
 	},
 	{
 		baseID:       ModelClaudeOpus46,
@@ -240,7 +252,8 @@ var claudeModels = []claudeModel{
 			WithCacheCreation(6.25, 10.00, 0),
 		geoRates: pricing.NewRates(5.50, 27.50, 0.55).
 			WithCacheCreation(6.875, 11.00, 0),
-		geoProfiles: []string{"us", "eu", "au"},
+		geoProfiles:          []string{"us", "eu", "au"},
+		inferenceProfileOnly: true,
 	},
 	{
 		baseID:       ModelClaudeOpus45,
@@ -262,7 +275,8 @@ var claudeModels = []claudeModel{
 			WithCacheCreation(3.75, 6.00, 0),
 		geoRates: pricing.NewRates(3.30, 16.50, 0.33).
 			WithCacheCreation(4.125, 6.60, 0),
-		geoProfiles: []string{"us", "eu", "au"},
+		geoProfiles:          []string{"us", "eu", "au"},
+		inferenceProfileOnly: true,
 	},
 	{
 		baseID:       ModelClaudeSonnet45,

--- a/providers/bedrock/models.go
+++ b/providers/bedrock/models.go
@@ -32,21 +32,22 @@ import (
 // can only be invoked via a prefixed ID. Older 4.5 models can be invoked with
 // the bare ID for in-region access.
 const (
-	// Claude Sonnet 4.6 (inference-profile-only).
+	// ModelClaudeSonnet46 is the bare Bedrock ID for Claude Sonnet 4.6
+	// (inference-profile-only — invoke via one of the prefixed variants).
 	ModelClaudeSonnet46       = "anthropic.claude-sonnet-4-6"
 	ModelClaudeSonnet46Global = "global." + ModelClaudeSonnet46
 	ModelClaudeSonnet46US     = "us." + ModelClaudeSonnet46
 	ModelClaudeSonnet46EU     = "eu." + ModelClaudeSonnet46
 	ModelClaudeSonnet46AU     = "au." + ModelClaudeSonnet46
 
-	// Claude Sonnet 4.5.
+	// ModelClaudeSonnet45 is the bare Bedrock ID for Claude Sonnet 4.5.
 	ModelClaudeSonnet45       = "anthropic.claude-sonnet-4-5-20250929-v1:0"
 	ModelClaudeSonnet45Global = "global." + ModelClaudeSonnet45
 	ModelClaudeSonnet45US     = "us." + ModelClaudeSonnet45
 	ModelClaudeSonnet45EU     = "eu." + ModelClaudeSonnet45
 	ModelClaudeSonnet45AU     = "au." + ModelClaudeSonnet45
 
-	// Claude Haiku 4.5.
+	// ModelClaudeHaiku45 is the bare Bedrock ID for Claude Haiku 4.5.
 	ModelClaudeHaiku45       = "anthropic.claude-haiku-4-5-20251001-v1:0"
 	ModelClaudeHaiku45Global = "global." + ModelClaudeHaiku45
 	ModelClaudeHaiku45US     = "us." + ModelClaudeHaiku45
@@ -54,21 +55,23 @@ const (
 	ModelClaudeHaiku45AU     = "au." + ModelClaudeHaiku45
 	ModelClaudeHaiku45APAC   = "apac." + ModelClaudeHaiku45
 
-	// Claude Opus 4.7 (inference-profile-only).
+	// ModelClaudeOpus47 is the bare Bedrock ID for Claude Opus 4.7
+	// (inference-profile-only — invoke via one of the prefixed variants).
 	ModelClaudeOpus47       = "anthropic.claude-opus-4-7"
 	ModelClaudeOpus47Global = "global." + ModelClaudeOpus47
 	ModelClaudeOpus47US     = "us." + ModelClaudeOpus47
 	ModelClaudeOpus47EU     = "eu." + ModelClaudeOpus47
 	ModelClaudeOpus47AU     = "au." + ModelClaudeOpus47
 
-	// Claude Opus 4.6 (inference-profile-only).
+	// ModelClaudeOpus46 is the bare Bedrock ID for Claude Opus 4.6
+	// (inference-profile-only — invoke via one of the prefixed variants).
 	ModelClaudeOpus46       = "anthropic.claude-opus-4-6-v1"
 	ModelClaudeOpus46Global = "global." + ModelClaudeOpus46
 	ModelClaudeOpus46US     = "us." + ModelClaudeOpus46
 	ModelClaudeOpus46EU     = "eu." + ModelClaudeOpus46
 	ModelClaudeOpus46AU     = "au." + ModelClaudeOpus46
 
-	// Claude Opus 4.5.
+	// ModelClaudeOpus45 is the bare Bedrock ID for Claude Opus 4.5.
 	ModelClaudeOpus45       = "anthropic.claude-opus-4-5-20251101-v1:0"
 	ModelClaudeOpus45Global = "global." + ModelClaudeOpus45
 	ModelClaudeOpus45EU     = "eu." + ModelClaudeOpus45
@@ -291,10 +294,12 @@ var supportedModels = buildSupportedModels()
 
 func buildSupportedModels() map[string]ModelDefinition {
 	m := make(map[string]ModelDefinition)
+
 	for _, model := range claudeModels {
 		for _, def := range model.expand() {
 			m[def.Name] = def
 		}
 	}
+
 	return m
 }

--- a/providers/bedrock/models.go
+++ b/providers/bedrock/models.go
@@ -24,9 +24,10 @@ import (
 // Model ID constants for Claude models on Bedrock.
 //
 // Each logical Claude model is exposed as multiple Bedrock model IDs, one per
-// inference profile. AWS bills these at different rates: the bare ID (when
-// invokable) and the "global." profile use the headline price, while geo
-// profiles ("us." / "eu." / "au." / "apac.") carry a ~10% cross-region premium.
+// inference profile. The catalog applies a single flat rate per logical model
+// to every variant — AWS actually charges a ~10% premium on the geo profiles
+// (us./eu./au./jp.) over the headline rate, so cost reports under-report on
+// geo invocations. Modelling per-variant pricing is tracked in AI-908.
 //
 // 4.6+ models (Sonnet 4.6, Opus 4.6, Opus 4.7) are inference-profile-only —
 // AWS does not allow on-demand invocation of the bare foundation-model ID, so
@@ -141,12 +142,17 @@ type claudeModel struct {
 	label        string
 	capabilities llm.ModelCapabilities
 	constraints  llm.ModelConstraints
-	// baseRates apply to the bare ID (when invokable) and the "global."
-	// profile — these share the headline rate.
-	baseRates pricing.Rates
-	// geoRates apply to the geo profiles (us./eu./au./apac.) — the AWS
-	// cross-region inference premium (~10% over baseRates).
-	geoRates pricing.Rates
+	// rates is applied uniformly to every variant (bare, global., and each
+	// geo profile). This is the headline rate AWS publishes for the model,
+	// and matches the bare/global. on-demand price.
+	//
+	// KNOWN LIMITATION: AWS actually charges a ~10% premium for the geo
+	// profiles (us./eu./au./jp.) over the headline rate, so cost reports
+	// derived from this catalog will under-report by ~10% for any geo
+	// invocation. See AI-908 for the proper fix (per-variant pricing for
+	// Claude, plus per-region overrides for non-Anthropic models like Nova /
+	// Gemma / DeepSeek where regional rates can differ by tens of percent).
+	rates pricing.Rates
 	// geoProfiles lists the geo prefixes (without trailing dot) that AWS
 	// publishes for this model.
 	geoProfiles []string
@@ -159,9 +165,13 @@ type claudeModel struct {
 	inferenceProfileOnly bool
 }
 
-// expand returns one ModelDefinition per inference profile variant.
+// expand returns one ModelDefinition per inference profile variant. All
+// variants share the same flat rate today — see the rates field doc for the
+// known under-reporting on geo profiles (tracked in AI-908).
 func (c claudeModel) expand() []ModelDefinition {
 	defs := make([]ModelDefinition, 0, 2+len(c.geoProfiles))
+
+	pricingInfo := pricing.FlatInfoFromRates(c.rates)
 
 	if !c.inferenceProfileOnly {
 		defs = append(defs, ModelDefinition{
@@ -169,7 +179,7 @@ func (c claudeModel) expand() []ModelDefinition {
 			Label:        c.label,
 			Capabilities: c.capabilities,
 			Constraints:  c.constraints,
-			Pricing:      pricing.FlatInfoFromRates(c.baseRates),
+			Pricing:      pricingInfo,
 		})
 	}
 
@@ -178,7 +188,7 @@ func (c claudeModel) expand() []ModelDefinition {
 		Label:        c.label + " (Global)",
 		Capabilities: c.capabilities,
 		Constraints:  c.constraints,
-		Pricing:      pricing.FlatInfoFromRates(c.baseRates),
+		Pricing:      pricingInfo,
 	})
 
 	for _, geo := range c.geoProfiles {
@@ -187,7 +197,7 @@ func (c claudeModel) expand() []ModelDefinition {
 			Label:        c.label + " (" + strings.ToUpper(geo) + ")",
 			Capabilities: c.capabilities,
 			Constraints:  c.constraints,
-			Pricing:      pricing.FlatInfoFromRates(c.geoRates),
+			Pricing:      pricingInfo,
 		})
 	}
 
@@ -224,23 +234,19 @@ var (
 // claudeModels enumerates every logical Claude model on Bedrock. Pricing
 // rates source: https://aws.amazon.com/bedrock/pricing/ (as of 2026-04).
 //
-// Per-profile pricing notes:
-//   - Bare ID and "global.": headline rate ("baseRates").
-//   - Geo profiles (us./eu./au./apac.): ~10% cross-region premium ("geoRates").
-//
-// Non-Anthropic Bedrock models (Gemma, DeepSeek, Amazon Nova) can have
-// larger regional pricing differences (up to ~57% premium); those should
-// model regional rates with pricing.Info overrides instead of this helper.
+// One flat rate per logical model is applied to every inference profile
+// variant. AWS actually charges a ~10% premium on the geo profiles
+// (us./eu./au./jp.) — this catalog under-reports cost on those by ~10%.
+// Modelling per-variant pricing (and per-region overrides for non-Anthropic
+// Bedrock models like Nova / Gemma / DeepSeek) is tracked in AI-908.
 var claudeModels = []claudeModel{
 	{
 		baseID:       ModelClaudeOpus47,
 		label:        "Claude Opus 4.7",
 		capabilities: claudeStandardCaps,
 		constraints:  claudeContext1MConstraints,
-		baseRates: pricing.NewRates(5.00, 25.00, 0.50).
+		rates: pricing.NewRates(5.00, 25.00, 0.50).
 			WithCacheCreation(6.25, 10.00, 0),
-		geoRates: pricing.NewRates(5.50, 27.50, 0.55).
-			WithCacheCreation(6.875, 11.00, 0),
 		geoProfiles:          []string{"us", "eu", "au"},
 		inferenceProfileOnly: true,
 	},
@@ -249,10 +255,8 @@ var claudeModels = []claudeModel{
 		label:        "Claude Opus 4.6",
 		capabilities: claudeStandardCaps,
 		constraints:  claudeContext1MConstraints,
-		baseRates: pricing.NewRates(5.00, 25.00, 0.50).
+		rates: pricing.NewRates(5.00, 25.00, 0.50).
 			WithCacheCreation(6.25, 10.00, 0),
-		geoRates: pricing.NewRates(5.50, 27.50, 0.55).
-			WithCacheCreation(6.875, 11.00, 0),
 		geoProfiles:          []string{"us", "eu", "au"},
 		inferenceProfileOnly: true,
 	},
@@ -261,10 +265,8 @@ var claudeModels = []claudeModel{
 		label:        "Claude Opus 4.5",
 		capabilities: claudeStandardCaps,
 		constraints:  claudeContext200kConstraints,
-		baseRates: pricing.NewRates(5.00, 25.00, 0.50).
+		rates: pricing.NewRates(5.00, 25.00, 0.50).
 			WithCacheCreation(6.25, 10.00, 0),
-		geoRates: pricing.NewRates(5.50, 27.50, 0.55).
-			WithCacheCreation(6.875, 11.00, 0),
 		geoProfiles: []string{"us", "eu"},
 	},
 	{
@@ -272,10 +274,8 @@ var claudeModels = []claudeModel{
 		label:        "Claude Sonnet 4.6",
 		capabilities: claudeStandardCaps,
 		constraints:  claudeContext200kConstraints,
-		baseRates: pricing.NewRates(3.00, 15.00, 0.30).
+		rates: pricing.NewRates(3.00, 15.00, 0.30).
 			WithCacheCreation(3.75, 6.00, 0),
-		geoRates: pricing.NewRates(3.30, 16.50, 0.33).
-			WithCacheCreation(4.125, 6.60, 0),
 		geoProfiles:          []string{"us", "eu", "au"},
 		inferenceProfileOnly: true,
 	},
@@ -284,10 +284,8 @@ var claudeModels = []claudeModel{
 		label:        "Claude Sonnet 4.5",
 		capabilities: claudeStandardCaps,
 		constraints:  claudeContext200kConstraints,
-		baseRates: pricing.NewRates(3.00, 15.00, 0.30).
+		rates: pricing.NewRates(3.00, 15.00, 0.30).
 			WithCacheCreation(3.75, 6.00, 0),
-		geoRates: pricing.NewRates(3.30, 16.50, 0.33).
-			WithCacheCreation(4.125, 6.60, 0),
 		geoProfiles: []string{"us", "eu", "au", "jp"},
 	},
 	{
@@ -295,10 +293,8 @@ var claudeModels = []claudeModel{
 		label:        "Claude Haiku 4.5",
 		capabilities: claudeStandardCaps,
 		constraints:  claudeContext200kConstraints,
-		baseRates: pricing.NewRates(1.00, 5.00, 0.10).
+		rates: pricing.NewRates(1.00, 5.00, 0.10).
 			WithCacheCreation(1.25, 2.00, 0),
-		geoRates: pricing.NewRates(1.10, 5.50, 0.11).
-			WithCacheCreation(1.375, 2.20, 0),
 		geoProfiles: []string{"us", "eu", "au"},
 	},
 }

--- a/providers/bedrock/models.go
+++ b/providers/bedrock/models.go
@@ -22,19 +22,61 @@ import (
 )
 
 // Model ID constants for Claude models on Bedrock.
-// These are real Bedrock model IDs that can be passed directly to NewModel.
+//
+// Each logical Claude model is exposed as multiple Bedrock model IDs, one per
+// inference profile. AWS bills these at different rates: the bare ID and the
+// "global." profile use the headline price, while geo profiles
+// ("us." / "eu." / "au." / "apac.") carry a ~10% cross-region premium.
+//
+// New 4.6+ models (Sonnet 4.6, Opus 4.6/4.7) are inference-profile-only and
+// can only be invoked via a prefixed ID. Older 4.5 models can be invoked with
+// the bare ID for in-region access.
 const (
-	ModelClaudeSonnet46 = "anthropic.claude-sonnet-4-6"
-	ModelClaudeSonnet45 = "anthropic.claude-sonnet-4-5-20250929-v1:0"
-	ModelClaudeHaiku45  = "anthropic.claude-haiku-4-5-20251001-v1:0"
-	ModelClaudeOpus47   = "anthropic.claude-opus-4-7"
-	ModelClaudeOpus46   = "anthropic.claude-opus-4-6-v1"
-	ModelClaudeOpus45   = "anthropic.claude-opus-4-5-20251101-v1:0"
+	// Claude Sonnet 4.6 (inference-profile-only).
+	ModelClaudeSonnet46       = "anthropic.claude-sonnet-4-6"
+	ModelClaudeSonnet46Global = "global." + ModelClaudeSonnet46
+	ModelClaudeSonnet46US     = "us." + ModelClaudeSonnet46
+	ModelClaudeSonnet46EU     = "eu." + ModelClaudeSonnet46
+	ModelClaudeSonnet46AU     = "au." + ModelClaudeSonnet46
+
+	// Claude Sonnet 4.5.
+	ModelClaudeSonnet45       = "anthropic.claude-sonnet-4-5-20250929-v1:0"
+	ModelClaudeSonnet45Global = "global." + ModelClaudeSonnet45
+	ModelClaudeSonnet45US     = "us." + ModelClaudeSonnet45
+	ModelClaudeSonnet45EU     = "eu." + ModelClaudeSonnet45
+	ModelClaudeSonnet45AU     = "au." + ModelClaudeSonnet45
+
+	// Claude Haiku 4.5.
+	ModelClaudeHaiku45       = "anthropic.claude-haiku-4-5-20251001-v1:0"
+	ModelClaudeHaiku45Global = "global." + ModelClaudeHaiku45
+	ModelClaudeHaiku45US     = "us." + ModelClaudeHaiku45
+	ModelClaudeHaiku45EU     = "eu." + ModelClaudeHaiku45
+	ModelClaudeHaiku45AU     = "au." + ModelClaudeHaiku45
+	ModelClaudeHaiku45APAC   = "apac." + ModelClaudeHaiku45
+
+	// Claude Opus 4.7 (inference-profile-only).
+	ModelClaudeOpus47       = "anthropic.claude-opus-4-7"
+	ModelClaudeOpus47Global = "global." + ModelClaudeOpus47
+	ModelClaudeOpus47US     = "us." + ModelClaudeOpus47
+	ModelClaudeOpus47EU     = "eu." + ModelClaudeOpus47
+	ModelClaudeOpus47AU     = "au." + ModelClaudeOpus47
+
+	// Claude Opus 4.6 (inference-profile-only).
+	ModelClaudeOpus46       = "anthropic.claude-opus-4-6-v1"
+	ModelClaudeOpus46Global = "global." + ModelClaudeOpus46
+	ModelClaudeOpus46US     = "us." + ModelClaudeOpus46
+	ModelClaudeOpus46EU     = "eu." + ModelClaudeOpus46
+	ModelClaudeOpus46AU     = "au." + ModelClaudeOpus46
+
+	// Claude Opus 4.5.
+	ModelClaudeOpus45       = "anthropic.claude-opus-4-5-20251101-v1:0"
+	ModelClaudeOpus45Global = "global." + ModelClaudeOpus45
+	ModelClaudeOpus45EU     = "eu." + ModelClaudeOpus45
 )
 
 // ModelDefinition defines a model with its capabilities and constraints.
 type ModelDefinition struct {
-	Name         string // Real Bedrock model ID (e.g. "anthropic.claude-sonnet-4-5-20250929-v1:0")
+	Name         string // Real Bedrock model ID (e.g. "us.anthropic.claude-sonnet-4-6")
 	Label        string
 	Capabilities llm.ModelCapabilities
 	Constraints  llm.ModelConstraints
@@ -78,166 +120,181 @@ func hasRegionPrefix(modelID string) bool {
 	return strings.ContainsRune(after, '.')
 }
 
-// lookupModel finds a ModelDefinition by model ID.
-// It tries a direct map lookup first, then strips the region prefix
-// (e.g. "us." from "us.anthropic.claude-sonnet-4-6") and retries.
+// lookupModel finds a ModelDefinition by exact model ID. Each inference
+// profile variant is registered as its own entry (with its own pricing), so
+// callers must pass the full prefixed ID to get the correct rate card.
 func lookupModel(modelName string) (ModelDefinition, bool) {
-	if def, ok := supportedModels[modelName]; ok {
-		return def, true
-	}
-
-	// Strip region prefix: "us.anthropic.claude-…" → "anthropic.claude-…"
-	if _, after, ok := strings.Cut(modelName, "."); ok {
-		if def, ok := supportedModels[after]; ok {
-			return def, true
-		}
-	}
-
-	return ModelDefinition{}, false
+	def, ok := supportedModels[modelName]
+	return def, ok
 }
 
-// supportedModels defines Claude models available on Bedrock via the Converse API.
-// Standard features only — no Anthropic-specific thinking/effort/speed.
+// claudeModel describes a single logical Claude model on Bedrock and the
+// inference profile variants under which it is exposed.
+type claudeModel struct {
+	baseID       string
+	label        string
+	capabilities llm.ModelCapabilities
+	constraints  llm.ModelConstraints
+	// baseRates apply to the bare ID and the "global." profile.
+	baseRates pricing.Rates
+	// geoRates apply to the geo profiles (us./eu./au./apac.) — the AWS
+	// cross-region inference premium (~10% over baseRates).
+	geoRates pricing.Rates
+	// geoProfiles lists the geo prefixes (without trailing dot) that AWS
+	// publishes for this model.
+	geoProfiles []string
+}
+
+// expand returns one ModelDefinition per inference profile variant.
+func (c claudeModel) expand() []ModelDefinition {
+	defs := make([]ModelDefinition, 0, 2+len(c.geoProfiles))
+
+	defs = append(defs,
+		ModelDefinition{
+			Name:         c.baseID,
+			Label:        c.label,
+			Capabilities: c.capabilities,
+			Constraints:  c.constraints,
+			Pricing:      pricing.FlatInfoFromRates(c.baseRates),
+		},
+		ModelDefinition{
+			Name:         "global." + c.baseID,
+			Label:        c.label + " (Global)",
+			Capabilities: c.capabilities,
+			Constraints:  c.constraints,
+			Pricing:      pricing.FlatInfoFromRates(c.baseRates),
+		},
+	)
+
+	for _, geo := range c.geoProfiles {
+		defs = append(defs, ModelDefinition{
+			Name:         geo + "." + c.baseID,
+			Label:        c.label + " (" + strings.ToUpper(geo) + ")",
+			Capabilities: c.capabilities,
+			Constraints:  c.constraints,
+			Pricing:      pricing.FlatInfoFromRates(c.geoRates),
+		})
+	}
+
+	return defs
+}
+
+// claudeMillionTokenCaps and claudeStandardCaps capture the two capability
+// shapes shared by all Claude models on Bedrock.
+var (
+	claudeStandardCaps = llm.ModelCapabilities{
+		Streaming:     true,
+		Tools:         true,
+		Vision:        false,
+		MultiTurn:     true,
+		SystemPrompts: true,
+		Reasoning:     true,
+	}
+
+	claudeContext1MConstraints = llm.ModelConstraints{
+		TemperatureRange: [2]float64{0.0, 1.0},
+		MaxInputTokens:   1000000,
+		MaxOutputTokens:  128000,
+		SupportedParams:  []string{"temperature", "top_p", "max_tokens", "stop"},
+	}
+
+	claudeContext200kConstraints = llm.ModelConstraints{
+		TemperatureRange: [2]float64{0.0, 1.0},
+		MaxInputTokens:   200000,
+		MaxOutputTokens:  64000,
+		SupportedParams:  []string{"temperature", "top_p", "max_tokens", "stop"},
+	}
+)
+
+// claudeModels enumerates every logical Claude model on Bedrock. Pricing
+// rates source: https://aws.amazon.com/bedrock/pricing/ (as of 2026-04).
 //
-// Pricing: Anthropic Claude models have uniform pricing across all Bedrock
-// regions — the rates here apply regardless of whether the request is routed
-// via in-region, geo cross-region (us./eu./ap. prefix), or global inference.
+// Per-profile pricing notes:
+//   - Bare ID and "global.": headline rate ("baseRates").
+//   - Geo profiles (us./eu./au./apac.): ~10% cross-region premium ("geoRates").
 //
-// Note: some non-Anthropic Bedrock models (Gemma, DeepSeek, Amazon Nova) DO
-// have regional pricing differences (up to ~57% premium in certain regions).
-// When those models are added, their definitions should include a
-// pricing.BedrockPricing sub-struct with regional overrides.
-var supportedModels = map[string]ModelDefinition{
-	ModelClaudeOpus47: {
-		Name:  ModelClaudeOpus47,
-		Label: "Claude Opus 4.7",
-		Capabilities: llm.ModelCapabilities{
-			Streaming:     true,
-			Tools:         true,
-			Vision:        false,
-			MultiTurn:     true,
-			SystemPrompts: true,
-			Reasoning:     true,
-		},
-		Constraints: llm.ModelConstraints{
-			TemperatureRange: [2]float64{0.0, 1.0},
-			MaxInputTokens:   1000000,
-			MaxOutputTokens:  128000,
-			SupportedParams:  []string{"temperature", "top_p", "max_tokens", "stop"},
-		},
-		Pricing: pricing.FlatInfoFromRates(
-			pricing.NewRates(5.00, 25.00, 0.50).
-				WithCacheCreation(6.25, 10.00, 0),
-		),
+// Non-Anthropic Bedrock models (Gemma, DeepSeek, Amazon Nova) can have
+// larger regional pricing differences (up to ~57% premium); those should
+// model regional rates with pricing.Info overrides instead of this helper.
+var claudeModels = []claudeModel{
+	{
+		baseID:       ModelClaudeOpus47,
+		label:        "Claude Opus 4.7",
+		capabilities: claudeStandardCaps,
+		constraints:  claudeContext1MConstraints,
+		baseRates: pricing.NewRates(5.00, 25.00, 0.50).
+			WithCacheCreation(6.25, 10.00, 0),
+		geoRates: pricing.NewRates(5.50, 27.50, 0.55).
+			WithCacheCreation(6.875, 11.00, 0),
+		geoProfiles: []string{"us", "eu", "au"},
 	},
-	ModelClaudeSonnet46: {
-		Name:  ModelClaudeSonnet46,
-		Label: "Claude Sonnet 4.6",
-		Capabilities: llm.ModelCapabilities{
-			Streaming:     true,
-			Tools:         true,
-			Vision:        false,
-			MultiTurn:     true,
-			SystemPrompts: true,
-			Reasoning:     true,
-		},
-		Constraints: llm.ModelConstraints{
-			TemperatureRange: [2]float64{0.0, 1.0},
-			MaxInputTokens:   200000,
-			MaxOutputTokens:  64000,
-			SupportedParams:  []string{"temperature", "top_p", "max_tokens", "stop"},
-		},
-		Pricing: pricing.FlatInfoFromRates(
-			pricing.NewRates(3.00, 15.00, 0.30).
-				WithCacheCreation(3.75, 6.00, 0),
-		),
+	{
+		baseID:       ModelClaudeOpus46,
+		label:        "Claude Opus 4.6",
+		capabilities: claudeStandardCaps,
+		constraints:  claudeContext1MConstraints,
+		baseRates: pricing.NewRates(5.00, 25.00, 0.50).
+			WithCacheCreation(6.25, 10.00, 0),
+		geoRates: pricing.NewRates(5.50, 27.50, 0.55).
+			WithCacheCreation(6.875, 11.00, 0),
+		geoProfiles: []string{"us", "eu", "au"},
 	},
-	ModelClaudeSonnet45: {
-		Name:  ModelClaudeSonnet45,
-		Label: "Claude Sonnet 4.5",
-		Capabilities: llm.ModelCapabilities{
-			Streaming:     true,
-			Tools:         true,
-			Vision:        false,
-			MultiTurn:     true,
-			SystemPrompts: true,
-			Reasoning:     true,
-		},
-		Constraints: llm.ModelConstraints{
-			TemperatureRange: [2]float64{0.0, 1.0},
-			MaxInputTokens:   200000,
-			MaxOutputTokens:  64000,
-			SupportedParams:  []string{"temperature", "top_p", "max_tokens", "stop"},
-		},
-		Pricing: pricing.FlatInfoFromRates(
-			pricing.NewRates(3.00, 15.00, 0.30).
-				WithCacheCreation(3.75, 6.00, 0),
-		),
+	{
+		baseID:       ModelClaudeOpus45,
+		label:        "Claude Opus 4.5",
+		capabilities: claudeStandardCaps,
+		constraints:  claudeContext200kConstraints,
+		baseRates: pricing.NewRates(5.00, 25.00, 0.50).
+			WithCacheCreation(6.25, 10.00, 0),
+		geoRates: pricing.NewRates(5.50, 27.50, 0.55).
+			WithCacheCreation(6.875, 11.00, 0),
+		geoProfiles: []string{"eu"},
 	},
-	ModelClaudeHaiku45: {
-		Name:  ModelClaudeHaiku45,
-		Label: "Claude Haiku 4.5",
-		Capabilities: llm.ModelCapabilities{
-			Streaming:     true,
-			Tools:         true,
-			Vision:        false,
-			MultiTurn:     true,
-			SystemPrompts: true,
-			Reasoning:     true,
-		},
-		Constraints: llm.ModelConstraints{
-			TemperatureRange: [2]float64{0.0, 1.0},
-			MaxInputTokens:   200000,
-			MaxOutputTokens:  64000,
-			SupportedParams:  []string{"temperature", "top_p", "max_tokens", "stop"},
-		},
-		Pricing: pricing.FlatInfoFromRates(
-			pricing.NewRates(1.00, 5.00, 0.10).
-				WithCacheCreation(1.25, 2.00, 0),
-		),
+	{
+		baseID:       ModelClaudeSonnet46,
+		label:        "Claude Sonnet 4.6",
+		capabilities: claudeStandardCaps,
+		constraints:  claudeContext200kConstraints,
+		baseRates: pricing.NewRates(3.00, 15.00, 0.30).
+			WithCacheCreation(3.75, 6.00, 0),
+		geoRates: pricing.NewRates(3.30, 16.50, 0.33).
+			WithCacheCreation(4.125, 6.60, 0),
+		geoProfiles: []string{"us", "eu", "au"},
 	},
-	ModelClaudeOpus46: {
-		Name:  ModelClaudeOpus46,
-		Label: "Claude Opus 4.6",
-		Capabilities: llm.ModelCapabilities{
-			Streaming:     true,
-			Tools:         true,
-			Vision:        false,
-			MultiTurn:     true,
-			SystemPrompts: true,
-			Reasoning:     true,
-		},
-		Constraints: llm.ModelConstraints{
-			TemperatureRange: [2]float64{0.0, 1.0},
-			MaxInputTokens:   1000000,
-			MaxOutputTokens:  128000,
-			SupportedParams:  []string{"temperature", "top_p", "max_tokens", "stop"},
-		},
-		Pricing: pricing.FlatInfoFromRates(
-			pricing.NewRates(5.00, 25.00, 0.50).
-				WithCacheCreation(6.25, 10.00, 0),
-		),
+	{
+		baseID:       ModelClaudeSonnet45,
+		label:        "Claude Sonnet 4.5",
+		capabilities: claudeStandardCaps,
+		constraints:  claudeContext200kConstraints,
+		baseRates: pricing.NewRates(3.00, 15.00, 0.30).
+			WithCacheCreation(3.75, 6.00, 0),
+		geoRates: pricing.NewRates(3.30, 16.50, 0.33).
+			WithCacheCreation(4.125, 6.60, 0),
+		geoProfiles: []string{"us", "eu", "au"},
 	},
-	ModelClaudeOpus45: {
-		Name:  ModelClaudeOpus45,
-		Label: "Claude Opus 4.5",
-		Capabilities: llm.ModelCapabilities{
-			Streaming:     true,
-			Tools:         true,
-			Vision:        false,
-			MultiTurn:     true,
-			SystemPrompts: true,
-			Reasoning:     true,
-		},
-		Constraints: llm.ModelConstraints{
-			TemperatureRange: [2]float64{0.0, 1.0},
-			MaxInputTokens:   200000,
-			MaxOutputTokens:  64000,
-			SupportedParams:  []string{"temperature", "top_p", "max_tokens", "stop"},
-		},
-		Pricing: pricing.FlatInfoFromRates(
-			pricing.NewRates(5.00, 25.00, 0.50).
-				WithCacheCreation(6.25, 10.00, 0),
-		),
+	{
+		baseID:       ModelClaudeHaiku45,
+		label:        "Claude Haiku 4.5",
+		capabilities: claudeStandardCaps,
+		constraints:  claudeContext200kConstraints,
+		baseRates: pricing.NewRates(1.00, 5.00, 0.10).
+			WithCacheCreation(1.25, 2.00, 0),
+		geoRates: pricing.NewRates(1.10, 5.50, 0.11).
+			WithCacheCreation(1.375, 2.20, 0),
+		geoProfiles: []string{"us", "eu", "au", "apac"},
 	},
+}
+
+// supportedModels is the per-variant catalog. Every Bedrock model ID that the
+// SDK accepts — including each inference profile prefix — is a key in this map.
+var supportedModels = buildSupportedModels()
+
+func buildSupportedModels() map[string]ModelDefinition {
+	m := make(map[string]ModelDefinition)
+	for _, model := range claudeModels {
+		for _, def := range model.expand() {
+			m[def.Name] = def
+		}
+	}
+	return m
 }

--- a/providers/bedrock/models.go
+++ b/providers/bedrock/models.go
@@ -48,6 +48,7 @@ const (
 	ModelClaudeSonnet45US     = "us." + ModelClaudeSonnet45
 	ModelClaudeSonnet45EU     = "eu." + ModelClaudeSonnet45
 	ModelClaudeSonnet45AU     = "au." + ModelClaudeSonnet45
+	ModelClaudeSonnet45JP     = "jp." + ModelClaudeSonnet45
 
 	// ModelClaudeHaiku45 is the bare Bedrock ID for Claude Haiku 4.5.
 	ModelClaudeHaiku45       = "anthropic.claude-haiku-4-5-20251001-v1:0"
@@ -55,7 +56,6 @@ const (
 	ModelClaudeHaiku45US     = "us." + ModelClaudeHaiku45
 	ModelClaudeHaiku45EU     = "eu." + ModelClaudeHaiku45
 	ModelClaudeHaiku45AU     = "au." + ModelClaudeHaiku45
-	ModelClaudeHaiku45APAC   = "apac." + ModelClaudeHaiku45
 
 	// ModelClaudeOpus47 is the bare Bedrock ID for Claude Opus 4.7
 	// (inference-profile-only — invoke via one of the prefixed variants).
@@ -76,6 +76,7 @@ const (
 	// ModelClaudeOpus45 is the bare Bedrock ID for Claude Opus 4.5.
 	ModelClaudeOpus45       = "anthropic.claude-opus-4-5-20251101-v1:0"
 	ModelClaudeOpus45Global = "global." + ModelClaudeOpus45
+	ModelClaudeOpus45US     = "us." + ModelClaudeOpus45
 	ModelClaudeOpus45EU     = "eu." + ModelClaudeOpus45
 )
 
@@ -264,7 +265,7 @@ var claudeModels = []claudeModel{
 			WithCacheCreation(6.25, 10.00, 0),
 		geoRates: pricing.NewRates(5.50, 27.50, 0.55).
 			WithCacheCreation(6.875, 11.00, 0),
-		geoProfiles: []string{"eu"},
+		geoProfiles: []string{"us", "eu"},
 	},
 	{
 		baseID:       ModelClaudeSonnet46,
@@ -287,7 +288,7 @@ var claudeModels = []claudeModel{
 			WithCacheCreation(3.75, 6.00, 0),
 		geoRates: pricing.NewRates(3.30, 16.50, 0.33).
 			WithCacheCreation(4.125, 6.60, 0),
-		geoProfiles: []string{"us", "eu", "au"},
+		geoProfiles: []string{"us", "eu", "au", "jp"},
 	},
 	{
 		baseID:       ModelClaudeHaiku45,
@@ -298,7 +299,7 @@ var claudeModels = []claudeModel{
 			WithCacheCreation(1.25, 2.00, 0),
 		geoRates: pricing.NewRates(1.10, 5.50, 0.11).
 			WithCacheCreation(1.375, 2.20, 0),
-		geoProfiles: []string{"us", "eu", "au", "apac"},
+		geoProfiles: []string{"us", "eu", "au"},
 	},
 }
 

--- a/providers/bedrock/provider.go
+++ b/providers/bedrock/provider.go
@@ -165,7 +165,7 @@ func (p *Provider) NewModel(modelName string, opts ...Option) (llm.Model, error)
 	apiModelID := modelName
 
 	if !hasRegionPrefix(apiModelID) {
-		apiModelID = inferenceProfileRegion(p.region) + "." + apiModelID
+		apiModelID = InferenceProfileRegion(p.region) + "." + apiModelID
 	}
 
 	// Look up by the prefixed ID — each inference profile variant is a

--- a/providers/bedrock/provider.go
+++ b/providers/bedrock/provider.go
@@ -159,11 +159,6 @@ func WithCaching() ProviderOption {
 
 // NewModel creates a new Bedrock model instance with the specified configuration.
 func (p *Provider) NewModel(modelName string, opts ...Option) (llm.Model, error) {
-	modelDef, ok := lookupModel(modelName)
-	if !ok {
-		return nil, fmt.Errorf("unsupported Bedrock model: %s", modelName)
-	}
-
 	// Build the API model ID with the region inference-profile prefix.
 	// If the caller already provided a region prefix (e.g. "eu.anthropic.…"),
 	// use it as-is. Otherwise prepend the provider's region.
@@ -171,6 +166,14 @@ func (p *Provider) NewModel(modelName string, opts ...Option) (llm.Model, error)
 
 	if !hasRegionPrefix(apiModelID) {
 		apiModelID = inferenceProfileRegion(p.region) + "." + apiModelID
+	}
+
+	// Look up by the prefixed ID — each inference profile variant is a
+	// separate catalog entry with its own pricing (geo profiles carry a
+	// cross-region premium over the base/global rate).
+	modelDef, ok := lookupModel(apiModelID)
+	if !ok {
+		return nil, fmt.Errorf("unsupported Bedrock model: %s", modelName)
 	}
 
 	cfg := &Config{

--- a/providers/bedrock/provider_test.go
+++ b/providers/bedrock/provider_test.go
@@ -133,7 +133,7 @@ func TestLookupModel(t *testing.T) {
 		},
 		{
 			name:   "geo profile not published for this model",
-			input:  "us." + ModelClaudeOpus45,
+			input:  "au." + ModelClaudeOpus45,
 			wantOK: false,
 		},
 	}
@@ -303,20 +303,20 @@ func TestNewModel_SupportedModels(t *testing.T) {
 	}
 }
 
-func TestNewModel_APACRegionPrefix(t *testing.T) {
+func TestNewModel_APACRegionPrefixHasNoMatchingModel(t *testing.T) {
 	t.Parallel()
 
-	// Provider configured with an Asia Pacific region should produce
-	// "apac." prefix, not "ap." (which AWS does not recognize). Haiku 4.5
-	// is the only Claude model with an apac inference profile.
+	// AWS does not publish an "apac." inference profile for any current
+	// Anthropic Claude model — Sonnet 4.5 has "jp." for Japan, and other
+	// Asia-Pacific regions have to use "global." instead. A provider in
+	// ap-southeast-1 calling NewModel with a bare Claude ID therefore fails
+	// at lookup; that's the correct behavior, exposed here as a regression
+	// guard so anyone re-introducing apac. needs to confirm AWS publishes it.
 	p := &Provider{client: nil, region: "ap-southeast-1"}
 
-	model, err := p.NewModel(ModelClaudeHaiku45)
-	require.NoError(t, err)
-
-	m, ok := model.(*Model)
-	require.True(t, ok)
-	assert.Equal(t, ModelClaudeHaiku45APAC, m.config.APIModelID)
+	_, err := p.NewModel(ModelClaudeHaiku45)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported Bedrock model")
 }
 
 func TestNewModel_USRegionPrefix(t *testing.T) {

--- a/providers/bedrock/provider_test.go
+++ b/providers/bedrock/provider_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/redpanda-data/ai-sdk-go/llm"
 )
 
-// ---------- inferenceProfileRegion ----------
+// ---------- InferenceProfileRegion ----------
 
 func TestInferenceProfileRegion(t *testing.T) {
 	t.Parallel()
@@ -51,7 +51,7 @@ func TestInferenceProfileRegion(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.region, func(t *testing.T) {
 			t.Parallel()
-			assert.Equal(t, tt.want, inferenceProfileRegion(tt.region))
+			assert.Equal(t, tt.want, InferenceProfileRegion(tt.region))
 		})
 	}
 }
@@ -93,10 +93,15 @@ func TestLookupModel(t *testing.T) {
 		wantDef string // expected ModelDefinition.Name if found
 	}{
 		{
-			name:    "base model ID",
-			input:   ModelClaudeSonnet46,
+			name:    "bare ID is invokable for 4.5 models",
+			input:   ModelClaudeSonnet45,
 			wantOK:  true,
-			wantDef: ModelClaudeSonnet46,
+			wantDef: ModelClaudeSonnet45,
+		},
+		{
+			name:   "bare ID is not in the catalog for inference-profile-only models",
+			input:  ModelClaudeSonnet46,
+			wantOK: false,
 		},
 		{
 			name:    "geo profile is its own entry",

--- a/providers/bedrock/provider_test.go
+++ b/providers/bedrock/provider_test.go
@@ -93,22 +93,28 @@ func TestLookupModel(t *testing.T) {
 		wantDef string // expected ModelDefinition.Name if found
 	}{
 		{
-			name:    "direct model ID",
+			name:    "base model ID",
 			input:   ModelClaudeSonnet46,
 			wantOK:  true,
 			wantDef: ModelClaudeSonnet46,
 		},
 		{
-			name:    "with region prefix",
-			input:   "eu." + ModelClaudeSonnet46,
+			name:    "geo profile is its own entry",
+			input:   ModelClaudeSonnet46EU,
 			wantOK:  true,
-			wantDef: ModelClaudeSonnet46,
+			wantDef: ModelClaudeSonnet46EU,
 		},
 		{
-			name:    "versioned with region",
-			input:   "us." + ModelClaudeHaiku45,
+			name:    "global profile is its own entry",
+			input:   ModelClaudeOpus47Global,
 			wantOK:  true,
-			wantDef: ModelClaudeHaiku45,
+			wantDef: ModelClaudeOpus47Global,
+		},
+		{
+			name:    "versioned model with region",
+			input:   ModelClaudeHaiku45US,
+			wantOK:  true,
+			wantDef: ModelClaudeHaiku45US,
 		},
 		{
 			name:   "unknown model",
@@ -118,6 +124,11 @@ func TestLookupModel(t *testing.T) {
 		{
 			name:   "unknown with region prefix",
 			input:  "us.meta.llama-3.2-90b",
+			wantOK: false,
+		},
+		{
+			name:   "geo profile not published for this model",
+			input:  "us." + ModelClaudeOpus45,
 			wantOK: false,
 		},
 	}
@@ -291,15 +302,16 @@ func TestNewModel_APACRegionPrefix(t *testing.T) {
 	t.Parallel()
 
 	// Provider configured with an Asia Pacific region should produce
-	// "apac." prefix, not "ap." (which AWS does not recognize).
+	// "apac." prefix, not "ap." (which AWS does not recognize). Haiku 4.5
+	// is the only Claude model with an apac inference profile.
 	p := &Provider{client: nil, region: "ap-southeast-1"}
 
-	model, err := p.NewModel(ModelClaudeSonnet46)
+	model, err := p.NewModel(ModelClaudeHaiku45)
 	require.NoError(t, err)
 
 	m, ok := model.(*Model)
 	require.True(t, ok)
-	assert.Equal(t, "apac."+ModelClaudeSonnet46, m.config.APIModelID)
+	assert.Equal(t, ModelClaudeHaiku45APAC, m.config.APIModelID)
 }
 
 func TestNewModel_USRegionPrefix(t *testing.T) {
@@ -811,7 +823,10 @@ func TestResponseMapper_TextResponse(t *testing.T) {
 	// Bedrock reports "optimized"; NormalizeSpeed collapses it to the
 	// cross-provider SpeedFast concept.
 	assert.Equal(t, llm.SpeedFast, resp.Speed)
-	assert.Equal(t, ModelClaudeSonnet46, resp.InvokedModelID)
+	// InvokedModelID reflects the actual inference profile AWS routed to,
+	// not just the logical model name — geo and global profiles bill at
+	// different rates so the routing identity matters downstream.
+	assert.Equal(t, ModelClaudeSonnet46US, resp.InvokedModelID)
 	require.NotNil(t, resp.Usage)
 	assert.Equal(t, 10, resp.Usage.InputTokens)
 	assert.Equal(t, 8, resp.Usage.OutputTokens)


### PR DESCRIPTION
## Summary

Split each Claude model on Bedrock into one catalog entry per AWS inference profile, so `Models()` and downstream cost reporting attribute per-profile (matching how LiteLLM and TrueFoundry expose Bedrock) and so the catalog never advertises a model ID that AWS won't accept on-demand.

## Why

The previous single-entry catalog had two problems:

1. **`Models()` exposed un-invokable IDs.** It returned bare names like `anthropic.claude-opus-4-7`, but newer 4.6+ models are inference-profile-only on AWS — calling them directly returns *"Invocation … with on-demand throughput isn't supported. Retry your request with the ID or ARN of an inference profile that contains this model."*
2. **Spend attribution couldn't distinguish profiles.** Every request routed through the SDK was billed by AWS as a specific inference profile (`us.` / `global.` / etc.), but the catalog only had a single logical entry per model — the gateway couldn't tell `us.opus-4-7` apart from `global.opus-4-7` in cost reports.

## What changed

- **`providers/bedrock/models.go`** — restructured catalog. Each logical Claude model is described once via a `claudeModel` struct (capabilities, constraints, pricing, supported geo profiles, whether it's inference-profile-only). `expand()` produces one `ModelDefinition` per profile (`global.` + each geo). Per-variant geo coverage cross-checked against AWS's per-model card pages, not LiteLLM (which has gaps and stale entries — we found `us.` missing for Opus 4.5, `jp.` missing for Sonnet 4.5, and a phantom `apac.` entry for Haiku 4.5 that AWS doesn't actually publish).
- **Bare entries are dropped for inference-profile-only models** (Sonnet 4.6, Opus 4.6, Opus 4.7). `Models()` won't list `anthropic.claude-opus-4-7` because it isn't on-demand invocable; the bare Go constant remains as a building block for the prefixed variants and as the ergonomic input form `NewModel("anthropic.claude-opus-4-7")` accepts (auto-prefix → matching geo entry).
- **`providers/bedrock/provider.go`** — `NewModel()` looks up the prefixed `apiModelID`, not the raw input, so the resolved `ModelDefinition` matches the actual inference profile AWS will route to.
- **`lookupModel`** is exact-match only — no prefix-stripping fallback (each variant is its own entry).
- **`response_mapper.go`** (via test) — `InvokedModelID` now reflects the actual inference profile AWS reported, not the bare logical name. Downstream cost attribution depends on routing identity.
- **Conformance fixture** — filters `Models()` to entries with the test region's geo prefix. Geo/`global.` variants stay in the SDK catalog (consumers see them) but are not exercised live, since one CI region can't reach all geographies and the SCP denies the foundation-model ARNs that `global.` resolves to. Per-variant catalog correctness is unit-tested.
- **`InferenceProfileRegion`** is now exported so the conformance fixture can compute the test region's geo prefix without duplicating logic.

## Known limitation: pricing is still flat per logical model

This PR keeps a single flat rate per logical Claude model, applied uniformly to every inference profile variant. AWS actually charges a ~10% premium on the geo profiles (`us.` / `eu.` / `au.` / `jp.`) over the headline rate, so cost reports under-report by ~10% for any geo invocation. Since `NewModel()` auto-prefixes a geo when given a bare name, that's the common path.

I had this fixed in an earlier revision of this PR (per-variant rates with the +10% premium baked in) but reverted it: the proper fix also has to handle non-Anthropic Bedrock models — Nova, Gemma, DeepSeek — where regional pricing can differ by tens of percent in non-uniform ways, which wants the existing `pricing.Info` `Selector{Region: …}` machinery rather than a per-prefix rate field. Tracked in [AI-957](https://redpandadata.atlassian.net/browse/AI-957).

## Pattern parity

Mirrors how LiteLLM and TrueFoundry expose Bedrock — every variant is its own catalog row, billed and reported separately.

## Backward compatibility

- Public Go API surface unchanged: `NewProvider`, `NewModel`, `WithRegion`, `ModelPricing`, `With*` options. `InferenceProfileRegion` is newly exported.
- Existing callers that pass un-prefixed names (`NewModel(ModelClaudeSonnet46)`) still work — auto-prefix is unchanged.
- `Models()` now returns ~30 entries instead of 6.
- `apac.` is no longer in the catalog for any Claude model — it never existed on AWS for these models, was an incorrect carry-over from LiteLLM.

## Test plan

- [x] `go test ./providers/bedrock/... -short` passes
- [x] `go vet ./...` clean
- [x] golangci-lint (godoclint, wsl_v5) clean
- [ ] CI integration tests (`TestBedrockConformance_Integration`) — fixture now filters to the test region's geo prefix so we don't try to invoke profiles the CI can't reach
- [ ] Reviewer sanity-check that the variant set per model matches AWS's per-model card pages (catalog was rebuilt against those, not LiteLLM)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[AI-957]: https://redpandadata.atlassian.net/browse/AI-957?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ