### PR TITLE
docs(usage): clarify CacheCreationUnknownTTL is forward-compat only

### DIFF
--- a/llm/types.go
+++ b/llm/types.go
@@ -78,15 +78,22 @@ type TokenUsage struct {
 	// Provider coverage: Anthropic, Bedrock-Anthropic.
 	CacheCreation1hTokens int `json:"cache_creation_1h_tokens,omitempty"`
 
-	// CacheCreationUnknownTTLTokens is the number of prompt tokens written
-	// to the provider's cache when a TTL-specific field was not available
-	// (older API shapes, future unknown TTLs). Disjoint from InputTokens and
-	// from the 5m/1h counters.
+	// CacheCreationUnknownTTLTokens is a defensive fallback bucket for
+	// cache-write tokens whose TTL the gateway can't categorize as 5m or
+	// 1h. Disjoint from InputTokens and from the 5m/1h counters.
 	//
-	// Extractors fall back to this field when a provider reports an
-	// aggregate cache-write count without a per-TTL breakdown, so the total
-	// stays reflected in BilledInputTokens() without pretending to know the
-	// TTL.
+	// Expected to stay at zero. Both Anthropic-direct and Bedrock Converse
+	// currently return clean per-TTL breakdowns whose sums match the
+	// aggregate cache-write count, so no tokens land here in practice. The
+	// bucket exists as forward-compat for two cases: (1) a provider
+	// introduces a new TTL string the extractor's switch doesn't recognize
+	// (e.g., a hypothetical 24h cache), and (2) the per-TTL breakdown
+	// covers fewer tokens than the aggregate. Either fires on an
+	// upstream-API change — the right response is to add an explicit TTL
+	// bucket (and rate) rather than treat this as a catch-all.
+	//
+	// Provider coverage: Anthropic, Bedrock-Anthropic. A non-zero value is
+	// a signal that gateway-side extraction needs updating.
 	CacheCreationUnknownTTLTokens int `json:"cache_creation_unknown_ttl_tokens,omitempty"`
 
 	// ToolUseInputTokens is the number of prompt tokens consumed by

--- a/pricing/rates.go
+++ b/pricing/rates.go
@@ -75,10 +75,18 @@ type Rates struct {
 
 	// Prompt-cache writes. Anthropic-family (direct + Bedrock) only:
 	// cache creation is billed separately from standard input, with
-	// distinct rates per TTL. CacheCreationUnknownTTL is the fallback
-	// bucket used when the provider reports aggregate cache-write
-	// tokens without a per-TTL breakdown. All three stay zero on
-	// providers that do not bill cache writes separately.
+	// distinct rates per TTL. All three stay zero on providers that do
+	// not bill cache writes separately.
+	//
+	// CacheCreationUnknownTTLPerMillion is the rate for the defensive
+	// fallback bucket described on llm.TokenUsage.CacheCreationUnknownTTLTokens.
+	// Anthropic does not publish a price for "unknown TTL" — and currently
+	// no tokens land in that bucket, since both Anthropic-direct and
+	// Bedrock Converse return clean per-TTL breakdowns. Catalog entries
+	// therefore set this to zero on purpose. If a provider later
+	// introduces a new TTL value (e.g., 24h), the correct fix is to add
+	// an explicit TTL bucket and price rather than invent a rate for
+	// "unknown".
 	CacheCreation5mPerMillion         int64
 	CacheCreation1hPerMillion         int64
 	CacheCreationUnknownTTLPerMillion int64


### PR DESCRIPTION
## Summary

- Comment-only change to two field declarations: `llm.TokenUsage.CacheCreationUnknownTTLTokens` and `pricing.Rates.CacheCreationUnknownTTLPerMillion`.
- Spell out that this bucket is **forward-compat defensive code**, not handling a current code path. Both Anthropic-direct and Bedrock Converse return clean per-TTL breakdowns whose sums match the aggregate cache-write count, so no tokens currently land here.
- Verified empirically with a live Bedrock Converse call against `us.anthropic.claude-sonnet-4-6` in `us-east-1`: response carried `cacheDetails: [{"ttl": "5m", "inputTokens": 4802}]` matching the aggregate `cacheWriteInputTokens: 4802`.
- Note on the pricing side: Anthropic does **not** publish a rate for "unknown TTL". Catalog entries pass `0` for `CacheCreationUnknownTTLPerMillion` deliberately. The new comment makes clear that if a provider introduces a new TTL value (e.g., 24h), the right fix is to add an explicit TTL bucket and rate rather than invent a fallback rate for "unknown".

## Why

The previous comments described the bucket in terms of "older API shapes" / "aggregate cache-write count without a per-TTL breakdown" — language that reads like a real, currently-occurring failure mode. It isn't, and the existing zero rate makes more sense once you frame it as forward-compat. This change makes that intent explicit so the next reader doesn't go looking for a missing price.

## Test plan

- [x] `go vet ./llm/... ./pricing/...` passes
- [x] `task lint:new` returns 0 issues
- [x] `task license:check` passes
- [x] Compile-only — no runtime behavior changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)