### PR TITLE
llmagent: add SystemPromptProvider for dynamic system prompts

### DIFF
--- a/agent/llmagent/config.go
+++ b/agent/llmagent/config.go
@@ -26,12 +26,17 @@ import (
 
 // SystemPromptProvider is a function that returns the system prompt for a
 // given request. It is called once per LLM call (i.e., every turn in the
-// agentic loop), receiving the request's context.Context so callers can
-// pass per-request data such as the authenticated user's identity.
+// agentic loop), receiving both the request context and the invocation
+// metadata so callers can draw from either source:
+//
+//   - ctx carries request-scoped values (e.g., authenticated identity
+//     injected by HTTP middleware via [context.WithValue]).
+//   - inv exposes session metadata, per-invocation metadata set by
+//     interceptors, and the current turn number.
 //
 // Use [WithSystemPromptProvider] to configure it. When set, it takes
 // precedence over the static systemPrompt string.
-type SystemPromptProvider func(ctx context.Context) (string, error)
+type SystemPromptProvider func(ctx context.Context, inv *agent.InvocationMetadata) (string, error)
 
 // config holds the internal configuration for an LLMAgent.
 type config struct {
@@ -89,9 +94,9 @@ type Option func(*config)
 // and the static systemPrompt argument to [New] is ignored. Pass an empty
 // string for systemPrompt when using a provider.
 //
-// The provider receives the request's context.Context, so callers can inject
-// per-request data (e.g., authenticated user identity) via [context.WithValue]
-// and read it back inside the provider.
+// The provider receives both context.Context (for request-scoped values like
+// authenticated identity) and [agent.InvocationMetadata] (for session state,
+// interceptor metadata, and turn number).
 func WithSystemPromptProvider(p SystemPromptProvider) Option {
 	return func(c *config) {
 		c.systemPromptProvider = p

--- a/agent/llmagent/config.go
+++ b/agent/llmagent/config.go
@@ -15,6 +15,7 @@
 package llmagent
 
 import (
+	"context"
 	"errors"
 	"fmt"
 
@@ -23,18 +24,28 @@ import (
 	"github.com/redpanda-data/ai-sdk-go/tool"
 )
 
+// SystemPromptProvider is a function that returns the system prompt for a
+// given request. It is called once per LLM call (i.e., every turn in the
+// agentic loop), receiving the request's context.Context so callers can
+// pass per-request data such as the authenticated user's identity.
+//
+// Use [WithSystemPromptProvider] to configure it. When set, it takes
+// precedence over the static systemPrompt string.
+type SystemPromptProvider func(ctx context.Context) (string, error)
+
 // config holds the internal configuration for an LLMAgent.
 type config struct {
-	name            string
-	description     string
-	systemPrompt    string
-	id              string
-	version         string
-	model           llm.Model
-	tools           tool.Registry
-	interceptors    []agent.Interceptor
-	maxTurns        int
-	toolConcurrency int
+	name                 string
+	description          string
+	systemPrompt         string
+	systemPromptProvider SystemPromptProvider
+	id                   string
+	version              string
+	model                llm.Model
+	tools                tool.Registry
+	interceptors         []agent.Interceptor
+	maxTurns             int
+	toolConcurrency      int
 }
 
 // validate checks that the configuration is valid.
@@ -43,8 +54,8 @@ func (c *config) validate() error {
 		return errors.New("llmagent: name is required")
 	}
 
-	if c.systemPrompt == "" {
-		return errors.New("llmagent: system prompt is required")
+	if c.systemPrompt == "" && c.systemPromptProvider == nil {
+		return errors.New("llmagent: system prompt is required (set either systemPrompt or SystemPromptProvider)")
 	}
 
 	if c.model == nil {
@@ -71,6 +82,21 @@ func (c *config) validate() error {
 
 // Option configures an LLMAgent.
 type Option func(*config)
+
+// WithSystemPromptProvider sets a dynamic system prompt provider.
+//
+// When set, the provider is called every turn to produce the system prompt,
+// and the static systemPrompt argument to [New] is ignored. Pass an empty
+// string for systemPrompt when using a provider.
+//
+// The provider receives the request's context.Context, so callers can inject
+// per-request data (e.g., authenticated user identity) via [context.WithValue]
+// and read it back inside the provider.
+func WithSystemPromptProvider(p SystemPromptProvider) Option {
+	return func(c *config) {
+		c.systemPromptProvider = p
+	}
+}
 
 // WithDescription sets the agent's description.
 // Used when wrapping agents as tools (agent-as-tool pattern).

--- a/agent/llmagent/llmagent.go
+++ b/agent/llmagent/llmagent.go
@@ -237,7 +237,10 @@ func (a *LLMAgent) executeSingleTurn(
 
 	// Build working message list with system prompt (not persisted)
 	// This creates a transient view for the LLM request
-	reqMessages := a.ensureSystemPrompt(sess.Messages)
+	reqMessages, err := a.resolveSystemPrompt(ctx, sess.Messages)
+	if err != nil {
+		return "", fmt.Errorf("llmagent: system prompt: %w", err)
+	}
 
 	// Prepare request
 	req := &llm.Request{
@@ -367,20 +370,34 @@ func (a *LLMAgent) executeSingleTurn(
 	return "", nil
 }
 
-// ensureSystemPrompt adds the system prompt if not already present.
+// resolveSystemPrompt produces a transient message list with the system
+// prompt prepended. The system prompt is never persisted to the session.
 //
-// The system prompt is never persisted - it's only added at runtime.
-// This prevents duplication across invocations.
-func (a *LLMAgent) ensureSystemPrompt(messages []llm.Message) []llm.Message {
-	if len(messages) > 0 && messages[0].Role == llm.RoleSystem {
-		// System prompt already present
-		return messages
+// When a [SystemPromptProvider] is configured it is called every turn,
+// receiving the request context so callers can pass per-request data
+// (e.g., the authenticated user's identity). Otherwise the static
+// systemPrompt string from the config is used.
+func (a *LLMAgent) resolveSystemPrompt(ctx context.Context, messages []llm.Message) ([]llm.Message, error) {
+	prompt := a.config.systemPrompt
+	if a.config.systemPromptProvider != nil {
+		p, err := a.config.systemPromptProvider(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		prompt = p
 	}
 
-	// Prepend system prompt
-	systemMsg := llm.NewMessage(llm.RoleSystem, llm.NewTextPart(a.config.systemPrompt))
+	systemMsg := llm.NewMessage(llm.RoleSystem, llm.NewTextPart(prompt))
 
-	return append([]llm.Message{systemMsg}, messages...)
+	// Strip an existing system message — it's always stale since the
+	// session never stores one; this guards against a previous turn's
+	// transient copy leaking in.
+	if len(messages) > 0 && messages[0].Role == llm.RoleSystem {
+		messages = messages[1:]
+	}
+
+	return append([]llm.Message{systemMsg}, messages...), nil
 }
 
 // generate calls the LLM to generate a response.

--- a/agent/llmagent/llmagent.go
+++ b/agent/llmagent/llmagent.go
@@ -237,7 +237,7 @@ func (a *LLMAgent) executeSingleTurn(
 
 	// Build working message list with system prompt (not persisted)
 	// This creates a transient view for the LLM request
-	reqMessages, err := a.resolveSystemPrompt(ctx, sess.Messages)
+	reqMessages, err := a.resolveSystemPrompt(ctx, inv, sess.Messages)
 	if err != nil {
 		return "", fmt.Errorf("llmagent: system prompt: %w", err)
 	}
@@ -374,13 +374,12 @@ func (a *LLMAgent) executeSingleTurn(
 // prompt prepended. The system prompt is never persisted to the session.
 //
 // When a [SystemPromptProvider] is configured it is called every turn,
-// receiving the request context so callers can pass per-request data
-// (e.g., the authenticated user's identity). Otherwise the static
-// systemPrompt string from the config is used.
-func (a *LLMAgent) resolveSystemPrompt(ctx context.Context, messages []llm.Message) ([]llm.Message, error) {
+// receiving both the request context and the invocation metadata.
+// Otherwise the static systemPrompt string from the config is used.
+func (a *LLMAgent) resolveSystemPrompt(ctx context.Context, inv *agent.InvocationMetadata, messages []llm.Message) ([]llm.Message, error) {
 	prompt := a.config.systemPrompt
 	if a.config.systemPromptProvider != nil {
-		p, err := a.config.systemPromptProvider(ctx)
+		p, err := a.config.systemPromptProvider(ctx, inv)
 		if err != nil {
 			return nil, err
 		}

--- a/agent/llmagent/llmagent_test.go
+++ b/agent/llmagent/llmagent_test.go
@@ -21,6 +21,7 @@ import (
 	"iter"
 	"strings"
 	"testing"
+	"text/template"
 	"time"
 
 	"github.com/stretchr/testify/assert"
@@ -95,7 +96,7 @@ func TestNew_Validation(t *testing.T) {
 			agentName: "test",
 			prompt:    "",
 			model:     model,
-			opts: []llmagent.Option{llmagent.WithSystemPromptProvider(func(context.Context) (string, error) {
+			opts: []llmagent.Option{llmagent.WithSystemPromptProvider(func(context.Context, *agent.InvocationMetadata) (string, error) {
 				return "dynamic prompt", nil
 			})},
 		},
@@ -209,38 +210,56 @@ func TestLLMAgent_Info(t *testing.T) {
 func TestRun_SystemPromptProvider(t *testing.T) {
 	t.Parallel()
 
-	t.Run("provider injects per-request data from context", func(t *testing.T) {
+	t.Run("go template with context and invocation metadata", func(t *testing.T) {
 		t.Parallel()
 
 		type emailKey struct{}
 
+		tmpl := template.Must(template.New("sys").Parse(
+			"You are assisting {{.Email}}, an employee at {{.Org}}. Session: {{.SessionID}}",
+		))
+
 		model := fakellm.NewFakeModel()
-		model.When(fakellm.SystemPromptContains("alice@example.com")).
-			ThenStreamText("Hello Alice!", fakellm.StreamConfig{})
+		model.When(fakellm.And(
+			fakellm.SystemPromptContains("alice@acme.com"),
+			fakellm.SystemPromptContains("AcmeCorp"),
+			fakellm.SystemPromptContains("sess-42"),
+		)).ThenStreamText("Hello Alice!", fakellm.StreamConfig{})
 
 		ag, err := llmagent.New("test-agent", "", model,
-			llmagent.WithSystemPromptProvider(func(ctx context.Context) (string, error) {
+			llmagent.WithSystemPromptProvider(func(ctx context.Context, inv *agent.InvocationMetadata) (string, error) {
 				email, _ := ctx.Value(emailKey{}).(string)
-				return "You are assisting " + email, nil
+				org, _ := inv.Session().Metadata["org"].(string)
+				var buf strings.Builder
+				if err := tmpl.Execute(&buf, map[string]string{
+					"Email":     email,
+					"Org":       org,
+					"SessionID": inv.Session().ID,
+				}); err != nil {
+					return "", err
+				}
+				return buf.String(), nil
 			}),
 		)
 		require.NoError(t, err)
 
 		sess := &session.State{
-			ID:       "test-session",
+			ID:       "sess-42",
 			Messages: []llm.Message{llm.NewMessage(llm.RoleUser, llm.NewTextPart("Hi"))},
+			Metadata: map[string]any{"org": "AcmeCorp"},
 		}
 		inv := agent.NewInvocationMetadata(sess, agent.Info{})
 
-		ctx := context.WithValue(t.Context(), emailKey{}, "alice@example.com")
+		ctx := context.WithValue(t.Context(), emailKey{}, "alice@acme.com")
 		events := collectEvents(t, ag.Run(ctx, inv))
 
 		endEvent := findInvocationEndEvent(events)
 		require.NotNil(t, endEvent)
 		assert.Equal(t, agent.FinishReasonStop, endEvent.FinishReason)
 
-		err = model.CheckCalled(fakellm.SystemPromptContains("alice@example.com"))
-		require.NoError(t, err)
+		require.NoError(t, model.CheckCalled(fakellm.SystemPromptContains("alice@acme.com")))
+		require.NoError(t, model.CheckCalled(fakellm.SystemPromptContains("AcmeCorp")))
+		require.NoError(t, model.CheckCalled(fakellm.SystemPromptContains("sess-42")))
 	})
 
 	t.Run("provider error is terminal", func(t *testing.T) {
@@ -250,7 +269,7 @@ func TestRun_SystemPromptProvider(t *testing.T) {
 		model.When(fakellm.Any()).ThenStreamText("unreachable", fakellm.StreamConfig{})
 
 		ag, err := llmagent.New("test-agent", "", model,
-			llmagent.WithSystemPromptProvider(func(context.Context) (string, error) {
+			llmagent.WithSystemPromptProvider(func(context.Context, *agent.InvocationMetadata) (string, error) {
 				return "", errors.New("identity service unavailable")
 			}),
 		)
@@ -284,7 +303,7 @@ func TestRun_SystemPromptProvider(t *testing.T) {
 			ThenStreamText("OK", fakellm.StreamConfig{})
 
 		ag, err := llmagent.New("test-agent", "static prompt", model,
-			llmagent.WithSystemPromptProvider(func(context.Context) (string, error) {
+			llmagent.WithSystemPromptProvider(func(context.Context, *agent.InvocationMetadata) (string, error) {
 				return "dynamic prompt", nil
 			}),
 		)
@@ -302,8 +321,7 @@ func TestRun_SystemPromptProvider(t *testing.T) {
 		require.NotNil(t, endEvent)
 		assert.Equal(t, agent.FinishReasonStop, endEvent.FinishReason)
 
-		err = model.CheckCalled(fakellm.SystemPromptContains("dynamic"))
-		require.NoError(t, err)
+		require.NoError(t, model.CheckCalled(fakellm.SystemPromptContains("dynamic")))
 	})
 }
 

--- a/agent/llmagent/llmagent_test.go
+++ b/agent/llmagent/llmagent_test.go
@@ -84,11 +84,20 @@ func TestNew_Validation(t *testing.T) {
 			wantErr:   "name is required",
 		},
 		{
-			name:      "missing prompt",
+			name:      "missing prompt and provider",
 			agentName: "test",
 			prompt:    "",
 			model:     model,
 			wantErr:   "system prompt is required",
+		},
+		{
+			name:      "provider replaces static prompt",
+			agentName: "test",
+			prompt:    "",
+			model:     model,
+			opts: []llmagent.Option{llmagent.WithSystemPromptProvider(func(context.Context) (string, error) {
+				return "dynamic prompt", nil
+			})},
 		},
 		{
 			name:      "missing model",
@@ -193,6 +202,108 @@ func TestLLMAgent_Info(t *testing.T) {
 		ag, err := llmagent.New("test-agent", "You are helpful", simpleModel{})
 		require.NoError(t, err)
 		assert.Empty(t, ag.Info().Description)
+	})
+}
+
+// TestRun_SystemPromptProvider verifies dynamic system prompt resolution.
+func TestRun_SystemPromptProvider(t *testing.T) {
+	t.Parallel()
+
+	t.Run("provider injects per-request data from context", func(t *testing.T) {
+		t.Parallel()
+
+		type emailKey struct{}
+
+		model := fakellm.NewFakeModel()
+		model.When(fakellm.SystemPromptContains("alice@example.com")).
+			ThenStreamText("Hello Alice!", fakellm.StreamConfig{})
+
+		ag, err := llmagent.New("test-agent", "", model,
+			llmagent.WithSystemPromptProvider(func(ctx context.Context) (string, error) {
+				email, _ := ctx.Value(emailKey{}).(string)
+				return "You are assisting " + email, nil
+			}),
+		)
+		require.NoError(t, err)
+
+		sess := &session.State{
+			ID:       "test-session",
+			Messages: []llm.Message{llm.NewMessage(llm.RoleUser, llm.NewTextPart("Hi"))},
+		}
+		inv := agent.NewInvocationMetadata(sess, agent.Info{})
+
+		ctx := context.WithValue(t.Context(), emailKey{}, "alice@example.com")
+		events := collectEvents(t, ag.Run(ctx, inv))
+
+		endEvent := findInvocationEndEvent(events)
+		require.NotNil(t, endEvent)
+		assert.Equal(t, agent.FinishReasonStop, endEvent.FinishReason)
+
+		err = model.CheckCalled(fakellm.SystemPromptContains("alice@example.com"))
+		require.NoError(t, err)
+	})
+
+	t.Run("provider error is terminal", func(t *testing.T) {
+		t.Parallel()
+
+		model := fakellm.NewFakeModel()
+		model.When(fakellm.Any()).ThenStreamText("unreachable", fakellm.StreamConfig{})
+
+		ag, err := llmagent.New("test-agent", "", model,
+			llmagent.WithSystemPromptProvider(func(context.Context) (string, error) {
+				return "", errors.New("identity service unavailable")
+			}),
+		)
+		require.NoError(t, err)
+
+		sess := &session.State{
+			ID:       "test-session",
+			Messages: []llm.Message{llm.NewMessage(llm.RoleUser, llm.NewTextPart("Hi"))},
+		}
+		inv := agent.NewInvocationMetadata(sess, agent.Info{})
+
+		var terminalErr error
+
+		for _, err := range ag.Run(t.Context(), inv) {
+			if err != nil {
+				terminalErr = err
+				break
+			}
+		}
+
+		require.Error(t, terminalErr)
+		assert.Contains(t, terminalErr.Error(), "identity service unavailable")
+		assert.Equal(t, 0, model.CallCount(), "model should not be called when provider fails")
+	})
+
+	t.Run("provider takes precedence over static prompt", func(t *testing.T) {
+		t.Parallel()
+
+		model := fakellm.NewFakeModel()
+		model.When(fakellm.SystemPromptContains("dynamic")).
+			ThenStreamText("OK", fakellm.StreamConfig{})
+
+		ag, err := llmagent.New("test-agent", "static prompt", model,
+			llmagent.WithSystemPromptProvider(func(context.Context) (string, error) {
+				return "dynamic prompt", nil
+			}),
+		)
+		require.NoError(t, err)
+
+		sess := &session.State{
+			ID:       "test-session",
+			Messages: []llm.Message{llm.NewMessage(llm.RoleUser, llm.NewTextPart("Hi"))},
+		}
+		inv := agent.NewInvocationMetadata(sess, agent.Info{})
+
+		events := collectEvents(t, ag.Run(t.Context(), inv))
+
+		endEvent := findInvocationEndEvent(events)
+		require.NotNil(t, endEvent)
+		assert.Equal(t, agent.FinishReasonStop, endEvent.FinishReason)
+
+		err = model.CheckCalled(fakellm.SystemPromptContains("dynamic"))
+		require.NoError(t, err)
 	})
 }
 

--- a/agent/llmagent/llmagent_test.go
+++ b/agent/llmagent/llmagent_test.go
@@ -230,6 +230,7 @@ func TestRun_SystemPromptProvider(t *testing.T) {
 			llmagent.WithSystemPromptProvider(func(ctx context.Context, inv *agent.InvocationMetadata) (string, error) {
 				email, _ := ctx.Value(emailKey{}).(string)
 				org, _ := inv.Session().Metadata["org"].(string)
+
 				var buf strings.Builder
 				if err := tmpl.Execute(&buf, map[string]string{
 					"Email":     email,
@@ -238,6 +239,7 @@ func TestRun_SystemPromptProvider(t *testing.T) {
 				}); err != nil {
 					return "", err
 				}
+
 				return buf.String(), nil
 			}),
 		)
@@ -257,9 +259,14 @@ func TestRun_SystemPromptProvider(t *testing.T) {
 		require.NotNil(t, endEvent)
 		assert.Equal(t, agent.FinishReasonStop, endEvent.FinishReason)
 
-		require.NoError(t, model.CheckCalled(fakellm.SystemPromptContains("alice@acme.com")))
-		require.NoError(t, model.CheckCalled(fakellm.SystemPromptContains("AcmeCorp")))
-		require.NoError(t, model.CheckCalled(fakellm.SystemPromptContains("sess-42")))
+		call, err := model.LastCall()
+		require.NoError(t, err)
+		require.NotEmpty(t, call.Request.Messages)
+		assert.Equal(t, llm.RoleSystem, call.Request.Messages[0].Role)
+		assert.Equal(t,
+			"You are assisting alice@acme.com, an employee at AcmeCorp. Session: sess-42",
+			call.Request.Messages[0].TextContent(),
+		)
 	})
 
 	t.Run("provider error is terminal", func(t *testing.T) {


### PR DESCRIPTION
## What

Add `SystemPromptProvider` -- a `func(ctx context.Context, inv *agent.InvocationMetadata) (string, error)` option that resolves the system prompt dynamically on every turn, replacing the static string when configured.

## Why

Shared agent binaries serving multiple users need per-request personalization in the system prompt (e.g., injecting the authenticated caller's identity). The static `systemPrompt` string can't do this. An interceptor-based workaround exists but is the wrong abstraction for something this fundamental.

## Implementation details

**New public API surface** (all in `agent/llmagent`):
- `SystemPromptProvider` type alias: `func(ctx context.Context, inv *agent.InvocationMetadata) (string, error)`
- `WithSystemPromptProvider(p)` option: when set, called every turn instead of the static string

**Internal change**: `ensureSystemPrompt()` became `resolveSystemPrompt(ctx, inv, messages)`. If a provider is configured, it runs; otherwise the static string is used unchanged. Provider errors are terminal, same as model call failures.

**Design choice**: The provider receives both `context.Context` and `*agent.InvocationMetadata`. Request-scoped data (user identity from HTTP middleware) flows through context; session metadata and interceptor-set state flow through the invocation. This gives the provider access to both data sources without inventing new state machinery.

No new packages, no new dependencies, no breaking changes. The static `systemPrompt` argument to `New()` can be empty when a provider is set; validation accepts either.