### PR TITLE
vercelaisdk: target ai@7.0.6 and fix conformance bugs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ go.work.sum
 .idea
 .build
 .bin
+
+# Vercel AI SDK reference clone (for adapter cross-checking)
+/vercel-ai-reference*/

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -73,6 +73,12 @@ tasks:
     cmds:
       - 'GOROOT={{.GO_ROOT}} GOTOOLCHAIN=local {{.GO_BIN}} test -json -cover -parallel 10 -timeout 30m -run Integration ./... | {{.BIN_DIR}}/tparse -follow -all'
 
+  test:conformance:
+    desc: Run the Vercel AI SDK UI message stream conformance suite (requires node + bun)
+    dir: adapter/vercelaisdk/uimessagestream/conformance
+    cmds:
+      - bash run.sh
+
   security:
     desc: Run security vulnerability checks (govulncheck + osv-scanner)
     deps:

--- a/adapter/vercelaisdk/uimessagestream/conformance/bun.lock
+++ b/adapter/vercelaisdk/uimessagestream/conformance/bun.lock
@@ -5,24 +5,24 @@
     "": {
       "name": "aisdk-conformance",
       "dependencies": {
-        "ai": "^6.0.177",
+        "ai": "^7.0.6",
       },
     },
   },
   "packages": {
-    "@ai-sdk/gateway": ["@ai-sdk/gateway@3.0.112", "", { "dependencies": { "@ai-sdk/provider": "3.0.10", "@ai-sdk/provider-utils": "4.0.27", "@vercel/oidc": "3.2.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-jiBao9pR4owWyjo0BnuNc7WSQBGOD0thysE4AFgZXaG+zMFbISQXUkJr7ePw/phBvePy7jE5FSA2Lf7lwqUiiQ=="],
+    "@ai-sdk/gateway": ["@ai-sdk/gateway@4.0.5", "", { "dependencies": { "@ai-sdk/provider": "4.0.0", "@ai-sdk/provider-utils": "5.0.1", "@vercel/oidc": "3.2.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-Zh4hxzrelJE0DDhaH7bXeUsB7ecFusRs+F7XHf0Dael6ekKG1GZCZgPw/lALEqyn1Vk1hLB+jjQgIoMTjA5m3A=="],
 
-    "@ai-sdk/provider": ["@ai-sdk/provider@3.0.10", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw=="],
+    "@ai-sdk/provider": ["@ai-sdk/provider@4.0.0", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-fr9Gs89prDWiuox/T+kCA+i2cJkHpxU5S+tr4megjTzRC27ZsvFhwjU/+XrqqMbvBUlfmXxTOYWy8ng45dsjIg=="],
 
-    "@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@4.0.27", "", { "dependencies": { "@ai-sdk/provider": "3.0.10", "@standard-schema/spec": "^1.1.0", "eventsource-parser": "^3.0.8" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-ubkAJ+xODouwtmN1tYlvTPphH1hPOBfZaEQe8U7skGvFAnIRs9PPpsq57bC2+Ky/MB4yzhd6YOsxTAx9sGpazw=="],
-
-    "@opentelemetry/api": ["@opentelemetry/api@1.9.0", "", {}, "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="],
+    "@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@5.0.1", "", { "dependencies": { "@ai-sdk/provider": "4.0.0", "@standard-schema/spec": "^1.1.0", "@workflow/serde": "4.1.0", "eventsource-parser": "^3.0.8" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-p9Ra+dN4jjHrssXvklNf4nFvWbj1KePMfUOs7nue0NuoIMbYFBULhX4Vu0+6DWLnw3+UsLL9+RCKLtzzU43Qpg=="],
 
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
     "@vercel/oidc": ["@vercel/oidc@3.2.0", "", {}, "sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug=="],
 
-    "ai": ["ai@6.0.177", "", { "dependencies": { "@ai-sdk/gateway": "3.0.112", "@ai-sdk/provider": "3.0.10", "@ai-sdk/provider-utils": "4.0.27", "@opentelemetry/api": "1.9.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-1xQtbeWwNcLyyM86ixZhkKvT+WRXc1lvarIKqPVtsyn8F9NDikwUMBqYu+aQKDgMht50SMXh4qboYuU8MeHZZA=="],
+    "@workflow/serde": ["@workflow/serde@4.1.0", "", {}, "sha512-pav4F2BoirECWR7Nf1TKt+2eETcBj7jj4cBefQ8VXQCA6NPkaKeLfj/zMgi+3zYV5ZIBT4GuUiphsj0/b9hPQQ=="],
+
+    "ai": ["ai@7.0.6", "", { "dependencies": { "@ai-sdk/gateway": "4.0.5", "@ai-sdk/provider": "4.0.0", "@ai-sdk/provider-utils": "5.0.1" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-RCina0WKhFgHQJHHOq+F11r9eaUo+Npcb84m7FDoYIVdG3IgeUb23fYfmqUTWIekI85c3GjkaTUxThiH3qHfkw=="],
 
     "eventsource-parser": ["eventsource-parser@3.0.8", "", {}, "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ=="],
 

--- a/adapter/vercelaisdk/uimessagestream/conformance/conformance.test.mjs
+++ b/adapter/vercelaisdk/uimessagestream/conformance/conformance.test.mjs
@@ -1,5 +1,5 @@
 // Conformance tests: verify that the Go aisdk adapter produces SSE streams
-// that the real Vercel AI SDK v6 TypeScript client parses correctly.
+// that the real Vercel AI SDK v7 TypeScript client parses correctly.
 //
 // This uses DefaultChatTransport + readUIMessageStream, which is the exact
 // same parsing path that useChat/AbstractChat uses internally.
@@ -27,7 +27,7 @@ async function sendChat(endpoint, userMessages) {
     api: `${baseUrl}${endpoint}`,
   });
 
-  // Build messages in AI SDK v6 format
+  // Build messages in AI SDK v7 format
   const messages = userMessages.map((msg, i) => ({
     id: `msg-${i}`,
     role: msg.role || 'user',
@@ -176,7 +176,7 @@ describe('AI SDK conformance', () => {
     );
   });
 
-  it('Test 4: multi-turn context with v6 parts format', async () => {
+  it('Test 4: multi-turn context with v7 parts format', async () => {
     const { message, errors } = await sendChat('/api/echo-context', [
       { text: 'My name is Alice' },
     ]);
@@ -275,5 +275,141 @@ describe('AI SDK conformance', () => {
     assert.equal(received[1].text, 'hi there');
     assert.equal(received[2].role, 'user');
     assert.equal(received[2].text, 'how are you?');
+  });
+
+  it('Test 7: reasoning then text', async () => {
+    const { message, errors } = await sendChat('/api/reasoning', [
+      { text: 'think' },
+    ]);
+
+    assert.equal(errors.length, 0, `unexpected errors: ${errors}`);
+    assert.ok(message, 'should have received a message');
+
+    const reasoningParts = message.parts.filter((p) => p.type === 'reasoning');
+    assert.ok(reasoningParts.length > 0, 'should have a reasoning part');
+    assert.equal(reasoningParts[0].text, 'Thinking about the question.');
+    for (const rp of reasoningParts) {
+      assert.equal(rp.state, 'done', 'reasoning part should be done');
+    }
+
+    const textParts = message.parts.filter((p) => p.type === 'text');
+    const fullText = textParts.map((p) => p.text).join('');
+    assert.equal(fullText, 'The answer is 42.');
+    for (const tp of textParts) {
+      assert.equal(tp.state, 'done', 'text part should be done');
+    }
+
+    // Reasoning must precede text in the assembled message.
+    const firstReasoning = message.parts.findIndex((p) => p.type === 'reasoning');
+    const firstText = message.parts.findIndex((p) => p.type === 'text');
+    assert.ok(
+      firstReasoning < firstText,
+      'reasoning part should come before text part'
+    );
+  });
+
+  it('Test 8: tool call then final answer', async () => {
+    const { message, errors } = await sendChat('/api/tools', [
+      { text: 'weather in SF?' },
+    ]);
+
+    assert.equal(errors.length, 0, `unexpected errors: ${errors}`);
+    assert.ok(message, 'should have received a message');
+
+    // The real client assembles the tool call into a tool-<name> part that
+    // transitions to output-available with the executor's output.
+    const toolParts = message.parts.filter((p) =>
+      p.type?.startsWith('tool-')
+    );
+    assert.equal(toolParts.length, 1, 'should have exactly one tool part');
+    assert.equal(toolParts[0].type, 'tool-getWeather');
+    assert.equal(
+      toolParts[0].state,
+      'output-available',
+      'tool part should reach output-available'
+    );
+    assert.deepEqual(toolParts[0].output, {
+      temperature: '72F',
+      conditions: 'sunny',
+    });
+
+    const fullText = message.parts
+      .filter((p) => p.type === 'text')
+      .map((p) => p.text)
+      .join('');
+    assert.equal(fullText, 'It is sunny and 72F in San Francisco.');
+  });
+
+  it('Test 9: tool executor error then recovery', async () => {
+    const { message, errors } = await sendChat('/api/tool-error', [
+      { text: 'weather in SF?' },
+    ]);
+
+    // tool-output-error is a normal part-state transition, not a stream error.
+    assert.equal(errors.length, 0, `unexpected errors: ${errors}`);
+
+    const toolParts = message.parts.filter((p) =>
+      p.type?.startsWith('tool-')
+    );
+    assert.equal(toolParts.length, 1, 'should have one tool part');
+    assert.equal(
+      toolParts[0].state,
+      'output-error',
+      'tool part should reach output-error'
+    );
+    assert.equal(toolParts[0].errorText, 'weather service unavailable');
+
+    const fullText = message.parts
+      .filter((p) => p.type === 'text')
+      .map((p) => p.text)
+      .join('');
+    assert.equal(fullText, 'I could not fetch the weather.');
+  });
+
+  it('Test 10: multi-step tool calls reset text ids across steps', async () => {
+    const { message, errors } = await sendChat('/api/multistep', [
+      { text: 'run both steps' },
+    ]);
+
+    assert.equal(errors.length, 0, `unexpected errors: ${errors}`);
+
+    const toolParts = message.parts.filter((p) =>
+      p.type?.startsWith('tool-')
+    );
+    assert.equal(toolParts.length, 2, 'should have two tool parts');
+    for (const tp of toolParts) {
+      assert.equal(tp.state, 'output-available');
+    }
+
+    // Final text streamed in a later step (after multiple finish-step resets)
+    // must still assemble without "missing text part" errors.
+    const fullText = message.parts
+      .filter((p) => p.type === 'text')
+      .map((p) => p.text)
+      .join('');
+    assert.equal(fullText, 'Both steps are complete.');
+  });
+
+  it('Test 11: mid-stream error closes the open text part', async () => {
+    const { message, errors } = await sendChat('/api/midstream-error', [
+      { text: 'go' },
+    ]);
+
+    // The mid-stream failure surfaces exactly one error to onError.
+    assert.ok(errors.length >= 1, 'should surface the mid-stream error');
+    const errorTexts = errors.map((e) => e.message || String(e));
+    assert.ok(
+      errorTexts.some((t) => t.includes('server error')),
+      `expected server error, got: ${errorTexts.join(', ')}`
+    );
+
+    // The partial text emitted before the failure must be closed (state done):
+    // the adapter emits text-end before the error chunk, so the client does not
+    // throw "missing text part".
+    const textParts = message.parts.filter((p) => p.type === 'text');
+    assert.ok(textParts.length > 0, 'should have partial text');
+    for (const tp of textParts) {
+      assert.equal(tp.state, 'done', 'partial text part should be closed');
+    }
   });
 });

--- a/adapter/vercelaisdk/uimessagestream/conformance/package.json
+++ b/adapter/vercelaisdk/uimessagestream/conformance/package.json
@@ -6,6 +6,6 @@
     "test": "node --test conformance.test.mjs"
   },
   "dependencies": {
-    "ai": "^6.0.177"
+    "ai": "^7.0.6"
   }
 }

--- a/adapter/vercelaisdk/uimessagestream/conformance/testserver/main.go
+++ b/adapter/vercelaisdk/uimessagestream/conformance/testserver/main.go
@@ -6,6 +6,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"log/slog"
@@ -40,12 +41,14 @@ func main() {
 		ThenStreamText("Hello streaming world", fakellm.StreamConfig{ChunkSize: 4})
 	mux.Handle("POST /api/streaming", uimessagestream.Handler(streamModel))
 
-	// POST /api/error -- rate limit error
+	// POST /api/error -- rate limit error, surfaced to the client via WithOnError
+	// (mirrors the reference onError option that maps an error to client text).
 	errorModel := fakellm.NewFakeModel(
 		fakellm.WithLatency(fakellm.LatencyProfile{}),
 	).When(fakellm.Any()).
 		ThenError(llm.ErrRateLimitExceeded)
-	mux.Handle("POST /api/error", uimessagestream.Handler(errorModel))
+	mux.Handle("POST /api/error", uimessagestream.Handler(errorModel,
+		uimessagestream.WithOnError(func(err error) string { return err.Error() })))
 
 	// POST /api/echo-context -- echoes back the received messages as JSON text
 	echoModel := fakellm.NewFakeModel(
@@ -97,6 +100,86 @@ func main() {
 			}, nil
 		})
 	mux.Handle("POST /api/system", uimessagestream.Handler(systemModel, uimessagestream.WithSystem("You are a pirate")))
+
+	// POST /api/reasoning -- emits a reasoning trace followed by text.
+	reasoningModel := fakellm.NewFakeModel(
+		fakellm.WithLatency(fakellm.LatencyProfile{}),
+	).When(fakellm.Any()).
+		ThenRespondWith(func(_ *llm.Request, _ *fakellm.CallContext) (*llm.Response, error) {
+			return &llm.Response{
+				Message: llm.NewMessage(llm.RoleAssistant,
+					llm.NewReasoningPart("Thinking about the question."),
+					llm.NewTextPart("The answer is 42."),
+				),
+				FinishReason: llm.FinishReasonStop,
+			}, nil
+		})
+	mux.Handle("POST /api/reasoning", uimessagestream.Handler(reasoningModel))
+
+	// Tool definition shared by the tool-calling endpoints.
+	weatherTool := llm.ToolDefinition{
+		Name:        "getWeather",
+		Description: "Get the current weather for a city.",
+		Parameters:  json.RawMessage(`{"type":"object","properties":{"city":{"type":"string"}},"required":["city"]}`),
+	}
+
+	// POST /api/tools -- single tool call, then a final text answer.
+	toolModel := fakellm.NewFakeModel(fakellm.WithLatency(fakellm.LatencyProfile{}))
+	toolModel.When(fakellm.LastMessageHasToolResponse("getWeather")).
+		ThenStreamText("It is sunny and 72F in San Francisco.", fakellm.StreamConfig{ChunkSize: 100})
+	toolModel.When(fakellm.Any()).
+		ThenRespondWithToolCall("getWeather", map[string]any{"city": "San Francisco"})
+
+	weatherExec := func(_ context.Context, _ string, _ json.RawMessage) (json.RawMessage, error) {
+		return json.RawMessage(`{"temperature":"72F","conditions":"sunny"}`), nil
+	}
+	mux.Handle("POST /api/tools", uimessagestream.Handler(toolModel,
+		uimessagestream.WithTools([]llm.ToolDefinition{weatherTool}, weatherExec)))
+
+	// POST /api/tool-error -- tool call whose executor fails, then a final text.
+	toolErrModel := fakellm.NewFakeModel(fakellm.WithLatency(fakellm.LatencyProfile{}))
+	toolErrModel.When(fakellm.LastMessageHasToolResponse("getWeather")).
+		ThenStreamText("I could not fetch the weather.", fakellm.StreamConfig{ChunkSize: 100})
+	toolErrModel.When(fakellm.Any()).
+		ThenRespondWithToolCall("getWeather", map[string]any{"city": "San Francisco"})
+
+	failingExec := func(_ context.Context, _ string, _ json.RawMessage) (json.RawMessage, error) {
+		return nil, errors.New("weather service unavailable")
+	}
+	mux.Handle("POST /api/tool-error", uimessagestream.Handler(toolErrModel,
+		uimessagestream.WithTools([]llm.ToolDefinition{weatherTool}, failingExec),
+		uimessagestream.WithOnError(func(err error) string { return err.Error() })))
+
+	// POST /api/multistep -- two sequential tool calls, then a final text answer.
+	// Exercises text-id reset across multiple finish-step boundaries.
+	stepOne := llm.ToolDefinition{Name: "stepOne", Description: "first step", Parameters: json.RawMessage(`{"type":"object"}`)}
+	stepTwo := llm.ToolDefinition{Name: "stepTwo", Description: "second step", Parameters: json.RawMessage(`{"type":"object"}`)}
+	multiModel := fakellm.NewFakeModel(fakellm.WithLatency(fakellm.LatencyProfile{}))
+	multiModel.When(fakellm.LastMessageHasToolResponse("stepTwo")).
+		ThenStreamText("Both steps are complete.", fakellm.StreamConfig{ChunkSize: 4})
+	multiModel.When(fakellm.LastMessageHasToolResponse("stepOne")).
+		ThenRespondWithToolCall("stepTwo", map[string]any{})
+	multiModel.When(fakellm.Any()).
+		ThenRespondWithToolCall("stepOne", map[string]any{})
+
+	stepExec := func(_ context.Context, name string, _ json.RawMessage) (json.RawMessage, error) {
+		return json.RawMessage(`{"step":"` + name + `","ok":true}`), nil
+	}
+	mux.Handle("POST /api/multistep", uimessagestream.Handler(multiModel,
+		uimessagestream.WithTools([]llm.ToolDefinition{stepOne, stepTwo}, stepExec)))
+
+	// POST /api/midstream-error -- streams partial text, then fails mid-stream.
+	// The open text part must be closed (text-end) before the error chunk so the
+	// client does not throw "missing text part".
+	midModel := fakellm.NewFakeModel(fakellm.WithLatency(fakellm.LatencyProfile{})).
+		When(fakellm.Any()).
+		ThenStreamText("Hello mid stream world", fakellm.StreamConfig{
+			ChunkSize:        4,
+			ErrorAfterChunks: 2,
+			MidStreamError:   llm.ErrServerError,
+		})
+	mux.Handle("POST /api/midstream-error", uimessagestream.Handler(midModel,
+		uimessagestream.WithOnError(func(err error) string { return err.Error() })))
 
 	// Health check.
 	mux.HandleFunc("GET /health", func(w http.ResponseWriter, _ *http.Request) {

--- a/adapter/vercelaisdk/uimessagestream/handler.go
+++ b/adapter/vercelaisdk/uimessagestream/handler.go
@@ -10,18 +10,30 @@
 //
 //	start → start-step → text-start → text-delta* → text-end → finish-step → finish → [DONE]
 //
-// This is a 1:1 port of the Vercel AI SDK's toUIMessageStream() from
-// packages/ai/src/generate-text/stream-text.ts and the SSE framing from
-// packages/ai/src/ui-message-stream/json-to-sse-transform-stream.ts.
+// This is a port of the Vercel AI SDK's UI message stream. Per-part chunk
+// shapes mirror packages/ai/src/ui-message-stream/to-ui-message-chunk.ts, the
+// stream assembly mirrors to-ui-message-stream.ts, and the SSE framing mirrors
+// json-to-sse-transform-stream.ts. Verified against ai@7.0.6.
+//
+// Inbound multi-turn history (including assistant tool calls and their results)
+// is reconstructed from the UI message parts, mirroring convert-to-model-messages.ts.
+//
+// Known limitations:
+//   - Inbound file/image parts are not forwarded to the model: the llm.Part
+//     type has no file kind yet. Inbound reasoning parts are likewise dropped.
+//   - The handler calls model.GenerateEvents directly; interceptor plugins
+//     (retry, OTel) must be wired at the model level.
 //
 // Reference: https://github.com/vercel/ai
 package uimessagestream
 
 import (
+	"bytes"
 	"context"
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -36,7 +48,12 @@ import (
 // protocol. It accepts POST requests with a JSON body containing messages
 // and streams back SSE events compatible with useChat.
 func Handler(model llm.Model, opts ...Option) http.Handler {
-	cfg := &config{logger: slog.Default()}
+	cfg := &config{
+		logger:       slog.Default(),
+		maxBodyBytes: 1 << 20, // 1MB
+		maxTurns:     10,
+		onError:      defaultErrorMapper,
+	}
 	for _, o := range opts {
 		o(cfg)
 	}
@@ -51,11 +68,26 @@ type Option func(*config)
 // tool name and parsed JSON arguments, and returns the result as JSON bytes.
 type ToolExecutor func(ctx context.Context, name string, args json.RawMessage) (json.RawMessage, error)
 
+// ErrorMapper maps an error to the client-facing text emitted in "error" and
+// "tool-output-error" chunks. It mirrors the Vercel AI SDK's onError option
+// (toUIMessageStream / toUIMessageChunk). The default returns a sanitized,
+// generic message to avoid leaking server-side error details to the client.
+type ErrorMapper func(error) string
+
+// defaultErrorText matches the Vercel AI SDK default onError return value
+// (packages/ai/src/ui-message-stream/to-ui-message-chunk.ts: () => 'An error occurred.').
+const defaultErrorText = "An error occurred."
+
+func defaultErrorMapper(error) string { return defaultErrorText }
+
 type config struct {
-	system   string
-	logger   *slog.Logger
-	tools    []llm.ToolDefinition
-	executor ToolExecutor
+	system       string
+	logger       *slog.Logger
+	tools        []llm.ToolDefinition
+	executor     ToolExecutor
+	maxBodyBytes int64
+	maxTurns     int
+	onError      ErrorMapper
 }
 
 // WithSystem sets the system prompt prepended to every request.
@@ -79,6 +111,29 @@ func WithTools(tools []llm.ToolDefinition, executor ToolExecutor) Option {
 	}
 }
 
+// WithMaxBodyBytes sets the maximum request body size in bytes. Default is 1MB.
+func WithMaxBodyBytes(n int64) Option {
+	return func(c *config) { c.maxBodyBytes = n }
+}
+
+// WithMaxTurns sets the maximum number of agentic tool-calling turns. Default is 10.
+func WithMaxTurns(n int) Option {
+	return func(c *config) { c.maxTurns = n }
+}
+
+// WithOnError sets the mapper that produces the client-facing error text for
+// "error" and "tool-output-error" chunks. This mirrors the Vercel AI SDK's
+// onError option. By default a sanitized, generic message ("An error occurred.")
+// is sent to avoid leaking server-side error details. Provide a custom mapper
+// to surface specific error information to the client. A nil mapper is ignored.
+func WithOnError(fn ErrorMapper) Option {
+	return func(c *config) {
+		if fn != nil {
+			c.onError = fn
+		}
+	}
+}
+
 type handler struct {
 	model llm.Model
 	cfg   *config
@@ -88,7 +143,6 @@ type handler struct {
 type chatRequest struct {
 	ID       string        `json:"id"`
 	Messages []chatMessage `json:"messages"`
-	Trigger  string        `json:"trigger"`
 }
 
 type chatMessage struct {
@@ -100,10 +154,37 @@ type chatMessage struct {
 type messagePart struct {
 	Type string `json:"type"`
 	Text string `json:"text"`
+
+	// Tool-call part fields. Tool parts carry a Type of "tool-<toolName>"
+	// (static tools) or "dynamic-tool" (with ToolName set), mirroring the v7 UI
+	// message ToolUIPart / DynamicToolUIPart shapes. The JSON tags are the
+	// camelCase names the Vercel AI SDK useChat client sends on the wire.
+	ToolCallID string          `json:"toolCallId"` //nolint:tagliatelle // Vercel AI SDK wire format is camelCase
+	ToolName   string          `json:"toolName"`   //nolint:tagliatelle // Vercel AI SDK wire format is camelCase
+	State      string          `json:"state"`
+	Input      json.RawMessage `json:"input"`
+	Output     json.RawMessage `json:"output"`
+	ErrorText  string          `json:"errorText"` //nolint:tagliatelle // Vercel AI SDK wire format is camelCase
+}
+
+// isTool reports whether the part is a tool-call part.
+func (p messagePart) isTool() bool {
+	return p.Type == "dynamic-tool" || strings.HasPrefix(p.Type, "tool-")
+}
+
+// toolName returns the tool name for a tool-call part. Static tool parts encode
+// the name in the type suffix ("tool-getWeather"); dynamic tool parts carry it
+// in the toolName field.
+func (p messagePart) toolName() string {
+	if p.Type == "dynamic-tool" {
+		return p.ToolName
+	}
+
+	return strings.TrimPrefix(p.Type, "tool-")
 }
 
 // textContent extracts the text content from a message, supporting both
-// the v6 parts-based format and the legacy content field.
+// the v7 parts-based format and the legacy content field.
 // All text parts are concatenated to preserve multi-step conversation history.
 func (m chatMessage) textContent() string {
 	var parts []string
@@ -127,8 +208,8 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Limit request body to 1MB to prevent abuse.
-	r.Body = http.MaxBytesReader(w, r.Body, 1<<20)
+	// Limit request body size to prevent abuse.
+	r.Body = http.MaxBytesReader(w, r.Body, h.cfg.maxBodyBytes)
 
 	var body chatRequest
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
@@ -158,14 +239,14 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	setSSEHeaders(w)
 
 	ew := &EventWriter{w: w, f: flusher}
-	StreamModelWithTools(r.Context(), h.model, req, ew, h.cfg.logger, h.cfg.executor)
+	StreamModelWithTools(r.Context(), h.model, req, ew, h.cfg.logger, h.cfg.executor, h.cfg.maxTurns, h.cfg.onError)
 }
 
 // generateMessageID creates a random 16-character hex ID for use as a messageId.
 func generateMessageID() string {
 	b := make([]byte, 8)
 	if _, err := rand.Read(b); err != nil {
-		return "msg-0000000000000000"
+		return "0000000000000000"
 	}
 
 	return hex.EncodeToString(b)
@@ -182,16 +263,25 @@ const (
 // complexity of StreamModel and StreamModelWithTools.
 type streamWriter struct {
 	ew               *EventWriter
+	logger           *slog.Logger
+	onError          ErrorMapper
 	textID           string
 	reasoningID      string
 	textStarted      bool
 	reasoningStarted bool
 	textCounter      int
+	reasoningCounter int
 }
 
-func newStreamWriter(ew *EventWriter) *streamWriter {
+func newStreamWriter(ew *EventWriter, logger *slog.Logger, onError ErrorMapper) *streamWriter {
+	if onError == nil {
+		onError = defaultErrorMapper
+	}
+
 	return &streamWriter{
 		ew:          ew,
+		logger:      logger,
+		onError:     onError,
 		textID:      "text-0",
 		reasoningID: "reasoning-0",
 	}
@@ -207,20 +297,8 @@ func (sw *streamWriter) endReasoning() error {
 	}
 
 	sw.reasoningStarted = false
-
-	return nil
-}
-
-func (sw *streamWriter) endText() error {
-	if !sw.textStarted {
-		return nil
-	}
-
-	if err := sw.ew.WriteChunk(Chunk{"type": "text-end", "id": sw.textID}); err != nil {
-		return err
-	}
-
-	sw.textStarted = false
+	sw.reasoningCounter++
+	sw.reasoningID = fmt.Sprintf("reasoning-%d", sw.reasoningCounter)
 
 	return nil
 }
@@ -257,7 +335,11 @@ func (sw *streamWriter) writeTextDelta(text string) error {
 	return sw.ew.WriteChunk(Chunk{"type": "text-delta", "id": sw.textID, "delta": text})
 }
 
-func (sw *streamWriter) writeReasoningDelta(trace *llm.ReasoningPart) error {
+func (sw *streamWriter) writeReasoningDelta(reasoning *llm.ReasoningPart) error {
+	if err := sw.endTextAndAdvance(); err != nil {
+		return err
+	}
+
 	if !sw.reasoningStarted {
 		if err := sw.ew.WriteChunk(Chunk{"type": "reasoning-start", "id": sw.reasoningID}); err != nil {
 			return err
@@ -266,11 +348,11 @@ func (sw *streamWriter) writeReasoningDelta(trace *llm.ReasoningPart) error {
 		sw.reasoningStarted = true
 	}
 
-	if trace == nil || trace.Text == "" {
+	if reasoning == nil {
 		return nil
 	}
 
-	return sw.ew.WriteChunk(Chunk{"type": "reasoning-delta", "id": sw.reasoningID, "delta": trace.Text})
+	return sw.ew.WriteChunk(Chunk{"type": "reasoning-delta", "id": sw.reasoningID, "delta": reasoning.Text})
 }
 
 func (sw *streamWriter) writeToolRequest(tr *llm.ToolRequestPart) error {
@@ -286,7 +368,9 @@ func (sw *streamWriter) writeToolRequest(tr *llm.ToolRequestPart) error {
 
 	var input any
 	if len(tr.Arguments) > 0 {
-		_ = json.Unmarshal(tr.Arguments, &input)
+		if err := json.Unmarshal(tr.Arguments, &input); err != nil {
+			sw.logger.Warn("failed to unmarshal tool input", "toolCallId", tr.ID, "error", err)
+		}
 	}
 
 	return sw.ew.WriteChunk(Chunk{
@@ -300,6 +384,8 @@ func (sw *streamWriter) writeToolResponse(tr *llm.ToolResponsePart) error {
 	}
 
 	if tr.IsError {
+		// A provider-executed tool reported an error; its payload travels in
+		// Result. The reference surfaces provider-executed tool errors verbatim.
 		return sw.ew.WriteChunk(Chunk{
 			"type": "tool-output-error", "toolCallId": tr.ID, "errorText": string(tr.Result),
 		})
@@ -307,7 +393,9 @@ func (sw *streamWriter) writeToolResponse(tr *llm.ToolResponsePart) error {
 
 	var output any
 	if len(tr.Result) > 0 {
-		_ = json.Unmarshal(tr.Result, &output)
+		if err := json.Unmarshal(tr.Result, &output); err != nil {
+			sw.logger.Warn("failed to unmarshal tool output", "toolCallId", tr.ID, "error", err)
+		}
 	}
 
 	return sw.ew.WriteChunk(Chunk{
@@ -321,12 +409,24 @@ func (sw *streamWriter) handleContentPart(part llm.Part) error {
 	case *llm.TextPart:
 		return sw.writeTextDelta(p.Text)
 	case *llm.ToolRequestPart:
-		if err := sw.endText(); err != nil {
+		if err := sw.endReasoning(); err != nil {
+			return err
+		}
+
+		if err := sw.endTextAndAdvance(); err != nil {
 			return err
 		}
 
 		return sw.writeToolRequest(p)
 	case *llm.ToolResponsePart:
+		if err := sw.endReasoning(); err != nil {
+			return err
+		}
+
+		if err := sw.endTextAndAdvance(); err != nil {
+			return err
+		}
+
 		return sw.writeToolResponse(p)
 	case *llm.ReasoningPart:
 		return sw.writeReasoningDelta(p)
@@ -340,24 +440,27 @@ func (sw *streamWriter) closeSpans() {
 	if sw.reasoningStarted {
 		_ = sw.ew.WriteChunk(Chunk{"type": "reasoning-end", "id": sw.reasoningID})
 		sw.reasoningStarted = false
+		sw.reasoningCounter++
+		sw.reasoningID = fmt.Sprintf("reasoning-%d", sw.reasoningCounter)
 	}
 
 	if sw.textStarted {
 		_ = sw.ew.WriteChunk(Chunk{"type": "text-end", "id": sw.textID})
 		sw.textStarted = false
 		sw.textCounter++
+		sw.textID = fmt.Sprintf("text-%d", sw.textCounter)
 	}
 }
 
 // writeStreamEnd handles a StreamEndEvent: emits error/close/finish chunks.
 func (sw *streamWriter) writeStreamEnd(e llm.StreamEndEvent, logger *slog.Logger) {
+	sw.closeSpans()
+
 	if e.Error != nil {
 		logger.Error("LLM error", "error", e.Error)
 
-		_ = sw.ew.WriteChunk(Chunk{"type": "error", "errorText": "An error occurred"})
+		_ = sw.ew.WriteChunk(Chunk{"type": "error", "errorText": sw.onError(e.Error)})
 	}
-
-	sw.closeSpans()
 
 	_ = sw.ew.WriteChunk(Chunk{"type": "finish-step"})
 
@@ -373,7 +476,7 @@ func (sw *streamWriter) writeStreamEnd(e llm.StreamEndEvent, logger *slog.Logger
 
 // StreamModel streams responses from an llm.Model as AI SDK UI Message Stream
 // events. This is the core streaming logic, usable from custom HTTP handlers.
-func StreamModel(ctx context.Context, model llm.Model, req *llm.Request, ew *EventWriter, logger *slog.Logger) {
+func StreamModel(ctx context.Context, model llm.Model, req *llm.Request, ew *EventWriter, logger *slog.Logger, onError ErrorMapper) {
 	if logger == nil {
 		logger = slog.Default()
 	}
@@ -388,17 +491,20 @@ func StreamModel(ctx context.Context, model llm.Model, req *llm.Request, ew *Eve
 		return
 	}
 
-	sw := newStreamWriter(ew)
+	sw := newStreamWriter(ew, logger, onError)
 
 	for event, err := range model.GenerateEvents(ctx, req) {
 		if err != nil {
 			if ctx.Err() != nil {
+				sw.writeAbort(ctx)
 				return
 			}
 
 			logger.Error("stream error", "error", err)
 
-			_ = ew.WriteChunk(Chunk{"type": "error", "errorText": "An error occurred"})
+			sw.closeSpans()
+
+			_ = ew.WriteChunk(Chunk{"type": "error", "errorText": sw.onError(err)})
 			_ = ew.WriteChunk(Chunk{"type": "finish-step"})
 			_ = ew.WriteChunk(Chunk{"type": "finish", "finishReason": finishReasonError})
 
@@ -414,12 +520,12 @@ func StreamModel(ctx context.Context, model llm.Model, req *llm.Request, ew *Eve
 		case llm.ErrorEvent:
 			logger.Warn("recoverable LLM error", "message", e.Message)
 
-			if err := ew.WriteChunk(Chunk{"type": "error", "errorText": "An error occurred"}); err != nil {
+			if err := ew.WriteChunk(Chunk{"type": "error", "errorText": sw.onError(errorEventErr(e))}); err != nil {
 				return
 			}
 
 		case llm.StreamResetEvent:
-			if err := sw.endText(); err != nil {
+			if err := sw.endTextAndAdvance(); err != nil {
 				return
 			}
 
@@ -435,18 +541,48 @@ func StreamModel(ctx context.Context, model llm.Model, req *llm.Request, ew *Eve
 	_ = ew.WriteDone()
 }
 
+// errorEventErr converts a recoverable ErrorEvent into an error so it can be
+// passed through the configured ErrorMapper, mirroring how the reference routes
+// every error chunk through onError.
+func errorEventErr(e llm.ErrorEvent) error {
+	if e.Code != "" {
+		return fmt.Errorf("%s: %s", e.Code, e.Message)
+	}
+
+	return errors.New(e.Message)
+}
+
+// writeAbort emits an "abort" chunk (with an optional reason) followed by the
+// terminal [DONE], mirroring stream-text.ts abort handling. Used when the
+// request context is cancelled. Write errors are ignored: a cancelled context
+// usually means the client has already disconnected.
+func (sw *streamWriter) writeAbort(ctx context.Context) {
+	chunk := Chunk{"type": "abort"}
+	if cause := context.Cause(ctx); cause != nil && !errors.Is(cause, context.Canceled) {
+		chunk["reason"] = cause.Error()
+	}
+
+	_ = sw.ew.WriteChunk(chunk)
+	_ = sw.ew.WriteDone()
+}
+
 // StreamModelWithTools is like StreamModel but supports agentic tool calling.
 // When the model returns tool calls, the executor is invoked for each, results
 // are streamed to the client, and the model is called again with the results
-// appended to the conversation. This loops until the model stops calling tools.
-func StreamModelWithTools(ctx context.Context, model llm.Model, req *llm.Request, ew *EventWriter, logger *slog.Logger, executor ToolExecutor) {
+// appended to the conversation. This loops until the model stops calling tools
+// or maxTurns is reached. If maxTurns is 0, it defaults to 10.
+func StreamModelWithTools(ctx context.Context, model llm.Model, req *llm.Request, ew *EventWriter, logger *slog.Logger, executor ToolExecutor, maxTurns int, onError ErrorMapper) {
 	if executor == nil {
-		StreamModel(ctx, model, req, ew, logger)
+		StreamModel(ctx, model, req, ew, logger, onError)
 		return
 	}
 
 	if logger == nil {
 		logger = slog.Default()
+	}
+
+	if maxTurns <= 0 {
+		maxTurns = 10
 	}
 
 	messageID := generateMessageID()
@@ -455,12 +591,19 @@ func StreamModelWithTools(ctx context.Context, model llm.Model, req *llm.Request
 	}
 
 	messages := slices.Clone(req.Messages)
-	sw := newStreamWriter(ew)
+	sw := newStreamWriter(ew, logger, onError)
 
-	const maxTurns = 10
+	lastFinishReason := finishReasonOther
 
 	for range maxTurns {
 		finishReason, toolRequests := streamToolTurn(ctx, model, req, messages, sw, ew, logger)
+
+		// Empty finishReason means the stream was aborted (ctx cancel or write failure).
+		if finishReason == "" {
+			return
+		}
+
+		lastFinishReason = finishReason
 
 		if len(toolRequests) == 0 || finishReason != "tool-calls" {
 			_ = ew.WriteChunk(Chunk{"type": "finish", "finishReason": finishReason})
@@ -476,12 +619,16 @@ func StreamModelWithTools(ctx context.Context, model llm.Model, req *llm.Request
 
 		messages = append(messages, llm.Message{Role: llm.RoleAssistant, Content: assistantParts})
 
-		if err := executeTools(ctx, toolRequests, &messages, ew, executor); err != nil {
+		if err := executeTools(ctx, toolRequests, &messages, ew, logger, executor, sw.onError); err != nil {
 			return
 		}
 	}
 
-	_ = ew.WriteChunk(Chunk{"type": "finish", "finishReason": finishReasonOther})
+	// maxTurns exhausted: surface the last turn's real finish reason (which is
+	// "tool-calls", since the loop only continues while the model keeps calling
+	// tools), matching the reference which always emits the model's last-step
+	// finish reason rather than a synthetic value.
+	_ = ew.WriteChunk(Chunk{"type": "finish", "finishReason": lastFinishReason})
 	_ = ew.WriteDone()
 }
 
@@ -499,32 +646,33 @@ func streamToolTurn(
 		return "", nil
 	}
 
-	sw.textID = fmt.Sprintf("text-%d", sw.textCounter)
-	sw.textStarted = false
-	sw.reasoningStarted = false
-
 	var toolRequests []*llm.ToolRequestPart
 
-	iterReq := &llm.Request{
-		Messages:   messages,
-		Tools:      req.Tools,
-		ToolChoice: req.ToolChoice,
-	}
+	iterReq := *req
+	iterReq.Messages = messages
 
 	var finishReason string
 
-	for event, err := range model.GenerateEvents(ctx, iterReq) {
+	for event, err := range model.GenerateEvents(ctx, &iterReq) {
 		if err != nil {
 			if ctx.Err() != nil {
+				sw.writeAbort(ctx)
 				return "", nil
 			}
 
 			logger.Error("stream error", "error", err)
 
-			_ = ew.WriteChunk(Chunk{"type": "error", "errorText": "An error occurred"})
+			sw.closeSpans()
+
+			for _, tr := range toolRequests {
+				_ = ew.WriteChunk(Chunk{
+					"type": "tool-output-error", "toolCallId": tr.ID,
+					"errorText": "stream error; tool call discarded",
+				})
+			}
+
+			_ = ew.WriteChunk(Chunk{"type": "error", "errorText": sw.onError(err)})
 			_ = ew.WriteChunk(Chunk{"type": "finish-step"})
-			_ = ew.WriteChunk(Chunk{"type": "finish", "finishReason": finishReasonError})
-			_ = ew.WriteDone()
 
 			return finishReasonError, nil
 		}
@@ -535,8 +683,44 @@ func streamToolTurn(
 				return "", nil
 			}
 
+		case llm.ErrorEvent:
+			logger.Warn("recoverable LLM error", "message", e.Message)
+
+			if err := ew.WriteChunk(Chunk{"type": "error", "errorText": sw.onError(errorEventErr(e))}); err != nil {
+				return "", nil
+			}
+
+		case llm.StreamResetEvent:
+			if err := sw.endTextAndAdvance(); err != nil {
+				return "", nil
+			}
+
+			if err := sw.endReasoning(); err != nil {
+				return "", nil
+			}
+
+			for _, tr := range toolRequests {
+				_ = ew.WriteChunk(Chunk{
+					"type": "tool-output-error", "toolCallId": tr.ID,
+					"errorText": "stream reset; tool call discarded",
+				})
+			}
+
+			toolRequests = nil
+
 		case llm.StreamEndEvent:
 			finishReason = writeToolTurnEnd(e, sw, ew, logger)
+
+			if e.Error != nil {
+				for _, tr := range toolRequests {
+					_ = ew.WriteChunk(Chunk{
+						"type": "tool-output-error", "toolCallId": tr.ID,
+						"errorText": "stream error; tool call discarded",
+					})
+				}
+
+				toolRequests = nil
+			}
 		}
 	}
 
@@ -564,10 +748,12 @@ func handleToolTurnPart(e llm.ContentPartEvent, sw *streamWriter, toolRequests *
 			return true
 		}
 
-		*toolRequests = append(*toolRequests, p)
+		if p != nil {
+			*toolRequests = append(*toolRequests, p)
 
-		if err := sw.writeToolRequest(p); err != nil {
-			return true
+			if err := sw.writeToolRequest(p); err != nil {
+				return true
+			}
 		}
 
 	case *llm.ToolResponsePart:
@@ -578,13 +764,13 @@ func handleToolTurnPart(e llm.ContentPartEvent, sw *streamWriter, toolRequests *
 }
 
 func writeToolTurnEnd(e llm.StreamEndEvent, sw *streamWriter, ew *EventWriter, logger *slog.Logger) string {
+	sw.closeSpans()
+
 	if e.Error != nil {
 		logger.Error("LLM error", "error", e.Error)
 
-		_ = ew.WriteChunk(Chunk{"type": "error", "errorText": "An error occurred"})
+		_ = ew.WriteChunk(Chunk{"type": "error", "errorText": sw.onError(e.Error)})
 	}
-
-	sw.closeSpans()
 
 	_ = ew.WriteChunk(Chunk{"type": "finish-step"})
 
@@ -598,14 +784,16 @@ func writeToolTurnEnd(e llm.StreamEndEvent, sw *streamWriter, ew *EventWriter, l
 	return reason
 }
 
-func executeTools(ctx context.Context, toolRequests []*llm.ToolRequestPart, messages *[]llm.Message, ew *EventWriter, executor ToolExecutor) error {
+func executeTools(ctx context.Context, toolRequests []*llm.ToolRequestPart, messages *[]llm.Message, ew *EventWriter, logger *slog.Logger, executor ToolExecutor, onError ErrorMapper) error {
 	toolResponseParts := make([]llm.Part, 0, len(toolRequests))
 
 	for _, tr := range toolRequests {
 		result, err := executor(ctx, tr.Name, tr.Arguments)
 		if err != nil {
+			// The client-facing text is sanitized through onError; the model
+			// still receives the real error so it can recover on the next turn.
 			_ = ew.WriteChunk(Chunk{
-				"type": "tool-output-error", "toolCallId": tr.ID, "errorText": err.Error(),
+				"type": "tool-output-error", "toolCallId": tr.ID, "errorText": onError(err),
 			})
 
 			errPayload, mErr := json.Marshal(map[string]string{"error": err.Error()})
@@ -613,16 +801,16 @@ func executeTools(ctx context.Context, toolRequests []*llm.ToolRequestPart, mess
 				errPayload = []byte(`{"error":"tool error"}`)
 			}
 
-			toolResponseParts = append(toolResponseParts, &llm.ToolResponsePart{
-				ID: tr.ID, Name: tr.Name, Result: errPayload, IsError: true,
-			})
+			toolResponseParts = append(toolResponseParts, llm.NewToolResponsePart(tr.ID, tr.Name, errPayload, true))
 
 			continue
 		}
 
 		var output any
 		if len(result) > 0 {
-			_ = json.Unmarshal(result, &output)
+			if err := json.Unmarshal(result, &output); err != nil {
+				logger.Warn("failed to unmarshal tool result", "toolCallId", tr.ID, "error", err)
+			}
 		}
 
 		if err := ew.WriteChunk(Chunk{
@@ -641,29 +829,142 @@ func executeTools(ctx context.Context, toolRequests []*llm.ToolRequestPart, mess
 
 func convertMessages(msgs []chatMessage, system string) []llm.Message {
 	out := make([]llm.Message, 0, len(msgs)+1)
+
+	// appendMessage coalesces consecutive same-role messages into one, mirroring
+	// how the reference providers merge adjacent same-role model messages (e.g.
+	// Anthropic's groupIntoBlocks). This keeps roles strictly alternating, which
+	// providers such as Anthropic require. Without it, two text-only assistant
+	// steps — or a dropped/incomplete assistant turn between two user turns —
+	// would emit consecutive same-role messages and the provider would reject them.
+	appendMessage := func(m llm.Message) {
+		if n := len(out); n > 0 && out[n-1].Role == m.Role {
+			out[n-1].Content = append(out[n-1].Content, m.Content...)
+			return
+		}
+
+		out = append(out, m)
+	}
+
 	if system != "" {
-		out = append(out, llm.NewMessage(llm.RoleSystem, llm.NewTextPart(system)))
+		appendMessage(llm.NewMessage(llm.RoleSystem, llm.NewTextPart(system)))
 	}
 
 	for _, m := range msgs {
+		role := messageRole(m.Role)
+
+		if role == llm.RoleAssistant {
+			for _, am := range reconstructAssistant(m) {
+				appendMessage(am)
+			}
+
+			continue
+		}
+
+		// User and system messages forward their concatenated text. Inbound
+		// file parts are dropped: llm.Part has no file kind.
 		text := m.textContent()
 		if text == "" {
 			continue
 		}
 
-		role := llm.RoleUser
-
-		switch m.Role {
-		case "assistant":
-			role = llm.RoleAssistant
-		case "system":
-			role = llm.RoleSystem
-		}
-
-		out = append(out, llm.NewMessage(role, llm.NewTextPart(text)))
+		appendMessage(llm.NewMessage(role, llm.NewTextPart(text)))
 	}
 
 	return out
+}
+
+// messageRole maps a UI message role string to an llm.MessageRole.
+func messageRole(role string) llm.MessageRole {
+	switch role {
+	case "assistant":
+		return llm.RoleAssistant
+	case "system":
+		return llm.RoleSystem
+	default:
+		return llm.RoleUser
+	}
+}
+
+// reconstructAssistant rebuilds the model messages for an assistant turn from
+// its UI message parts, mirroring convert-to-model-messages.ts. Each step
+// (delimited by "step-start" parts) becomes an assistant message containing its
+// text and tool-call parts, optionally followed by a user message carrying that
+// step's tool results (output-available / output-error). Splitting on steps
+// preserves the call -> result -> answer ordering that providers such as
+// Anthropic require.
+//
+// Inbound reasoning and file parts are not reconstructed: providers vary in
+// accepting reasoning history, and llm.Part has no file kind.
+func reconstructAssistant(m chatMessage) []llm.Message {
+	// Legacy content field (no parts): a single assistant text message.
+	if len(m.Parts) == 0 {
+		if m.Content == "" {
+			return nil
+		}
+
+		return []llm.Message{llm.NewMessage(llm.RoleAssistant, llm.NewTextPart(m.Content))}
+	}
+
+	var (
+		msgs        []llm.Message
+		assistant   []llm.Part
+		toolResults []llm.Part
+	)
+
+	flush := func() {
+		if len(assistant) > 0 {
+			msgs = append(msgs, llm.Message{Role: llm.RoleAssistant, Content: assistant})
+		}
+
+		if len(toolResults) > 0 {
+			msgs = append(msgs, llm.Message{Role: llm.RoleUser, Content: toolResults})
+		}
+
+		assistant = nil
+		toolResults = nil
+	}
+
+	for _, p := range m.Parts {
+		switch {
+		case p.Type == "step-start":
+			// Step boundary: close the current block so its tool results are
+			// ordered before the next step's text/answer.
+			flush()
+
+		case p.Type == "text":
+			if p.Text != "" {
+				assistant = append(assistant, llm.NewTextPart(p.Text))
+			}
+
+		case p.isTool():
+			// Skip calls still streaming their input; not yet a complete call.
+			if p.State == "input-streaming" || p.ToolCallID == "" {
+				continue
+			}
+
+			name := p.toolName()
+
+			assistant = append(assistant, llm.NewToolRequestPart(p.ToolCallID, name, p.Input))
+
+			switch p.State {
+			case "output-available":
+				toolResults = append(toolResults, llm.NewToolResponsePart(p.ToolCallID, name, p.Output, false))
+			case "output-error":
+				// The new ToolResponsePart carries the error payload in Result
+				// with IsError set, rather than a dedicated error string field.
+				errPayload, mErr := json.Marshal(map[string]string{"error": p.ErrorText})
+				if mErr != nil {
+					errPayload = []byte(`{"error":"tool error"}`)
+				}
+
+				toolResults = append(toolResults, llm.NewToolResponsePart(p.ToolCallID, name, errPayload, true))
+			}
+		}
+	}
+
+	flush()
+
+	return msgs
 }
 
 // setSSEHeaders sets the required HTTP headers for the AI SDK UI Message
@@ -713,10 +1014,20 @@ func NewEventWriter(w http.ResponseWriter) *EventWriter {
 
 // WriteChunk writes a single SSE data event and flushes.
 func (ew *EventWriter) WriteChunk(c Chunk) error {
-	data, err := json.Marshal(c)
-	if err != nil {
+	// Match the reference SSE framing byte-for-byte: JSON.stringify does not
+	// HTML-escape <, >, or &, but Go's json.Marshal does. Use an Encoder with
+	// HTML escaping disabled so deltas containing markup/code are sent verbatim.
+	var buf bytes.Buffer
+
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+
+	if err := enc.Encode(c); err != nil {
 		return err
 	}
+
+	// Encoder.Encode appends a trailing newline; the SSE framing adds its own.
+	data := bytes.TrimRight(buf.Bytes(), "\n")
 
 	if _, err := io.WriteString(ew.w, "data: "); err != nil {
 		return err

--- a/adapter/vercelaisdk/uimessagestream/handler_test.go
+++ b/adapter/vercelaisdk/uimessagestream/handler_test.go
@@ -13,24 +13,35 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/redpanda-data/ai-sdk-go/llm"
 	"github.com/redpanda-data/ai-sdk-go/llm/fakellm"
 )
 
 const (
-	typeStart          = "start"
-	typeStartStep      = "start-step"
-	typeTextStart      = "text-start"
-	typeTextDelta      = "text-delta"
-	typeTextEnd        = "text-end"
-	typeFinishStep     = "finish-step"
-	typeFinish         = "finish"
-	typeError          = "error"
-	typeReasoningStart = "reasoning-start"
-	typeReasoningDelta = "reasoning-delta"
-	typeReasoningEnd   = "reasoning-end"
+	typeStart              = "start"
+	typeStartStep          = "start-step"
+	typeTextStart          = "text-start"
+	typeTextDelta          = "text-delta"
+	typeTextEnd            = "text-end"
+	typeFinishStep         = "finish-step"
+	typeFinish             = "finish"
+	typeError              = "error"
+	typeReasoningStart     = "reasoning-start"
+	typeReasoningDelta     = "reasoning-delta"
+	typeReasoningEnd       = "reasoning-end"
+	typeToolInputStart     = "tool-input-start"
+	typeToolInputAvailable = "tool-input-available"
+	typeToolOutputAvail    = "tool-output-available"
+	typeToolOutputError    = "tool-output-error"
+	typeAbort              = "abort"
 
-	sanitizedError = "An error occurred"
+	// sanitizedError is the default client-facing error text. It matches the
+	// Vercel AI SDK default onError return value ("An error occurred." — with
+	// the trailing period).
+	sanitizedError = "An error occurred."
 )
 
 // parseSSE reads SSE events from a response body and returns the parsed JSON
@@ -91,6 +102,16 @@ func chunkStr(t *testing.T, c Chunk, key string) string {
 	return v
 }
 
+// partText asserts that p is a *llm.TextPart and returns its text.
+func partText(t *testing.T, p llm.Part) string {
+	t.Helper()
+
+	tp, ok := p.(*llm.TextPart)
+	require.True(t, ok, "expected *llm.TextPart, got %T", p)
+
+	return tp.Text
+}
+
 func newPostRequest(t *testing.T, body string) *http.Request {
 	t.Helper()
 
@@ -116,44 +137,30 @@ func TestHandler_SimpleTextResponse(t *testing.T) {
 
 	h.ServeHTTP(rec, req)
 
-	if rec.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
-	}
-
-	if ct := rec.Header().Get("Content-Type"); ct != "text/event-stream" {
-		t.Errorf("Content-Type = %q, want text/event-stream", ct)
-	}
-
-	if v := rec.Header().Get("X-Vercel-Ai-Ui-Message-Stream"); v != "v1" {
-		t.Errorf("X-Vercel-Ai-Ui-Message-Stream = %q, want v1", v)
-	}
+	require.Equal(t, http.StatusOK, rec.Code, "response body: %s", rec.Body.String())
+	assert.Equal(t, "text/event-stream", rec.Header().Get("Content-Type"))
+	assert.Equal(t, "v1", rec.Header().Get("X-Vercel-Ai-Ui-Message-Stream"))
 
 	chunks, done := parseSSE(t, rec.Body)
-	if !done {
-		t.Error("stream not terminated with [DONE]")
-	}
+	assert.True(t, done, "stream not terminated with [DONE]")
 
 	types := chunkTypes(chunks)
 
 	expectedPrefix := []string{typeStart, typeStartStep, typeTextStart}
 	for i, exp := range expectedPrefix {
-		if i >= len(types) || types[i] != exp {
-			t.Fatalf("chunk[%d] type = %q, want %q\nall types: %v", i, types[i], exp, types)
-		}
+		require.Greater(t, len(types), i, "not enough chunks, all types: %v", types)
+		require.Equal(t, exp, types[i], "chunk[%d] type mismatch, all types: %v", i, types)
 	}
 
 	for i := 3; i < len(types)-3; i++ {
-		if types[i] != typeTextDelta {
-			t.Errorf("chunk[%d] type = %q, want text-delta", i, types[i])
-		}
+		assert.Equal(t, typeTextDelta, types[i], "chunk[%d] type mismatch", i)
 	}
 
 	expectedSuffix := []string{typeTextEnd, typeFinishStep, typeFinish}
 	for i, exp := range expectedSuffix {
 		idx := len(types) - 3 + i
-		if idx < 0 || idx >= len(types) || types[idx] != exp {
-			t.Fatalf("chunk[%d] type = %q, want %q\nall types: %v", idx, types[idx], exp, types)
-		}
+		require.True(t, idx >= 0 && idx < len(types), "suffix index %d out of range, all types: %v", idx, types)
+		require.Equal(t, exp, types[idx], "chunk[%d] type mismatch, all types: %v", idx, types)
 	}
 
 	var text strings.Builder
@@ -164,9 +171,7 @@ func TestHandler_SimpleTextResponse(t *testing.T) {
 		}
 	}
 
-	if got := text.String(); got != "Hello, world!" {
-		t.Errorf("assembled text = %q, want %q", got, "Hello, world!")
-	}
+	assert.Equal(t, "Hello, world!", text.String(), "assembled text mismatch")
 
 	var startID, endID string
 
@@ -180,15 +185,11 @@ func TestHandler_SimpleTextResponse(t *testing.T) {
 		}
 	}
 
-	if startID != endID {
-		t.Errorf("text-start id = %q, text-end id = %q, want match", startID, endID)
-	}
+	assert.Equal(t, startID, endID, "text-start id and text-end id should match")
 
 	for _, c := range chunks {
 		if c["type"] == typeFinish {
-			if reason := chunkStr(t, c, "finishReason"); reason != finishReasonStop {
-				t.Errorf("finish.finishReason = %v, want 'stop'", c["finishReason"])
-			}
+			assert.Equal(t, finishReasonStop, chunkStr(t, c, "finishReason"))
 		}
 	}
 }
@@ -210,9 +211,7 @@ func TestHandler_StreamingTextResponse(t *testing.T) {
 	h.ServeHTTP(rec, req)
 
 	chunks, done := parseSSE(t, rec.Body)
-	if !done {
-		t.Error("stream not terminated with [DONE]")
-	}
+	assert.True(t, done, "stream not terminated with [DONE]")
 
 	var text strings.Builder
 
@@ -226,13 +225,8 @@ func TestHandler_StreamingTextResponse(t *testing.T) {
 		}
 	}
 
-	if got := text.String(); got != "Streaming works!" {
-		t.Errorf("assembled text = %q, want %q", got, "Streaming works!")
-	}
-
-	if deltaCount < 2 {
-		t.Errorf("expected multiple text-delta chunks for streaming, got %d", deltaCount)
-	}
+	assert.Equal(t, "Streaming works!", text.String(), "assembled text mismatch")
+	assert.GreaterOrEqual(t, deltaCount, 2, "expected multiple text-delta chunks for streaming")
 }
 
 func TestHandler_ErrorResponse(t *testing.T) {
@@ -252,30 +246,15 @@ func TestHandler_ErrorResponse(t *testing.T) {
 	h.ServeHTTP(rec, req)
 
 	chunks, done := parseSSE(t, rec.Body)
-	if !done {
-		t.Error("stream not terminated with [DONE]")
-	}
+	assert.True(t, done, "stream not terminated with [DONE]")
 
 	types := chunkTypes(chunks)
 
 	expected := []string{typeStart, typeStartStep, typeError, typeFinishStep, typeFinish}
-	if len(types) != len(expected) {
-		t.Fatalf("chunk types = %v, want %v", types, expected)
-	}
+	require.Equal(t, expected, types, "chunk types mismatch")
 
-	for i, exp := range expected {
-		if types[i] != exp {
-			t.Fatalf("chunk[%d] type = %q, want %q\nall types: %v", i, types[i], exp, types)
-		}
-	}
-
-	if et := chunkStr(t, chunks[2], "errorText"); et != sanitizedError {
-		t.Errorf("error chunk errorText = %q, want sanitized %q", et, sanitizedError)
-	}
-
-	if reason := chunkStr(t, chunks[4], "finishReason"); reason != finishReasonError {
-		t.Errorf("finish.finishReason = %v, want %q", chunks[4]["finishReason"], finishReasonError)
-	}
+	assert.Equal(t, sanitizedError, chunkStr(t, chunks[2], "errorText"))
+	assert.Equal(t, finishReasonError, chunkStr(t, chunks[4], "finishReason"))
 }
 
 func TestHandler_SystemPrompt(t *testing.T) {
@@ -303,18 +282,9 @@ func TestHandler_SystemPrompt(t *testing.T) {
 
 	h.ServeHTTP(rec, req)
 
-	if len(capturedMessages) != 2 {
-		t.Fatalf("expected 2 messages (system + user), got %d", len(capturedMessages))
-	}
-
-	if capturedMessages[0].Role != llm.RoleSystem {
-		t.Errorf("first message role = %q, want system", capturedMessages[0].Role)
-	}
-
-	tp, ok := capturedMessages[0].Content[0].(*llm.TextPart)
-	if !ok || tp.Text != "Be concise." {
-		t.Errorf("system prompt = %v, want 'Be concise.'", capturedMessages[0].Content[0])
-	}
+	require.Len(t, capturedMessages, 2, "expected system + user messages")
+	assert.Equal(t, llm.RoleSystem, capturedMessages[0].Role)
+	assert.Equal(t, "Be concise.", partText(t, capturedMessages[0].Content[0]))
 }
 
 func TestHandler_MultiTurnConversation(t *testing.T) {
@@ -346,21 +316,10 @@ func TestHandler_MultiTurnConversation(t *testing.T) {
 
 	h.ServeHTTP(rec, req)
 
-	if len(capturedMessages) != 3 {
-		t.Fatalf("expected 3 messages, got %d", len(capturedMessages))
-	}
-
-	if capturedMessages[0].Role != llm.RoleUser {
-		t.Errorf("msg[0] role = %q, want user", capturedMessages[0].Role)
-	}
-
-	if capturedMessages[1].Role != llm.RoleAssistant {
-		t.Errorf("msg[1] role = %q, want assistant", capturedMessages[1].Role)
-	}
-
-	if capturedMessages[2].Role != llm.RoleUser {
-		t.Errorf("msg[2] role = %q, want user", capturedMessages[2].Role)
-	}
+	require.Len(t, capturedMessages, 3)
+	assert.Equal(t, llm.RoleUser, capturedMessages[0].Role)
+	assert.Equal(t, llm.RoleAssistant, capturedMessages[1].Role)
+	assert.Equal(t, llm.RoleUser, capturedMessages[2].Role)
 }
 
 func TestHandler_MethodNotAllowed(t *testing.T) {
@@ -374,9 +333,7 @@ func TestHandler_MethodNotAllowed(t *testing.T) {
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, req)
 
-	if rec.Code != http.StatusMethodNotAllowed {
-		t.Errorf("expected 405, got %d", rec.Code)
-	}
+	assert.Equal(t, http.StatusMethodNotAllowed, rec.Code)
 }
 
 func TestHandler_InvalidBody(t *testing.T) {
@@ -391,9 +348,7 @@ func TestHandler_InvalidBody(t *testing.T) {
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, req)
 
-	if rec.Code != http.StatusBadRequest {
-		t.Errorf("expected 400, got %d", rec.Code)
-	}
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
 }
 
 func TestHandler_V6PartsFormat(t *testing.T) {
@@ -441,30 +396,10 @@ func TestHandler_V6PartsFormat(t *testing.T) {
 
 	h.ServeHTTP(rec, req)
 
-	if len(capturedMessages) != 3 {
-		t.Fatalf("expected 3 messages, got %d", len(capturedMessages))
-	}
-
-	textOf := func(p llm.Part) string {
-		tp, _ := p.(*llm.TextPart)
-		if tp == nil {
-			return ""
-		}
-
-		return tp.Text
-	}
-
-	if got := textOf(capturedMessages[0].Content[0]); got != "hello from v6" {
-		t.Errorf("msg[0] text = %q, want 'hello from v6'", got)
-	}
-
-	if got := textOf(capturedMessages[1].Content[0]); got != "hi there" {
-		t.Errorf("msg[1] text = %q, want 'hi there'", got)
-	}
-
-	if got := textOf(capturedMessages[2].Content[0]); got != "follow up" {
-		t.Errorf("msg[2] text = %q, want 'follow up'", got)
-	}
+	require.Len(t, capturedMessages, 3)
+	assert.Equal(t, "hello from v6", partText(t, capturedMessages[0].Content[0]))
+	assert.Equal(t, "hi there", partText(t, capturedMessages[1].Content[0]))
+	assert.Equal(t, "follow up", partText(t, capturedMessages[2].Content[0]))
 }
 
 // errorStreamModel is a minimal llm.Model that yields specific event sequences
@@ -511,38 +446,26 @@ func TestStreamModel_StreamEndEventWithError(t *testing.T) {
 
 	StreamModel(context.Background(), model, &llm.Request{
 		Messages: []llm.Message{llm.NewMessage(llm.RoleUser, llm.NewTextPart("hi"))},
-	}, ew, nil)
+	}, ew, nil, nil)
 
 	chunks, done := parseSSE(t, rec.Body)
-	if !done {
-		t.Error("stream not terminated with [DONE]")
-	}
+	assert.True(t, done, "stream not terminated with [DONE]")
 
 	types := chunkTypes(chunks)
 
-	expected := []string{typeStart, typeStartStep, typeTextStart, typeTextDelta, typeError, typeTextEnd, typeFinishStep, typeFinish}
-	if len(types) != len(expected) {
-		t.Fatalf("chunk types = %v, want %v", types, expected)
-	}
-
-	for i, exp := range expected {
-		if types[i] != exp {
-			t.Fatalf("chunk[%d] type = %q, want %q\nall types: %v", i, types[i], exp, types)
-		}
-	}
+	// Open spans are closed (text-end) BEFORE the error chunk, matching the
+	// iterator-error path. The error chunk is never wedged inside an open run.
+	expected := []string{typeStart, typeStartStep, typeTextStart, typeTextDelta, typeTextEnd, typeError, typeFinishStep, typeFinish}
+	require.Equal(t, expected, types, "chunk types mismatch")
 
 	for _, c := range chunks {
 		if c["type"] == typeError {
-			if et := chunkStr(t, c, "errorText"); et != sanitizedError {
-				t.Errorf("error.errorText = %v, want %q", c["errorText"], sanitizedError)
-			}
+			assert.Equal(t, sanitizedError, chunkStr(t, c, "errorText"))
 		}
 	}
 
 	finishChunk := chunks[len(chunks)-1]
-	if reason := chunkStr(t, finishChunk, "finishReason"); reason != finishReasonError {
-		t.Errorf("finish.finishReason = %v, want %q", finishChunk["finishReason"], finishReasonError)
-	}
+	assert.Equal(t, finishReasonError, chunkStr(t, finishChunk, "finishReason"))
 }
 
 func TestHandler_FinishReasonMapping(t *testing.T) {
@@ -565,9 +488,7 @@ func TestHandler_FinishReasonMapping(t *testing.T) {
 		t.Run(tt.want, func(t *testing.T) {
 			t.Parallel()
 
-			if got := mapFinishReason(tt.reason); got != tt.want {
-				t.Errorf("mapFinishReason(%q) = %q, want %q", tt.reason, got, tt.want)
-			}
+			assert.Equal(t, tt.want, mapFinishReason(tt.reason))
 		})
 	}
 }
@@ -589,9 +510,7 @@ func TestHandler_WithLogger(t *testing.T) {
 
 	h.ServeHTTP(rec, req)
 
-	if rec.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d", rec.Code)
-	}
+	require.Equal(t, http.StatusOK, rec.Code)
 }
 
 func TestHandler_SystemRoleMessage(t *testing.T) {
@@ -619,13 +538,8 @@ func TestHandler_SystemRoleMessage(t *testing.T) {
 
 	h.ServeHTTP(rec, req)
 
-	if len(capturedMessages) != 2 {
-		t.Fatalf("expected 2 messages, got %d", len(capturedMessages))
-	}
-
-	if capturedMessages[0].Role != llm.RoleSystem {
-		t.Errorf("msg[0] role = %q, want system", capturedMessages[0].Role)
-	}
+	require.Len(t, capturedMessages, 2)
+	assert.Equal(t, llm.RoleSystem, capturedMessages[0].Role)
 }
 
 func TestHandler_EmptyMessagesSkipped(t *testing.T) {
@@ -656,14 +570,8 @@ func TestHandler_EmptyMessagesSkipped(t *testing.T) {
 
 	h.ServeHTTP(rec, req)
 
-	if len(capturedMessages) != 1 {
-		t.Fatalf("expected 1 message (empty skipped), got %d", len(capturedMessages))
-	}
-
-	tp, ok := capturedMessages[0].Content[0].(*llm.TextPart)
-	if !ok || tp.Text != "real message" {
-		t.Errorf("msg = %v, want text 'real message'", capturedMessages[0].Content[0])
-	}
+	require.Len(t, capturedMessages, 1, "empty message should be skipped")
+	assert.Equal(t, "real message", partText(t, capturedMessages[0].Content[0]))
 }
 
 func TestHandler_ContextCancellation(t *testing.T) {
@@ -672,26 +580,38 @@ func TestHandler_ContextCancellation(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	cancellingModel := &cancellingErrorModel{cancel: cancel}
+	// Drive cancellation through the full Handler/ServeHTTP path.
+	model := &cancellingErrorModel{cancel: cancel}
+	h := Handler(model)
+
+	req := httptest.NewRequestWithContext(ctx, http.MethodPost, "/api/chat",
+		strings.NewReader(`{"messages":[{"role":"user","content":"hi"}]}`))
+	req.Header.Set("Content-Type", "application/json")
 
 	rec := httptest.NewRecorder()
-	ew := NewEventWriter(rec)
+	h.ServeHTTP(rec, req)
 
-	StreamModel(ctx, cancellingModel, &llm.Request{
-		Messages: []llm.Message{llm.NewMessage(llm.RoleUser, llm.NewTextPart("hi"))},
-	}, ew, nil)
+	chunks, done := parseSSE(t, rec.Body)
+	assertAbortedSequence(t, chunks, done)
+}
 
-	chunks, _ := parseSSE(t, rec.Body)
+// assertAbortedSequence verifies a cancelled stream: start, start-step, an
+// abort chunk, [DONE], and no finish chunk.
+func assertAbortedSequence(t *testing.T, chunks []Chunk, done bool) {
+	t.Helper()
 
 	types := chunkTypes(chunks)
-	if len(types) < 2 || types[0] != typeStart || types[1] != typeStartStep {
-		t.Fatalf("expected at least start + start-step, got %v", types)
-	}
+	require.GreaterOrEqual(t, len(types), 2, "expected at least start + start-step, got %v", types)
+	require.Equal(t, typeStart, types[0])
+	require.Equal(t, typeStartStep, types[1])
+
+	// On context cancellation the adapter emits an abort chunk then terminates
+	// with [DONE], mirroring stream-text.ts. No finish chunk is emitted.
+	assert.True(t, done, "stream should terminate with [DONE] after abort")
+	assert.Contains(t, types, typeAbort, "expected an abort chunk on cancellation")
 
 	for _, tp := range types {
-		if tp == typeFinish {
-			t.Error("should not have finish chunk when context is cancelled")
-		}
+		assert.NotEqual(t, typeFinish, tp, "should not have finish chunk when context is cancelled")
 	}
 }
 
@@ -712,31 +632,19 @@ func TestHandler_ErrorEventNonTerminal(t *testing.T) {
 
 	StreamModel(context.Background(), model, &llm.Request{
 		Messages: []llm.Message{llm.NewMessage(llm.RoleUser, llm.NewTextPart("hi"))},
-	}, ew, nil)
+	}, ew, nil, nil)
 
 	chunks, done := parseSSE(t, rec.Body)
-	if !done {
-		t.Error("stream not terminated with [DONE]")
-	}
+	assert.True(t, done, "stream not terminated with [DONE]")
 
 	types := chunkTypes(chunks)
 
 	expected := []string{typeStart, typeStartStep, typeTextStart, typeTextDelta, typeError, typeTextDelta, typeTextEnd, typeFinishStep, typeFinish}
-	if len(types) != len(expected) {
-		t.Fatalf("chunk types = %v, want %v", types, expected)
-	}
-
-	for i, exp := range expected {
-		if types[i] != exp {
-			t.Fatalf("chunk[%d] type = %q, want %q\nall: %v", i, types[i], exp, types)
-		}
-	}
+	require.Equal(t, expected, types, "chunk types mismatch")
 
 	for _, c := range chunks {
 		if c["type"] == typeError {
-			if et := chunkStr(t, c, "errorText"); et != sanitizedError {
-				t.Errorf("errorText = %q, want %q (sanitized)", et, sanitizedError)
-			}
+			assert.Equal(t, sanitizedError, chunkStr(t, c, "errorText"), "error text should be sanitized")
 		}
 	}
 
@@ -748,9 +656,7 @@ func TestHandler_ErrorEventNonTerminal(t *testing.T) {
 		}
 	}
 
-	if got := text.String(); got != "before after" {
-		t.Errorf("assembled text = %q, want 'before after'", got)
-	}
+	assert.Equal(t, "before after", text.String(), "assembled text mismatch")
 }
 
 func TestHandler_TextContentPrefersPartsOverContent(t *testing.T) {
@@ -762,9 +668,7 @@ func TestHandler_TextContentPrefersPartsOverContent(t *testing.T) {
 		Parts:   []messagePart{{Type: "text", Text: "parts content"}},
 	}
 
-	if got := msg.textContent(); got != "parts content" {
-		t.Errorf("textContent() = %q, want 'parts content'", got)
-	}
+	assert.Equal(t, "parts content", msg.textContent())
 }
 
 func TestHandler_TextContentFallsBackToContent(t *testing.T) {
@@ -775,9 +679,7 @@ func TestHandler_TextContentFallsBackToContent(t *testing.T) {
 		Content: "legacy content",
 	}
 
-	if got := msg.textContent(); got != "legacy content" {
-		t.Errorf("textContent() = %q, want 'legacy content'", got)
-	}
+	assert.Equal(t, "legacy content", msg.textContent())
 }
 
 func TestStreamModel_ReasoningTrace(t *testing.T) {
@@ -785,7 +687,7 @@ func TestStreamModel_ReasoningTrace(t *testing.T) {
 
 	model := &errorStreamModel{
 		events: []llm.Event{
-			llm.ContentPartEvent{Index: 0, Part: &llm.ReasoningPart{Text: "thinking..."}},
+			llm.ContentPartEvent{Index: 0, Part: llm.NewReasoningPart("thinking...")},
 			llm.ContentPartEvent{Index: 1, Part: llm.NewTextPart("result")},
 			llm.StreamEndEvent{Response: &llm.Response{FinishReason: llm.FinishReasonStop}},
 		},
@@ -796,31 +698,19 @@ func TestStreamModel_ReasoningTrace(t *testing.T) {
 
 	StreamModel(context.Background(), model, &llm.Request{
 		Messages: []llm.Message{llm.NewMessage(llm.RoleUser, llm.NewTextPart("think"))},
-	}, ew, nil)
+	}, ew, nil, nil)
 
 	chunks, done := parseSSE(t, rec.Body)
-	if !done {
-		t.Error("stream not terminated with [DONE]")
-	}
+	assert.True(t, done, "stream not terminated with [DONE]")
 
 	types := chunkTypes(chunks)
 
 	expected := []string{typeStart, typeStartStep, typeReasoningStart, typeReasoningDelta, typeReasoningEnd, typeTextStart, typeTextDelta, typeTextEnd, typeFinishStep, typeFinish}
-	if len(types) != len(expected) {
-		t.Fatalf("chunk types = %v, want %v", types, expected)
-	}
-
-	for i, exp := range expected {
-		if types[i] != exp {
-			t.Fatalf("chunk[%d] type = %q, want %q\nall: %v", i, types[i], exp, types)
-		}
-	}
+	require.Equal(t, expected, types, "chunk types mismatch")
 
 	for _, c := range chunks {
 		if c["type"] == typeReasoningDelta {
-			if d := chunkStr(t, c, "delta"); d != "thinking..." {
-				t.Errorf("reasoning-delta = %q, want 'thinking...'", d)
-			}
+			assert.Equal(t, "thinking...", chunkStr(t, c, "delta"))
 		}
 	}
 }
@@ -830,9 +720,9 @@ func TestStreamModel_ReasoningStatefulTracking(t *testing.T) {
 
 	model := &errorStreamModel{
 		events: []llm.Event{
-			llm.ContentPartEvent{Index: 0, Part: &llm.ReasoningPart{Text: "step 1"}},
-			llm.ContentPartEvent{Index: 0, Part: &llm.ReasoningPart{Text: " step 2"}},
-			llm.ContentPartEvent{Index: 0, Part: &llm.ReasoningPart{Text: " step 3"}},
+			llm.ContentPartEvent{Index: 0, Part: llm.NewReasoningPart("step 1")},
+			llm.ContentPartEvent{Index: 0, Part: llm.NewReasoningPart(" step 2")},
+			llm.ContentPartEvent{Index: 0, Part: llm.NewReasoningPart(" step 3")},
 			llm.ContentPartEvent{Index: 1, Part: llm.NewTextPart("result")},
 			llm.StreamEndEvent{Response: &llm.Response{FinishReason: llm.FinishReasonStop}},
 		},
@@ -843,12 +733,10 @@ func TestStreamModel_ReasoningStatefulTracking(t *testing.T) {
 
 	StreamModel(context.Background(), model, &llm.Request{
 		Messages: []llm.Message{llm.NewMessage(llm.RoleUser, llm.NewTextPart("think hard"))},
-	}, ew, nil)
+	}, ew, nil, nil)
 
 	chunks, done := parseSSE(t, rec.Body)
-	if !done {
-		t.Error("stream not terminated with [DONE]")
-	}
+	assert.True(t, done, "stream not terminated with [DONE]")
 
 	types := chunkTypes(chunks)
 
@@ -858,15 +746,7 @@ func TestStreamModel_ReasoningStatefulTracking(t *testing.T) {
 		typeTextStart, typeTextDelta, typeTextEnd,
 		typeFinishStep, typeFinish,
 	}
-	if len(types) != len(expected) {
-		t.Fatalf("chunk types = %v, want %v", types, expected)
-	}
-
-	for i, exp := range expected {
-		if types[i] != exp {
-			t.Fatalf("chunk[%d] type = %q, want %q\nall: %v", i, types[i], exp, types)
-		}
-	}
+	require.Equal(t, expected, types, "chunk types mismatch")
 
 	var rStartID, rEndID string
 
@@ -883,14 +763,10 @@ func TestStreamModel_ReasoningStatefulTracking(t *testing.T) {
 		}
 	}
 
-	if rStartID != rEndID {
-		t.Errorf("reasoning-start id = %q, reasoning-end id = %q, want match", rStartID, rEndID)
-	}
+	assert.Equal(t, rStartID, rEndID, "reasoning-start id and reasoning-end id should match")
 
 	for i, id := range deltaIDs {
-		if id != rStartID {
-			t.Errorf("reasoning-delta[%d] id = %q, want %q", i, id, rStartID)
-		}
+		assert.Equal(t, rStartID, id, "reasoning-delta[%d] id mismatch", i)
 	}
 
 	var reasoning strings.Builder
@@ -901,9 +777,7 @@ func TestStreamModel_ReasoningStatefulTracking(t *testing.T) {
 		}
 	}
 
-	if got := reasoning.String(); got != "step 1 step 2 step 3" {
-		t.Errorf("assembled reasoning = %q, want 'step 1 step 2 step 3'", got)
-	}
+	assert.Equal(t, "step 1 step 2 step 3", reasoning.String(), "assembled reasoning mismatch")
 }
 
 func TestStreamModel_ReasoningNilTrace(t *testing.T) {
@@ -911,7 +785,7 @@ func TestStreamModel_ReasoningNilTrace(t *testing.T) {
 
 	model := &errorStreamModel{
 		events: []llm.Event{
-			llm.ContentPartEvent{Index: 0, Part: &llm.ReasoningPart{}},
+			llm.ContentPartEvent{Index: 0, Part: (*llm.ReasoningPart)(nil)},
 			llm.StreamEndEvent{Response: &llm.Response{FinishReason: llm.FinishReasonStop}},
 		},
 	}
@@ -921,19 +795,16 @@ func TestStreamModel_ReasoningNilTrace(t *testing.T) {
 
 	StreamModel(context.Background(), model, &llm.Request{
 		Messages: []llm.Message{llm.NewMessage(llm.RoleUser, llm.NewTextPart("think"))},
-	}, ew, nil)
+	}, ew, nil, nil)
 
 	chunks, done := parseSSE(t, rec.Body)
-	if !done {
-		t.Error("stream not terminated with [DONE]")
-	}
+	assert.True(t, done, "stream not terminated with [DONE]")
 
 	types := chunkTypes(chunks)
 
+	// A nil reasoning part still opens and closes the span, with no delta.
 	expected := []string{typeStart, typeStartStep, typeReasoningStart, typeReasoningEnd, typeFinishStep, typeFinish}
-	if len(types) != len(expected) {
-		t.Fatalf("chunk types = %v, want %v", types, expected)
-	}
+	require.Equal(t, expected, types, "chunk types mismatch")
 }
 
 type noFlushResponseWriter struct {
@@ -954,9 +825,7 @@ func TestHandler_NoFlusherSupport(t *testing.T) {
 
 	h.ServeHTTP(rec, req)
 
-	if inner.Code != http.StatusInternalServerError {
-		t.Errorf("expected 500, got %d", inner.Code)
-	}
+	assert.Equal(t, http.StatusInternalServerError, inner.Code)
 }
 
 func TestStreamModel_IteratorErrorWithCancelledContext(t *testing.T) {
@@ -972,20 +841,10 @@ func TestStreamModel_IteratorErrorWithCancelledContext(t *testing.T) {
 
 	StreamModel(ctx, cancellingModel, &llm.Request{
 		Messages: []llm.Message{llm.NewMessage(llm.RoleUser, llm.NewTextPart("hi"))},
-	}, ew, nil)
+	}, ew, nil, nil)
 
-	chunks, _ := parseSSE(t, rec.Body)
-
-	types := chunkTypes(chunks)
-	if len(types) < 2 || types[0] != typeStart || types[1] != typeStartStep {
-		t.Fatalf("expected at least start + start-step, got %v", types)
-	}
-
-	for _, tp := range types {
-		if tp == typeFinish {
-			t.Error("should not have finish chunk when context is cancelled")
-		}
-	}
+	chunks, done := parseSSE(t, rec.Body)
+	assertAbortedSequence(t, chunks, done)
 }
 
 // cancellingErrorModel cancels the context then returns an error from the iterator.
@@ -1027,9 +886,7 @@ func TestHandler_AllRequiredHeaders(t *testing.T) {
 	}
 
 	for k, want := range headers {
-		if got := rec.Header().Get(k); got != want {
-			t.Errorf("header %q = %q, want %q", k, got, want)
-		}
+		assert.Equal(t, want, rec.Header().Get(k), "header %q mismatch", k)
 	}
 }
 
@@ -1050,27 +907,16 @@ func TestHandler_StartChunkHasMessageID(t *testing.T) {
 	h.ServeHTTP(rec, req)
 
 	chunks, done := parseSSE(t, rec.Body)
-	if !done {
-		t.Error("stream not terminated with [DONE]")
-	}
+	assert.True(t, done, "stream not terminated with [DONE]")
 
-	if len(chunks) == 0 {
-		t.Fatal("no chunks")
-	}
+	require.NotEmpty(t, chunks, "no chunks")
 
 	startChunk := chunks[0]
-	if startChunk["type"] != typeStart {
-		t.Fatalf("first chunk type = %q, want 'start'", startChunk["type"])
-	}
+	require.Equal(t, typeStart, startChunk["type"])
 
 	mid := chunkStr(t, startChunk, "messageId")
-	if mid == "" {
-		t.Fatalf("start chunk has no messageId")
-	}
-
-	if len(mid) != 16 {
-		t.Errorf("messageId length = %d, want 16", len(mid))
-	}
+	require.NotEmpty(t, mid, "start chunk has no messageId")
+	assert.Len(t, mid, 16)
 }
 
 func TestHandler_RequestBodySizeLimit(t *testing.T) {
@@ -1087,9 +933,7 @@ func TestHandler_RequestBodySizeLimit(t *testing.T) {
 
 	h.ServeHTTP(rec, req)
 
-	if rec.Code != http.StatusBadRequest {
-		t.Errorf("expected 400 for oversized body, got %d", rec.Code)
-	}
+	assert.Equal(t, http.StatusBadRequest, rec.Code, "oversized body should be rejected")
 }
 
 func TestHandler_EmptyMessagesArray(t *testing.T) {
@@ -1105,9 +949,7 @@ func TestHandler_EmptyMessagesArray(t *testing.T) {
 
 	h.ServeHTTP(rec, req)
 
-	if rec.Code != http.StatusBadRequest {
-		t.Errorf("expected 400 for empty messages, got %d", rec.Code)
-	}
+	assert.Equal(t, http.StatusBadRequest, rec.Code, "empty messages should be rejected")
 }
 
 func TestStreamModel_StreamResetEvent(t *testing.T) {
@@ -1127,12 +969,10 @@ func TestStreamModel_StreamResetEvent(t *testing.T) {
 
 	StreamModel(context.Background(), model, &llm.Request{
 		Messages: []llm.Message{llm.NewMessage(llm.RoleUser, llm.NewTextPart("hi"))},
-	}, ew, nil)
+	}, ew, nil, nil)
 
 	chunks, done := parseSSE(t, rec.Body)
-	if !done {
-		t.Error("stream not terminated with [DONE]")
-	}
+	assert.True(t, done, "stream not terminated with [DONE]")
 
 	types := chunkTypes(chunks)
 
@@ -1142,15 +982,7 @@ func TestStreamModel_StreamResetEvent(t *testing.T) {
 		typeTextStart, typeTextDelta, typeTextEnd,
 		typeFinishStep, typeFinish,
 	}
-	if len(types) != len(expected) {
-		t.Fatalf("chunk types = %v, want %v", types, expected)
-	}
-
-	for i, exp := range expected {
-		if types[i] != exp {
-			t.Fatalf("chunk[%d] type = %q, want %q\nall: %v", i, types[i], exp, types)
-		}
-	}
+	require.Equal(t, expected, types, "chunk types mismatch")
 }
 
 func TestStreamModel_StreamResetEventWithReasoning(t *testing.T) {
@@ -1158,7 +990,7 @@ func TestStreamModel_StreamResetEventWithReasoning(t *testing.T) {
 
 	model := &errorStreamModel{
 		events: []llm.Event{
-			llm.ContentPartEvent{Index: 0, Part: &llm.ReasoningPart{Text: "think1"}},
+			llm.ContentPartEvent{Index: 0, Part: llm.NewReasoningPart("think1")},
 			llm.ContentPartEvent{Index: 1, Part: llm.NewTextPart("text1")},
 			llm.StreamResetEvent{Attempt: 1, Reason: "retrying"},
 			llm.ContentPartEvent{Index: 0, Part: llm.NewTextPart("text2")},
@@ -1171,12 +1003,10 @@ func TestStreamModel_StreamResetEventWithReasoning(t *testing.T) {
 
 	StreamModel(context.Background(), model, &llm.Request{
 		Messages: []llm.Message{llm.NewMessage(llm.RoleUser, llm.NewTextPart("hi"))},
-	}, ew, nil)
+	}, ew, nil, nil)
 
 	chunks, done := parseSSE(t, rec.Body)
-	if !done {
-		t.Error("stream not terminated with [DONE]")
-	}
+	assert.True(t, done, "stream not terminated with [DONE]")
 
 	types := chunkTypes(chunks)
 
@@ -1189,15 +1019,7 @@ func TestStreamModel_StreamResetEventWithReasoning(t *testing.T) {
 		typeTextStart, typeTextDelta, typeTextEnd,
 		typeFinishStep, typeFinish,
 	}
-	if len(types) != len(expected) {
-		t.Fatalf("chunk types = %v, want %v", types, expected)
-	}
-
-	for i, exp := range expected {
-		if types[i] != exp {
-			t.Fatalf("chunk[%d] type = %q, want %q\nall: %v", i, types[i], exp, types)
-		}
-	}
+	require.Equal(t, expected, types, "chunk types mismatch")
 }
 
 func TestHandler_TextContentConcatenatesAllParts(t *testing.T) {
@@ -1212,9 +1034,7 @@ func TestHandler_TextContentConcatenatesAllParts(t *testing.T) {
 		},
 	}
 
-	if got := msg.textContent(); got != "Hello World" {
-		t.Errorf("textContent() = %q, want 'Hello World'", got)
-	}
+	assert.Equal(t, "Hello World", msg.textContent())
 }
 
 func TestHandler_ErrorResponseSanitized(t *testing.T) {
@@ -1231,20 +1051,16 @@ func TestHandler_ErrorResponseSanitized(t *testing.T) {
 
 	StreamModel(context.Background(), model, &llm.Request{
 		Messages: []llm.Message{llm.NewMessage(llm.RoleUser, llm.NewTextPart("hi"))},
-	}, ew, nil)
+	}, ew, nil, nil)
 
 	chunks, _ := parseSSE(t, rec.Body)
 
 	for _, c := range chunks {
 		if c["type"] == typeError {
 			et := chunkStr(t, c, "errorText")
-			if strings.Contains(et, "secret") || strings.Contains(et, "password") {
-				t.Errorf("error text leaks internals: %q", et)
-			}
-
-			if et != sanitizedError {
-				t.Errorf("error text = %q, want %q", et, sanitizedError)
-			}
+			assert.NotContains(t, et, "secret", "error text leaks internals")
+			assert.NotContains(t, et, "password", "error text leaks internals")
+			assert.Equal(t, sanitizedError, et)
 		}
 	}
 }
@@ -1255,16 +1071,8 @@ func TestStreamModel_ToolCall(t *testing.T) {
 	model := &errorStreamModel{
 		events: []llm.Event{
 			llm.ContentPartEvent{Index: 0, Part: llm.NewTextPart("Let me check the weather.")},
-			llm.ContentPartEvent{Index: 1, Part: &llm.ToolRequestPart{
-				ID:        "call-1",
-				Name:      "getWeather",
-				Arguments: json.RawMessage(`{"location":"San Francisco"}`),
-			}},
-			llm.ContentPartEvent{Index: 2, Part: &llm.ToolResponsePart{
-				ID:     "call-1",
-				Name:   "getWeather",
-				Result: json.RawMessage(`{"temp":72,"condition":"sunny"}`),
-			}},
+			llm.ContentPartEvent{Index: 1, Part: llm.NewToolRequestPart("call-1", "getWeather", json.RawMessage(`{"location":"San Francisco"}`))},
+			llm.ContentPartEvent{Index: 2, Part: llm.NewToolResponsePart("call-1", "getWeather", json.RawMessage(`{"temp":72,"condition":"sunny"}`), false)},
 			llm.ContentPartEvent{Index: 3, Part: llm.NewTextPart("It's 72F and sunny!")},
 			llm.StreamEndEvent{Response: &llm.Response{FinishReason: llm.FinishReasonStop}},
 		},
@@ -1275,68 +1083,43 @@ func TestStreamModel_ToolCall(t *testing.T) {
 
 	StreamModel(context.Background(), model, &llm.Request{
 		Messages: []llm.Message{llm.NewMessage(llm.RoleUser, llm.NewTextPart("weather?"))},
-	}, ew, nil)
+	}, ew, nil, nil)
 
 	chunks, done := parseSSE(t, rec.Body)
-	if !done {
-		t.Error("stream not terminated with [DONE]")
-	}
+	assert.True(t, done, "stream not terminated with [DONE]")
 
 	types := chunkTypes(chunks)
 
 	expected := []string{
 		typeStart, typeStartStep,
 		typeTextStart, typeTextDelta, typeTextEnd,
-		"tool-input-start", "tool-input-available",
-		"tool-output-available",
+		typeToolInputStart, typeToolInputAvailable,
+		typeToolOutputAvail,
 		typeTextStart, typeTextDelta, typeTextEnd,
 		typeFinishStep, typeFinish,
 	}
-	if len(types) != len(expected) {
-		t.Fatalf("chunk types = %v\nwant       = %v", types, expected)
-	}
+	require.Equal(t, expected, types, "chunk types mismatch")
 
-	for i, exp := range expected {
-		if types[i] != exp {
-			t.Fatalf("chunk[%d] type = %q, want %q\nall: %v", i, types[i], exp, types)
+	for _, c := range chunks {
+		if c["type"] == typeToolInputStart {
+			assert.Equal(t, "call-1", c["toolCallId"])
+			assert.Equal(t, "getWeather", c["toolName"])
 		}
 	}
 
 	for _, c := range chunks {
-		if c["type"] == "tool-input-start" {
-			if c["toolCallId"] != "call-1" {
-				t.Errorf("tool-input-start toolCallId = %v, want call-1", c["toolCallId"])
-			}
-
-			if c["toolName"] != "getWeather" {
-				t.Errorf("tool-input-start toolName = %v, want getWeather", c["toolName"])
-			}
-		}
-	}
-
-	for _, c := range chunks {
-		if c["type"] == "tool-input-available" {
+		if c["type"] == typeToolInputAvailable {
 			input, ok := c["input"].(map[string]any)
-			if !ok {
-				t.Fatalf("tool-input-available input is not map: %T", c["input"])
-			}
-
-			if input["location"] != "San Francisco" {
-				t.Errorf("input.location = %v, want San Francisco", input["location"])
-			}
+			require.True(t, ok, "tool-input-available input is not map: %T", c["input"])
+			assert.Equal(t, "San Francisco", input["location"])
 		}
 	}
 
 	for _, c := range chunks {
-		if c["type"] == "tool-output-available" {
+		if c["type"] == typeToolOutputAvail {
 			output, ok := c["output"].(map[string]any)
-			if !ok {
-				t.Fatalf("tool-output-available output is not map: %T", c["output"])
-			}
-
-			if output["condition"] != "sunny" {
-				t.Errorf("output.condition = %v, want sunny", output["condition"])
-			}
+			require.True(t, ok, "tool-output-available output is not map: %T", c["output"])
+			assert.Equal(t, "sunny", output["condition"])
 		}
 	}
 }
@@ -1346,15 +1129,8 @@ func TestStreamModel_ToolCallError(t *testing.T) {
 
 	model := &errorStreamModel{
 		events: []llm.Event{
-			llm.ContentPartEvent{Index: 0, Part: &llm.ToolRequestPart{
-				ID:        "call-2",
-				Name:      "failTool",
-				Arguments: json.RawMessage(`{}`),
-			}},
-			llm.ContentPartEvent{Index: 1, Part: &llm.ToolResponsePart{
-				ID:    "call-2",
-				Name:  "failTool",
-				IsError: true, Result: json.RawMessage(`{"error":"tool execution failed"}`),			}},
+			llm.ContentPartEvent{Index: 0, Part: llm.NewToolRequestPart("call-2", "failTool", json.RawMessage(`{}`))},
+			llm.ContentPartEvent{Index: 1, Part: llm.NewToolResponsePart("call-2", "failTool", json.RawMessage("tool execution failed"), true)},
 			llm.StreamEndEvent{Response: &llm.Response{FinishReason: llm.FinishReasonStop}},
 		},
 	}
@@ -1364,41 +1140,1306 @@ func TestStreamModel_ToolCallError(t *testing.T) {
 
 	StreamModel(context.Background(), model, &llm.Request{
 		Messages: []llm.Message{llm.NewMessage(llm.RoleUser, llm.NewTextPart("fail"))},
-	}, ew, nil)
+	}, ew, nil, nil)
 
 	chunks, done := parseSSE(t, rec.Body)
-	if !done {
-		t.Error("stream not terminated with [DONE]")
-	}
+	assert.True(t, done, "stream not terminated with [DONE]")
 
 	types := chunkTypes(chunks)
 
 	expected := []string{
 		typeStart, typeStartStep,
-		"tool-input-start", "tool-input-available",
-		"tool-output-error",
+		typeToolInputStart, typeToolInputAvailable,
+		typeToolOutputError,
 		typeFinishStep, typeFinish,
 	}
-	if len(types) != len(expected) {
-		t.Fatalf("chunk types = %v\nwant       = %v", types, expected)
-	}
-
-	for i, exp := range expected {
-		if types[i] != exp {
-			t.Fatalf("chunk[%d] = %q, want %q", i, types[i], exp)
-		}
-	}
+	require.Equal(t, expected, types, "chunk types mismatch")
 
 	for _, c := range chunks {
-		if c["type"] == "tool-output-error" {
-			errText, _ := c["errorText"].(string)
-			if !strings.Contains(errText, "tool execution failed") {
-				t.Errorf("errorText = %v, want to contain 'tool execution failed'", c["errorText"])
-			}
+		if c["type"] == typeToolOutputError {
+			assert.Equal(t, "tool execution failed", c["errorText"])
+			assert.Equal(t, "call-2", c["toolCallId"])
+		}
+	}
+}
 
-			if c["toolCallId"] != "call-2" {
-				t.Errorf("toolCallId = %v, want call-2", c["toolCallId"])
+func TestStreamModel_IteratorErrorClosesSpans(t *testing.T) {
+	t.Parallel()
+
+	// When the iterator yields an error mid-stream, open text/reasoning spans
+	// must be closed before the error/finish-step/finish sequence.
+	model := &errorStreamModel{
+		events: []llm.Event{
+			llm.ContentPartEvent{Index: 0, Part: llm.NewTextPart("partial")},
+		},
+	}
+
+	// Wrap with an iterator that yields the events then an error.
+	iterErrModel := &iteratorErrorModel{
+		inner: model.events,
+		err:   errors.New("network blip"),
+	}
+
+	rec := httptest.NewRecorder()
+	ew := NewEventWriter(rec)
+
+	StreamModel(context.Background(), iterErrModel, &llm.Request{
+		Messages: []llm.Message{llm.NewMessage(llm.RoleUser, llm.NewTextPart("hi"))},
+	}, ew, nil, nil)
+
+	chunks, done := parseSSE(t, rec.Body)
+	assert.True(t, done, "stream not terminated with [DONE]")
+
+	types := chunkTypes(chunks)
+
+	// text-end must appear before error to close the open span.
+	expected := []string{
+		typeStart, typeStartStep,
+		typeTextStart, typeTextDelta, typeTextEnd,
+		typeError, typeFinishStep, typeFinish,
+	}
+	require.Equal(t, expected, types, "chunk types mismatch")
+}
+
+// iteratorErrorModel yields events then a terminal error from the iterator.
+type iteratorErrorModel struct {
+	errorStreamModel
+
+	inner []llm.Event
+	err   error
+}
+
+func (m *iteratorErrorModel) GenerateEvents(_ context.Context, _ *llm.Request) iter.Seq2[llm.Event, error] {
+	return func(yield func(llm.Event, error) bool) {
+		for _, e := range m.inner {
+			if !yield(e, nil) {
+				return
 			}
 		}
+
+		yield(nil, m.err)
+	}
+}
+
+func TestStreamModel_ReasoningIDsIncrement(t *testing.T) {
+	t.Parallel()
+
+	// reasoning → text → reasoning should produce distinct reasoning IDs.
+	model := &errorStreamModel{
+		events: []llm.Event{
+			llm.ContentPartEvent{Index: 0, Part: llm.NewReasoningPart("think1")},
+			llm.ContentPartEvent{Index: 1, Part: llm.NewTextPart("middle")},
+			llm.ContentPartEvent{Index: 2, Part: llm.NewReasoningPart("think2")},
+			llm.ContentPartEvent{Index: 3, Part: llm.NewTextPart("final")},
+			llm.StreamEndEvent{Response: &llm.Response{FinishReason: llm.FinishReasonStop}},
+		},
+	}
+
+	rec := httptest.NewRecorder()
+	ew := NewEventWriter(rec)
+
+	StreamModel(context.Background(), model, &llm.Request{
+		Messages: []llm.Message{llm.NewMessage(llm.RoleUser, llm.NewTextPart("think"))},
+	}, ew, nil, nil)
+
+	chunks, done := parseSSE(t, rec.Body)
+	assert.True(t, done, "stream not terminated with [DONE]")
+
+	types := chunkTypes(chunks)
+
+	expected := []string{
+		typeStart, typeStartStep,
+		typeReasoningStart, typeReasoningDelta, typeReasoningEnd,
+		typeTextStart, typeTextDelta, typeTextEnd,
+		typeReasoningStart, typeReasoningDelta, typeReasoningEnd,
+		typeTextStart, typeTextDelta, typeTextEnd,
+		typeFinishStep, typeFinish,
+	}
+	require.Equal(t, expected, types, "chunk types mismatch")
+
+	// Collect reasoning-start IDs and verify they differ.
+	var reasoningIDs []string
+
+	for _, c := range chunks {
+		if c["type"] == typeReasoningStart {
+			reasoningIDs = append(reasoningIDs, chunkStr(t, c, "id"))
+		}
+	}
+
+	require.Len(t, reasoningIDs, 2, "expected 2 reasoning-start chunks")
+	assert.NotEqual(t, reasoningIDs[0], reasoningIDs[1], "reasoning IDs should differ")
+}
+
+func TestStreamModel_TextIDsIncrementAcrossToolCalls(t *testing.T) {
+	t.Parallel()
+
+	// text → tool → text should produce distinct text IDs.
+	model := &errorStreamModel{
+		events: []llm.Event{
+			llm.ContentPartEvent{Index: 0, Part: llm.NewTextPart("before tool")},
+			llm.ContentPartEvent{Index: 1, Part: llm.NewToolRequestPart("call-1", "lookup", json.RawMessage(`{}`))},
+			llm.ContentPartEvent{Index: 2, Part: llm.NewToolResponsePart("call-1", "lookup", json.RawMessage(`"ok"`), false)},
+			llm.ContentPartEvent{Index: 3, Part: llm.NewTextPart("after tool")},
+			llm.StreamEndEvent{Response: &llm.Response{FinishReason: llm.FinishReasonStop}},
+		},
+	}
+
+	rec := httptest.NewRecorder()
+	ew := NewEventWriter(rec)
+
+	StreamModel(context.Background(), model, &llm.Request{
+		Messages: []llm.Message{llm.NewMessage(llm.RoleUser, llm.NewTextPart("go"))},
+	}, ew, nil, nil)
+
+	chunks, _ := parseSSE(t, rec.Body)
+
+	// Collect text-start IDs and verify they differ.
+	var textIDs []string
+
+	for _, c := range chunks {
+		if c["type"] == typeTextStart {
+			textIDs = append(textIDs, chunkStr(t, c, "id"))
+		}
+	}
+
+	require.Len(t, textIDs, 2, "expected 2 text-start chunks")
+	assert.NotEqual(t, textIDs[0], textIDs[1], "text IDs should differ")
+}
+
+func TestStreamModel_ReasoningThenToolRequest(t *testing.T) {
+	t.Parallel()
+
+	// reasoning → tool-request must close the reasoning span before emitting tool events.
+	model := &errorStreamModel{
+		events: []llm.Event{
+			llm.ContentPartEvent{Index: 0, Part: llm.NewReasoningPart("thinking about tool")},
+			llm.ContentPartEvent{Index: 1, Part: llm.NewToolRequestPart("call-1", "lookup", json.RawMessage(`{}`))},
+			llm.ContentPartEvent{Index: 2, Part: llm.NewToolResponsePart("call-1", "lookup", json.RawMessage(`"found"`), false)},
+			llm.StreamEndEvent{Response: &llm.Response{FinishReason: llm.FinishReasonStop}},
+		},
+	}
+
+	rec := httptest.NewRecorder()
+	ew := NewEventWriter(rec)
+
+	StreamModel(context.Background(), model, &llm.Request{
+		Messages: []llm.Message{llm.NewMessage(llm.RoleUser, llm.NewTextPart("go"))},
+	}, ew, nil, nil)
+
+	chunks, done := parseSSE(t, rec.Body)
+	assert.True(t, done, "stream not terminated with [DONE]")
+
+	types := chunkTypes(chunks)
+
+	expected := []string{
+		typeStart, typeStartStep,
+		typeReasoningStart, typeReasoningDelta, typeReasoningEnd,
+		typeToolInputStart, typeToolInputAvailable,
+		typeToolOutputAvail,
+		typeFinishStep, typeFinish,
+	}
+	require.Equal(t, expected, types, "chunk types mismatch")
+}
+
+func TestHandler_WithMaxBodyBytes(t *testing.T) {
+	t.Parallel()
+
+	model := fakellm.NewFakeModel()
+	h := Handler(model, WithMaxBodyBytes(50))
+
+	// Valid JSON structure that exceeds the 50-byte limit.
+	body := `{"id":"x","messages":[{"role":"user","content":"this payload is definitely longer than fifty bytes"}]}`
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/chat", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	rec := httptest.NewRecorder()
+
+	h.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code, "body exceeding custom limit should be rejected")
+}
+
+func TestGenerateMessageID_Length(t *testing.T) {
+	t.Parallel()
+
+	id := generateMessageID()
+	assert.Len(t, id, 16, "generateMessageID() value = %q", id)
+}
+
+// toolCallModel returns tool calls on the first N turns, then stops.
+type toolCallModel struct {
+	errorStreamModel
+
+	turnsWithTools int
+	callCount      int
+}
+
+func (m *toolCallModel) GenerateEvents(_ context.Context, _ *llm.Request) iter.Seq2[llm.Event, error] {
+	m.callCount++
+	turn := m.callCount
+
+	return func(yield func(llm.Event, error) bool) {
+		if turn <= m.turnsWithTools {
+			if !yield(llm.ContentPartEvent{Index: 0, Part: llm.NewTextPart("calling tool")}, nil) {
+				return
+			}
+
+			if !yield(llm.ContentPartEvent{Index: 1, Part: llm.NewToolRequestPart("call-1", "lookup", json.RawMessage(`{}`))}, nil) {
+				return
+			}
+
+			yield(llm.StreamEndEvent{Response: &llm.Response{FinishReason: llm.FinishReasonToolCalls}}, nil)
+
+			return
+		}
+
+		if !yield(llm.ContentPartEvent{Index: 0, Part: llm.NewTextPart("done")}, nil) {
+			return
+		}
+
+		yield(llm.StreamEndEvent{Response: &llm.Response{FinishReason: llm.FinishReasonStop}}, nil)
+	}
+}
+
+func TestStreamModelWithTools_HappyPath(t *testing.T) {
+	t.Parallel()
+
+	model := &toolCallModel{turnsWithTools: 1}
+
+	executor := func(_ context.Context, _ string, _ json.RawMessage) (json.RawMessage, error) {
+		return json.RawMessage(`"result"`), nil
+	}
+
+	rec := httptest.NewRecorder()
+	ew := NewEventWriter(rec)
+
+	StreamModelWithTools(context.Background(), model, &llm.Request{
+		Messages: []llm.Message{llm.NewMessage(llm.RoleUser, llm.NewTextPart("go"))},
+		Tools:    []llm.ToolDefinition{{Name: "lookup"}},
+	}, ew, nil, executor, 0, nil)
+
+	chunks, done := parseSSE(t, rec.Body)
+	assert.True(t, done, "stream not terminated with [DONE]")
+
+	types := chunkTypes(chunks)
+
+	expected := []string{
+		typeStart,
+		// Turn 1: tool call
+		typeStartStep, typeTextStart, typeTextDelta, typeTextEnd,
+		typeToolInputStart, typeToolInputAvailable,
+		typeFinishStep,
+		typeToolOutputAvail,
+		// Turn 2: final answer
+		typeStartStep, typeTextStart, typeTextDelta, typeTextEnd,
+		typeFinishStep,
+		typeFinish,
+	}
+	require.Equal(t, expected, types, "chunk types mismatch")
+
+	finishChunk := chunks[len(chunks)-1]
+	assert.Equal(t, finishReasonStop, chunkStr(t, finishChunk, "finishReason"))
+}
+
+func TestStreamModelWithTools_MaxTurnsExhaustion(t *testing.T) {
+	t.Parallel()
+
+	// Model always returns tool calls — will exhaust maxTurns.
+	model := &toolCallModel{turnsWithTools: 100}
+
+	executor := func(_ context.Context, _ string, _ json.RawMessage) (json.RawMessage, error) {
+		return json.RawMessage(`"ok"`), nil
+	}
+
+	rec := httptest.NewRecorder()
+	ew := NewEventWriter(rec)
+
+	StreamModelWithTools(context.Background(), model, &llm.Request{
+		Messages: []llm.Message{llm.NewMessage(llm.RoleUser, llm.NewTextPart("go"))},
+		Tools:    []llm.ToolDefinition{{Name: "lookup"}},
+	}, ew, nil, executor, 2, nil)
+
+	chunks, done := parseSSE(t, rec.Body)
+	assert.True(t, done, "stream not terminated with [DONE]")
+
+	types := chunkTypes(chunks)
+
+	// Count paired start-step/finish-step.
+	startSteps := 0
+	finishSteps := 0
+
+	for _, tp := range types {
+		switch tp {
+		case typeStartStep:
+			startSteps++
+		case typeFinishStep:
+			finishSteps++
+		}
+	}
+
+	assert.Equal(t, 2, startSteps, "expected 2 start-step chunks")
+	assert.Equal(t, 2, finishSteps, "expected 2 finish-step chunks")
+
+	// Exactly one finish chunk.
+	finishCount := 0
+
+	for _, tp := range types {
+		if tp == typeFinish {
+			finishCount++
+		}
+	}
+
+	assert.Equal(t, 1, finishCount, "expected 1 finish chunk")
+
+	// On maxTurns exhaustion the adapter surfaces the last turn's real finish
+	// reason (the model kept calling tools, so "tool-calls"), matching the
+	// reference rather than emitting a synthetic "other".
+	finishChunk := chunks[len(chunks)-1]
+	assert.Equal(t, "tool-calls", chunkStr(t, finishChunk, "finishReason"))
+}
+
+func TestStreamModelWithTools_IteratorErrorNoDuplicateTerminal(t *testing.T) {
+	t.Parallel()
+
+	// Model yields text then iterator error — exercises the streamToolTurn error
+	// path and verifies the caller doesn't emit a second finish+[DONE].
+	model := &iteratorErrorModel{
+		inner: []llm.Event{
+			llm.ContentPartEvent{Index: 0, Part: llm.NewTextPart("partial")},
+		},
+		err: errors.New("network blip"),
+	}
+
+	executor := func(_ context.Context, _ string, _ json.RawMessage) (json.RawMessage, error) {
+		return json.RawMessage(`"ok"`), nil
+	}
+
+	rec := httptest.NewRecorder()
+	ew := NewEventWriter(rec)
+
+	StreamModelWithTools(context.Background(), model, &llm.Request{
+		Messages: []llm.Message{llm.NewMessage(llm.RoleUser, llm.NewTextPart("go"))},
+		Tools:    []llm.ToolDefinition{{Name: "lookup"}},
+	}, ew, nil, executor, 0, nil)
+
+	chunks, done := parseSSE(t, rec.Body)
+	assert.True(t, done, "stream not terminated with [DONE]")
+
+	// Exactly one finish chunk.
+	finishCount := 0
+
+	for _, c := range chunks {
+		if c["type"] == typeFinish {
+			finishCount++
+		}
+	}
+
+	require.Equal(t, 1, finishCount, "expected exactly 1 finish chunk")
+
+	// Verify it's an error finish.
+	for _, c := range chunks {
+		if c["type"] == typeFinish {
+			assert.Equal(t, finishReasonError, chunkStr(t, c, "finishReason"))
+		}
+	}
+}
+
+func TestStreamModelWithTools_IteratorErrorPairsToolChunks(t *testing.T) {
+	t.Parallel()
+
+	// When a tool-input has been emitted and then the iterator errors,
+	// the orphaned tool-input must get a matching tool-output-error.
+	model := &iteratorErrorModel{
+		inner: []llm.Event{
+			llm.ContentPartEvent{Index: 0, Part: llm.NewToolRequestPart("call-orphan", "lookup", json.RawMessage(`{}`))},
+		},
+		err: errors.New("connection reset"),
+	}
+
+	executor := func(_ context.Context, _ string, _ json.RawMessage) (json.RawMessage, error) {
+		return json.RawMessage(`"ok"`), nil
+	}
+
+	rec := httptest.NewRecorder()
+	ew := NewEventWriter(rec)
+
+	StreamModelWithTools(context.Background(), model, &llm.Request{
+		Messages: []llm.Message{llm.NewMessage(llm.RoleUser, llm.NewTextPart("go"))},
+		Tools:    []llm.ToolDefinition{{Name: "lookup"}},
+	}, ew, nil, executor, 0, nil)
+
+	chunks, done := parseSSE(t, rec.Body)
+	assert.True(t, done, "stream not terminated with [DONE]")
+
+	types := chunkTypes(chunks)
+
+	expected := []string{
+		typeStart, typeStartStep,
+		typeToolInputStart, typeToolInputAvailable,
+		typeToolOutputError,
+		typeError, typeFinishStep, typeFinish,
+	}
+	require.Equal(t, expected, types, "chunk types mismatch")
+
+	// Verify the tool-output-error references the right call.
+	for _, c := range chunks {
+		if c["type"] == typeToolOutputError {
+			assert.Equal(t, "call-orphan", c["toolCallId"])
+		}
+	}
+}
+
+func TestStreamModelWithTools_StreamEndEventErrorPairsToolChunks(t *testing.T) {
+	t.Parallel()
+
+	// StreamEndEvent{Error} after tool-input has been emitted must pair
+	// the orphaned tool-input with a tool-output-error.
+	model := &errorStreamModel{
+		events: []llm.Event{
+			llm.ContentPartEvent{Index: 0, Part: llm.NewToolRequestPart("call-orphan", "lookup", json.RawMessage(`{}`))},
+			llm.StreamEndEvent{Error: errors.New("message too long")},
+		},
+	}
+
+	executor := func(_ context.Context, _ string, _ json.RawMessage) (json.RawMessage, error) {
+		return json.RawMessage(`"ok"`), nil
+	}
+
+	rec := httptest.NewRecorder()
+	ew := NewEventWriter(rec)
+
+	StreamModelWithTools(context.Background(), model, &llm.Request{
+		Messages: []llm.Message{llm.NewMessage(llm.RoleUser, llm.NewTextPart("go"))},
+		Tools:    []llm.ToolDefinition{{Name: "lookup"}},
+	}, ew, nil, executor, 0, nil)
+
+	chunks, done := parseSSE(t, rec.Body)
+	assert.True(t, done, "stream not terminated with [DONE]")
+
+	types := chunkTypes(chunks)
+
+	expected := []string{
+		typeStart, typeStartStep,
+		typeToolInputStart, typeToolInputAvailable,
+		typeError, typeFinishStep,
+		typeToolOutputError,
+		typeFinish,
+	}
+	require.Equal(t, expected, types, "chunk types mismatch")
+
+	for _, c := range chunks {
+		if c["type"] == typeToolOutputError {
+			assert.Equal(t, "call-orphan", c["toolCallId"])
+		}
+	}
+}
+
+func TestStreamModelWithTools_StreamEndEventWithError(t *testing.T) {
+	t.Parallel()
+
+	// StreamEndEvent{Error: ...} (as opposed to iterator error) must also
+	// produce exactly one finish+[DONE]. This exercises the writeToolTurnEnd
+	// path where the caller emits finish, not streamToolTurn itself.
+	model := &errorStreamModel{
+		events: []llm.Event{
+			llm.ContentPartEvent{Index: 0, Part: llm.NewTextPart("partial")},
+			llm.StreamEndEvent{Error: errors.New("provider exploded")},
+		},
+	}
+
+	executor := func(_ context.Context, _ string, _ json.RawMessage) (json.RawMessage, error) {
+		return json.RawMessage(`"ok"`), nil
+	}
+
+	rec := httptest.NewRecorder()
+	ew := NewEventWriter(rec)
+
+	StreamModelWithTools(context.Background(), model, &llm.Request{
+		Messages: []llm.Message{llm.NewMessage(llm.RoleUser, llm.NewTextPart("go"))},
+		Tools:    []llm.ToolDefinition{{Name: "lookup"}},
+	}, ew, nil, executor, 0, nil)
+
+	chunks, done := parseSSE(t, rec.Body)
+	assert.True(t, done, "stream not terminated with [DONE]")
+
+	finishCount := 0
+
+	for _, c := range chunks {
+		if c["type"] == typeFinish {
+			finishCount++
+		}
+	}
+
+	require.Equal(t, 1, finishCount, "expected exactly 1 finish chunk")
+
+	for _, c := range chunks {
+		if c["type"] == typeFinish {
+			assert.Equal(t, finishReasonError, chunkStr(t, c, "finishReason"))
+		}
+	}
+}
+
+func TestStreamModelWithTools_StreamResetEvent(t *testing.T) {
+	t.Parallel()
+
+	// StreamResetEvent during a tool-calling turn must close spans, reset
+	// collected tool requests, and not double-fire tools from the discarded attempt.
+	executorCalls := 0
+
+	model := &errorStreamModel{
+		events: []llm.Event{
+			// First attempt: text + tool request, then reset.
+			llm.ContentPartEvent{Index: 0, Part: llm.NewTextPart("attempt1")},
+			llm.ContentPartEvent{Index: 1, Part: llm.NewToolRequestPart("call-discarded", "lookup", json.RawMessage(`{}`))},
+			llm.StreamResetEvent{Attempt: 1, Reason: "retrying"},
+			// Second attempt: just text, no tool call.
+			llm.ContentPartEvent{Index: 0, Part: llm.NewTextPart("attempt2")},
+			llm.StreamEndEvent{Response: &llm.Response{FinishReason: llm.FinishReasonStop}},
+		},
+	}
+
+	executor := func(_ context.Context, _ string, _ json.RawMessage) (json.RawMessage, error) {
+		executorCalls++
+
+		return json.RawMessage(`"ok"`), nil
+	}
+
+	rec := httptest.NewRecorder()
+	ew := NewEventWriter(rec)
+
+	StreamModelWithTools(context.Background(), model, &llm.Request{
+		Messages: []llm.Message{llm.NewMessage(llm.RoleUser, llm.NewTextPart("go"))},
+		Tools:    []llm.ToolDefinition{{Name: "lookup"}},
+	}, ew, nil, executor, 0, nil)
+
+	chunks, done := parseSSE(t, rec.Body)
+	assert.True(t, done, "stream not terminated with [DONE]")
+
+	// Tool executor must NOT have been called — the tool request was from the
+	// discarded attempt before the reset.
+	assert.Equal(t, 0, executorCalls, "executor should not be called for discarded tool requests")
+
+	types := chunkTypes(chunks)
+
+	// Verify text spans are properly closed across the reset, and the
+	// discarded tool request gets a tool-output-error to satisfy the
+	// protocol pairing invariant.
+	expected := []string{
+		typeStart,
+		typeStartStep,
+		typeTextStart, typeTextDelta, typeTextEnd,
+		typeToolInputStart, typeToolInputAvailable,
+		typeToolOutputError,
+		typeTextStart, typeTextDelta, typeTextEnd,
+		typeFinishStep, typeFinish,
+	}
+	require.Equal(t, expected, types, "chunk types mismatch")
+
+	assert.Equal(t, finishReasonStop, chunkStr(t, chunks[len(chunks)-1], "finishReason"))
+}
+
+func TestStreamModel_ToolResponseClosesSpans(t *testing.T) {
+	t.Parallel()
+
+	// PartToolResponse should close any open text/reasoning span.
+	model := &errorStreamModel{
+		events: []llm.Event{
+			llm.ContentPartEvent{Index: 0, Part: llm.NewTextPart("before")},
+			llm.ContentPartEvent{Index: 1, Part: llm.NewToolResponsePart("call-1", "lookup", json.RawMessage(`"found"`), false)},
+			llm.ContentPartEvent{Index: 2, Part: llm.NewTextPart("after")},
+			llm.StreamEndEvent{Response: &llm.Response{FinishReason: llm.FinishReasonStop}},
+		},
+	}
+
+	rec := httptest.NewRecorder()
+	ew := NewEventWriter(rec)
+
+	StreamModel(context.Background(), model, &llm.Request{
+		Messages: []llm.Message{llm.NewMessage(llm.RoleUser, llm.NewTextPart("go"))},
+	}, ew, nil, nil)
+
+	chunks, done := parseSSE(t, rec.Body)
+	assert.True(t, done, "stream not terminated with [DONE]")
+
+	types := chunkTypes(chunks)
+
+	expected := []string{
+		typeStart, typeStartStep,
+		typeTextStart, typeTextDelta, typeTextEnd,
+		typeToolOutputAvail,
+		typeTextStart, typeTextDelta, typeTextEnd,
+		typeFinishStep, typeFinish,
+	}
+	require.Equal(t, expected, types, "chunk types mismatch")
+
+	// Verify text IDs differ across the tool response boundary.
+	var textIDs []string
+
+	for _, c := range chunks {
+		if c["type"] == typeTextStart {
+			textIDs = append(textIDs, chunkStr(t, c, "id"))
+		}
+	}
+
+	require.Len(t, textIDs, 2)
+	assert.NotEqual(t, textIDs[0], textIDs[1], "text IDs should differ across tool response")
+}
+
+func TestStreamModelWithTools_ErrorEventNonTerminal(t *testing.T) {
+	t.Parallel()
+
+	// ErrorEvent in tool-calling mode must be forwarded to the wire,
+	// not silently dropped.
+	model := &errorStreamModel{
+		events: []llm.Event{
+			llm.ContentPartEvent{Index: 0, Part: llm.NewTextPart("before")},
+			llm.ErrorEvent{Message: "recoverable warning"},
+			llm.ContentPartEvent{Index: 0, Part: llm.NewTextPart(" after")},
+			llm.StreamEndEvent{Response: &llm.Response{FinishReason: llm.FinishReasonStop}},
+		},
+	}
+
+	executor := func(_ context.Context, _ string, _ json.RawMessage) (json.RawMessage, error) {
+		return json.RawMessage(`"ok"`), nil
+	}
+
+	rec := httptest.NewRecorder()
+	ew := NewEventWriter(rec)
+
+	StreamModelWithTools(context.Background(), model, &llm.Request{
+		Messages: []llm.Message{llm.NewMessage(llm.RoleUser, llm.NewTextPart("go"))},
+		Tools:    []llm.ToolDefinition{{Name: "lookup"}},
+	}, ew, nil, executor, 0, nil)
+
+	chunks, done := parseSSE(t, rec.Body)
+	assert.True(t, done, "stream not terminated with [DONE]")
+
+	types := chunkTypes(chunks)
+
+	expected := []string{
+		typeStart, typeStartStep,
+		typeTextStart, typeTextDelta, typeError, typeTextDelta, typeTextEnd,
+		typeFinishStep, typeFinish,
+	}
+	require.Equal(t, expected, types, "chunk types mismatch")
+
+	for _, c := range chunks {
+		if c["type"] == typeError {
+			assert.Equal(t, sanitizedError, chunkStr(t, c, "errorText"))
+		}
+	}
+}
+
+func TestStreamModelWithTools_RequestFieldsForwarded(t *testing.T) {
+	t.Parallel()
+
+	// Verify that Options, ResponseFormat, and Metadata from the original
+	// request are forwarded to subsequent model turns, not dropped.
+	type testOptions struct {
+		MaxTokens int
+	}
+
+	var capturedOptions []any
+
+	// Model that returns tool call on first turn, stop on second.
+	callCount := 0
+	model := &callbackModel{
+		fn: func(_ context.Context, req *llm.Request) iter.Seq2[llm.Event, error] {
+			callCount++
+
+			capturedOptions = append(capturedOptions, req.Options)
+
+			return func(yield func(llm.Event, error) bool) {
+				if callCount == 1 {
+					if !yield(llm.ContentPartEvent{Index: 0, Part: llm.NewToolRequestPart("call-1", "lookup", json.RawMessage(`{}`))}, nil) {
+						return
+					}
+
+					yield(llm.StreamEndEvent{Response: &llm.Response{FinishReason: llm.FinishReasonToolCalls}}, nil)
+
+					return
+				}
+
+				if !yield(llm.ContentPartEvent{Index: 0, Part: llm.NewTextPart("done")}, nil) {
+					return
+				}
+
+				yield(llm.StreamEndEvent{Response: &llm.Response{FinishReason: llm.FinishReasonStop}}, nil)
+			}
+		},
+	}
+
+	executor := func(_ context.Context, _ string, _ json.RawMessage) (json.RawMessage, error) {
+		return json.RawMessage(`"ok"`), nil
+	}
+
+	rec := httptest.NewRecorder()
+	ew := NewEventWriter(rec)
+
+	opts := testOptions{MaxTokens: 1000}
+
+	StreamModelWithTools(context.Background(), model, &llm.Request{
+		Messages: []llm.Message{llm.NewMessage(llm.RoleUser, llm.NewTextPart("go"))},
+		Tools:    []llm.ToolDefinition{{Name: "lookup"}},
+		Options:  opts,
+	}, ew, nil, executor, 0, nil)
+
+	require.Len(t, capturedOptions, 2, "expected 2 model calls")
+	assert.Equal(t, opts, capturedOptions[0], "turn 1 should have options")
+	assert.Equal(t, opts, capturedOptions[1], "turn 2 should have options")
+}
+
+// callbackModel delegates GenerateEvents to a callback function.
+type callbackModel struct {
+	errorStreamModel
+
+	fn func(context.Context, *llm.Request) iter.Seq2[llm.Event, error]
+}
+
+func (m *callbackModel) GenerateEvents(ctx context.Context, req *llm.Request) iter.Seq2[llm.Event, error] {
+	return m.fn(ctx, req)
+}
+
+// ── Conformance invariant checkers ──────────────────────────────────
+//
+// These mirror the strict UIMessageChunk schema (ui-message-chunks.ts) and the
+// client parse state machine (process-ui-message-stream.ts) from ai@7.0.6, so
+// Go-level tests can prove conformance without spinning up the JS client.
+
+var validFinishReasons = map[string]bool{
+	"stop": true, "length": true, "content-filter": true,
+	"tool-calls": true, "error": true, "other": true,
+}
+
+type chunkKeySpec struct {
+	required []string
+	optional []string
+}
+
+// emittedChunkSchema lists the keys the strict schema permits for every chunk
+// type this adapter emits. "type" is always allowed.
+var emittedChunkSchema = map[string]chunkKeySpec{
+	typeStart:              {optional: []string{"messageId", "messageMetadata"}},
+	typeStartStep:          {},
+	typeFinishStep:         {},
+	typeFinish:             {optional: []string{"finishReason", "messageMetadata"}},
+	typeTextStart:          {required: []string{"id"}, optional: []string{"providerMetadata"}},
+	typeTextDelta:          {required: []string{"id", "delta"}, optional: []string{"providerMetadata"}},
+	typeTextEnd:            {required: []string{"id"}, optional: []string{"providerMetadata"}},
+	typeReasoningStart:     {required: []string{"id"}, optional: []string{"providerMetadata"}},
+	typeReasoningDelta:     {required: []string{"id", "delta"}, optional: []string{"providerMetadata"}},
+	typeReasoningEnd:       {required: []string{"id"}, optional: []string{"providerMetadata"}},
+	typeToolInputStart:     {required: []string{"toolCallId", "toolName"}, optional: []string{"providerExecuted", "providerMetadata", "toolMetadata", "dynamic", "title"}},
+	typeToolInputAvailable: {required: []string{"toolCallId", "toolName", "input"}, optional: []string{"providerExecuted", "providerMetadata", "toolMetadata", "dynamic", "title"}},
+	typeToolOutputAvail:    {required: []string{"toolCallId", "output"}, optional: []string{"providerExecuted", "providerMetadata", "toolMetadata", "dynamic", "preliminary"}},
+	typeToolOutputError:    {required: []string{"toolCallId", "errorText"}, optional: []string{"providerExecuted", "providerMetadata", "toolMetadata", "dynamic"}},
+	typeError:              {required: []string{"errorText"}},
+	typeAbort:              {optional: []string{"reason"}},
+}
+
+// assertSchemaValid checks every chunk against the strict schema: known type,
+// all required keys present, no key outside required+optional.
+func assertSchemaValid(t *testing.T, chunks []Chunk) {
+	t.Helper()
+
+	for i, c := range chunks {
+		typ, _ := c["type"].(string)
+
+		spec, ok := emittedChunkSchema[typ]
+		require.Truef(t, ok, "chunk %d has unknown type %q", i, typ)
+
+		allowed := map[string]bool{"type": true}
+
+		for _, k := range spec.required {
+			allowed[k] = true
+
+			_, present := c[k]
+			assert.Truef(t, present, "chunk %d (%s) missing required key %q", i, typ, k)
+		}
+
+		for _, k := range spec.optional {
+			allowed[k] = true
+		}
+
+		for k := range c {
+			assert.Truef(t, allowed[k], "chunk %d (%s) has key %q not permitted by the strict schema", i, typ, k)
+		}
+
+		if typ == typeFinish {
+			if fr, present := c["finishReason"]; present {
+				s, _ := fr.(string)
+				assert.Truef(t, validFinishReasons[s], "chunk %d finishReason %q not in enum", i, s)
+			}
+		}
+	}
+}
+
+// assertOrderingValid replays the client parse state machine: every text and
+// reasoning delta/end needs a matching start since the last finish-step (which
+// resets active text/reasoning parts); every tool-output needs a prior
+// tool-input creating the invocation (tool parts persist across steps).
+func assertOrderingValid(t *testing.T, chunks []Chunk) {
+	t.Helper()
+
+	activeText := map[string]bool{}
+	activeReasoning := map[string]bool{}
+	toolParts := map[string]bool{}
+
+	str := func(c Chunk, k string) string { s, _ := c[k].(string); return s }
+
+	for i, c := range chunks {
+		typ, _ := c["type"].(string)
+		switch typ {
+		case typeTextStart:
+			activeText[str(c, "id")] = true
+		case typeTextDelta:
+			assert.Truef(t, activeText[str(c, "id")], "chunk %d text-delta for id %q without active text-start", i, str(c, "id"))
+		case typeTextEnd:
+			assert.Truef(t, activeText[str(c, "id")], "chunk %d text-end for id %q without active text-start", i, str(c, "id"))
+			delete(activeText, str(c, "id"))
+		case typeReasoningStart:
+			activeReasoning[str(c, "id")] = true
+		case typeReasoningDelta:
+			assert.Truef(t, activeReasoning[str(c, "id")], "chunk %d reasoning-delta for id %q without active reasoning-start", i, str(c, "id"))
+		case typeReasoningEnd:
+			assert.Truef(t, activeReasoning[str(c, "id")], "chunk %d reasoning-end for id %q without active reasoning-start", i, str(c, "id"))
+			delete(activeReasoning, str(c, "id"))
+		case typeToolInputStart, typeToolInputAvailable:
+			toolParts[str(c, "toolCallId")] = true
+		case typeToolOutputAvail, typeToolOutputError:
+			assert.Truef(t, toolParts[str(c, "toolCallId")], "chunk %d %s for toolCallId %q without prior tool-input", i, typ, str(c, "toolCallId"))
+		case typeFinishStep:
+			activeText = map[string]bool{}
+			activeReasoning = map[string]bool{}
+		}
+	}
+}
+
+// assertConformant runs both the schema and ordering invariant checks.
+func assertConformant(t *testing.T, chunks []Chunk) {
+	t.Helper()
+	assertSchemaValid(t, chunks)
+	assertOrderingValid(t, chunks)
+}
+
+func streamModelChunks(t *testing.T, events []llm.Event, onError ErrorMapper) []Chunk {
+	t.Helper()
+
+	model := &errorStreamModel{events: events}
+	rec := httptest.NewRecorder()
+	ew := NewEventWriter(rec)
+
+	StreamModel(context.Background(), model, &llm.Request{
+		Messages: []llm.Message{llm.NewMessage(llm.RoleUser, llm.NewTextPart("hi"))},
+	}, ew, nil, onError)
+
+	chunks, done := parseSSE(t, rec.Body)
+	assert.True(t, done, "stream not terminated with [DONE]")
+
+	return chunks
+}
+
+func TestStreamModel_AllEmittedChunksAreSchemaValid(t *testing.T) {
+	t.Parallel()
+
+	stop := llm.StreamEndEvent{Response: &llm.Response{FinishReason: llm.FinishReasonStop}}
+
+	cases := []struct {
+		name   string
+		events []llm.Event
+	}{
+		{
+			name:   "text",
+			events: []llm.Event{llm.ContentPartEvent{Part: llm.NewTextPart("hello")}, stop},
+		},
+		{
+			name: "reasoning then text",
+			events: []llm.Event{
+				llm.ContentPartEvent{Part: llm.NewReasoningPart("thinking")},
+				llm.ContentPartEvent{Part: llm.NewTextPart("answer")},
+				stop,
+			},
+		},
+		{
+			name: "tool request and response",
+			events: []llm.Event{
+				llm.ContentPartEvent{Part: llm.NewToolRequestPart("c1", "lookup", json.RawMessage(`{"q":"x"}`))},
+				llm.ContentPartEvent{Part: llm.NewToolResponsePart("c1", "lookup", json.RawMessage(`{"ok":true}`), false)},
+				stop,
+			},
+		},
+		{
+			name:   "error",
+			events: []llm.Event{llm.ContentPartEvent{Part: llm.NewTextPart("partial")}, llm.StreamEndEvent{Error: errors.New("boom")}},
+		},
+		{
+			name: "every finish reason",
+			events: []llm.Event{
+				llm.ContentPartEvent{Part: llm.NewTextPart("x")},
+				llm.StreamEndEvent{Response: &llm.Response{FinishReason: llm.FinishReasonContentFilter}},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assertConformant(t, streamModelChunks(t, tc.events, nil))
+		})
+	}
+}
+
+func TestStreamModelWithTools_AllEmittedChunksAreSchemaValid(t *testing.T) {
+	t.Parallel()
+
+	model := &toolCallModel{turnsWithTools: 1}
+	executor := func(_ context.Context, _ string, _ json.RawMessage) (json.RawMessage, error) {
+		return json.RawMessage(`{"ok":true}`), nil
+	}
+
+	rec := httptest.NewRecorder()
+	ew := NewEventWriter(rec)
+
+	StreamModelWithTools(context.Background(), model, &llm.Request{
+		Messages: []llm.Message{llm.NewMessage(llm.RoleUser, llm.NewTextPart("go"))},
+		Tools:    []llm.ToolDefinition{{Name: "lookup"}},
+	}, ew, nil, executor, 5, nil)
+
+	chunks, done := parseSSE(t, rec.Body)
+	assert.True(t, done, "stream not terminated with [DONE]")
+	assertConformant(t, chunks)
+}
+
+func TestWithOnError_SurfacesCustomErrorText(t *testing.T) {
+	t.Parallel()
+
+	chunks := streamModelChunks(t, []llm.Event{
+		llm.StreamEndEvent{Error: errors.New("rate limit exceeded")},
+	}, func(err error) string { return err.Error() })
+
+	var got string
+
+	for _, c := range chunks {
+		if c["type"] == typeError {
+			got = chunkStr(t, c, "errorText")
+		}
+	}
+
+	assert.Equal(t, "rate limit exceeded", got, "custom mapper should surface the real error")
+}
+
+func TestWithOnError_DefaultSanitizes(t *testing.T) {
+	t.Parallel()
+
+	chunks := streamModelChunks(t, []llm.Event{
+		llm.StreamEndEvent{Error: errors.New("sensitive internal detail")},
+	}, nil)
+
+	for _, c := range chunks {
+		if c["type"] == typeError {
+			assert.Equal(t, sanitizedError, chunkStr(t, c, "errorText"), "default mapper should sanitize")
+			assert.NotContains(t, chunkStr(t, c, "errorText"), "sensitive")
+		}
+	}
+}
+
+func TestStreamModelWithTools_ToolErrorTextRoutedThroughOnError(t *testing.T) {
+	t.Parallel()
+
+	run := func(onError ErrorMapper) string {
+		model := &toolCallModel{turnsWithTools: 1}
+		executor := func(_ context.Context, _ string, _ json.RawMessage) (json.RawMessage, error) {
+			return nil, errors.New("db connection failed")
+		}
+
+		rec := httptest.NewRecorder()
+		ew := NewEventWriter(rec)
+
+		StreamModelWithTools(context.Background(), model, &llm.Request{
+			Messages: []llm.Message{llm.NewMessage(llm.RoleUser, llm.NewTextPart("go"))},
+			Tools:    []llm.ToolDefinition{{Name: "lookup"}},
+		}, ew, nil, executor, 5, onError)
+
+		chunks, _ := parseSSE(t, rec.Body)
+		assertConformant(t, chunks)
+
+		for _, c := range chunks {
+			if c["type"] == typeToolOutputError {
+				return chunkStr(t, c, "errorText")
+			}
+		}
+
+		return ""
+	}
+
+	assert.Equal(t, sanitizedError, run(nil), "default should sanitize tool error text")
+	assert.Equal(t, "db connection failed", run(func(err error) string { return err.Error() }), "custom mapper should surface tool error text")
+}
+
+func TestStreamModel_ToolOutputNullWhenEmpty(t *testing.T) {
+	t.Parallel()
+
+	chunks := streamModelChunks(t, []llm.Event{
+		llm.ContentPartEvent{Part: llm.NewToolRequestPart("c1", "lookup", json.RawMessage(`{}`))},
+		llm.ContentPartEvent{Part: llm.NewToolResponsePart("c1", "lookup", nil, false)}, // empty Result
+		llm.StreamEndEvent{Response: &llm.Response{FinishReason: llm.FinishReasonStop}},
+	}, nil)
+
+	assertConformant(t, chunks)
+
+	var found bool
+
+	for _, c := range chunks {
+		if c["type"] == typeToolOutputAvail {
+			found = true
+			v, present := c["output"]
+			assert.True(t, present, "output key must be present even when empty")
+			assert.Nil(t, v, "empty tool result should serialize as JSON null")
+		}
+	}
+
+	assert.True(t, found, "expected a tool-output-available chunk")
+}
+
+func TestStreamModel_ReasoningTextInterleaving(t *testing.T) {
+	t.Parallel()
+
+	chunks := streamModelChunks(t, []llm.Event{
+		llm.ContentPartEvent{Part: llm.NewReasoningPart("think1")},
+		llm.ContentPartEvent{Part: llm.NewTextPart("answer")},
+		llm.ContentPartEvent{Part: llm.NewReasoningPart("think2")},
+		llm.StreamEndEvent{Response: &llm.Response{FinishReason: llm.FinishReasonStop}},
+	}, nil)
+
+	assertConformant(t, chunks)
+
+	// Reasoning resuming after text within the same step must use a NEW id.
+	var reasoningStartIDs []string
+
+	for _, c := range chunks {
+		if c["type"] == typeReasoningStart {
+			reasoningStartIDs = append(reasoningStartIDs, chunkStr(t, c, "id"))
+		}
+	}
+
+	require.Len(t, reasoningStartIDs, 2, "expected two reasoning spans")
+	assert.Equal(t, "reasoning-0", reasoningStartIDs[0])
+	assert.Equal(t, "reasoning-1", reasoningStartIDs[1])
+	assert.NotEqual(t, reasoningStartIDs[0], reasoningStartIDs[1])
+}
+
+func TestStreamModel_EmptyTextDeltaIsValid(t *testing.T) {
+	t.Parallel()
+
+	chunks := streamModelChunks(t, []llm.Event{
+		llm.ContentPartEvent{Part: llm.NewTextPart("")},
+		llm.StreamEndEvent{Response: &llm.Response{FinishReason: llm.FinishReasonStop}},
+	}, nil)
+
+	assertConformant(t, chunks)
+
+	for _, c := range chunks {
+		if c["type"] == typeTextDelta {
+			assert.Empty(t, chunkStr(t, c, "delta"), "empty delta is permitted by the schema")
+		}
+	}
+}
+
+func TestStreamModelWithTools_MultiStepResetsTextID(t *testing.T) {
+	t.Parallel()
+
+	// turnsWithTools:1 -> turn 1 emits "calling tool" text + a tool call, turn 2
+	// emits "done" text. The turn-2 text run must start with a fresh text-start
+	// (different id) after the turn-1 finish-step reset.
+	model := &toolCallModel{turnsWithTools: 1}
+	executor := func(_ context.Context, _ string, _ json.RawMessage) (json.RawMessage, error) {
+		return json.RawMessage(`{"ok":true}`), nil
+	}
+
+	rec := httptest.NewRecorder()
+	ew := NewEventWriter(rec)
+
+	StreamModelWithTools(context.Background(), model, &llm.Request{
+		Messages: []llm.Message{llm.NewMessage(llm.RoleUser, llm.NewTextPart("go"))},
+		Tools:    []llm.ToolDefinition{{Name: "lookup"}},
+	}, ew, nil, executor, 5, nil)
+
+	chunks, done := parseSSE(t, rec.Body)
+	assert.True(t, done)
+	assertConformant(t, chunks)
+
+	var textStartIDs []string
+
+	for _, c := range chunks {
+		if c["type"] == typeTextStart {
+			textStartIDs = append(textStartIDs, chunkStr(t, c, "id"))
+		}
+	}
+
+	require.Len(t, textStartIDs, 2, "expected one text run per step")
+	assert.NotEqual(t, textStartIDs[0], textStartIDs[1], "text ids must reset across steps")
+}
+
+func TestWriteChunk_DoesNotHTMLEscape(t *testing.T) {
+	t.Parallel()
+
+	rec := httptest.NewRecorder()
+	ew := NewEventWriter(rec)
+
+	require.NoError(t, ew.WriteChunk(Chunk{"type": typeTextDelta, "id": "text-0", "delta": "if a < b && c > d"}))
+
+	body := rec.Body.String()
+	assert.Contains(t, body, `"delta":"if a < b && c > d"`, "markup must be emitted verbatim, matching JSON.stringify")
+	// HTML escaping (Go's default) would replace <, >, & with <, >,
+	// &. Disabling it keeps the bytes identical to JSON.stringify.
+	assert.NotContains(t, body, "\\u003c", "< must not be escaped")
+	assert.NotContains(t, body, "\\u003e", "> must not be escaped")
+	assert.NotContains(t, body, "\\u0026", "& must not be escaped")
+}
+
+func TestConvertMessages_ReconstructsToolHistory(t *testing.T) {
+	t.Parallel()
+
+	msgs := []chatMessage{
+		{Role: "user", Parts: []messagePart{{Type: "text", Text: "weather in SF?"}}},
+		{Role: "assistant", Parts: []messagePart{
+			{Type: "step-start"},
+			{
+				Type:       "tool-getWeather",
+				ToolCallID: "call-1",
+				State:      "output-available",
+				Input:      json.RawMessage(`{"city":"SF"}`),
+				Output:     json.RawMessage(`{"temp":"72F"}`),
+			},
+			{Type: "step-start"},
+			{Type: "text", Text: "It is 72F in SF."},
+		}},
+		{Role: "user", Parts: []messagePart{{Type: "text", Text: "thanks"}}},
+	}
+
+	out := convertMessages(msgs, "")
+
+	// user, assistant(tool-call), user(tool-result), assistant(text), user
+	require.Len(t, out, 5)
+
+	assert.Equal(t, llm.RoleUser, out[0].Role)
+	assert.Equal(t, "weather in SF?", out[0].TextContent())
+
+	require.Equal(t, llm.RoleAssistant, out[1].Role)
+	require.Len(t, out[1].Content, 1)
+	req, ok := out[1].Content[0].(*llm.ToolRequestPart)
+	require.True(t, ok, "expected *llm.ToolRequestPart, got %T", out[1].Content[0])
+	assert.Equal(t, "call-1", req.ID)
+	assert.Equal(t, "getWeather", req.Name)
+	assert.JSONEq(t, `{"city":"SF"}`, string(req.Arguments))
+
+	require.Equal(t, llm.RoleUser, out[2].Role)
+	require.Len(t, out[2].Content, 1)
+	resp, ok := out[2].Content[0].(*llm.ToolResponsePart)
+	require.True(t, ok, "expected *llm.ToolResponsePart, got %T", out[2].Content[0])
+	assert.False(t, resp.IsError)
+	assert.Equal(t, "call-1", resp.ID)
+	assert.JSONEq(t, `{"temp":"72F"}`, string(resp.Result))
+
+	assert.Equal(t, llm.RoleAssistant, out[3].Role)
+	assert.Equal(t, "It is 72F in SF.", out[3].TextContent())
+
+	assert.Equal(t, llm.RoleUser, out[4].Role)
+	assert.Equal(t, "thanks", out[4].TextContent())
+}
+
+func TestConvertMessages_ToolErrorAndDynamicTool(t *testing.T) {
+	t.Parallel()
+
+	msgs := []chatMessage{
+		{Role: "assistant", Parts: []messagePart{
+			{
+				Type:       "dynamic-tool",
+				ToolName:   "search",
+				ToolCallID: "c2",
+				State:      "output-error",
+				Input:      json.RawMessage(`{"q":"x"}`),
+				ErrorText:  "search backend down",
+			},
+		}},
+	}
+
+	out := convertMessages(msgs, "")
+
+	require.Len(t, out, 2, "assistant tool-call + user tool-result(error)")
+	req, ok := out[0].Content[0].(*llm.ToolRequestPart)
+	require.True(t, ok, "expected *llm.ToolRequestPart, got %T", out[0].Content[0])
+	assert.Equal(t, "search", req.Name)
+
+	resp, ok := out[1].Content[0].(*llm.ToolResponsePart)
+	require.True(t, ok, "expected *llm.ToolResponsePart, got %T", out[1].Content[0])
+	assert.True(t, resp.IsError, "error tool result should set IsError")
+	assert.JSONEq(t, `{"error":"search backend down"}`, string(resp.Result))
+}
+
+func TestConvertMessages_SkipsIncompleteToolCalls(t *testing.T) {
+	t.Parallel()
+
+	msgs := []chatMessage{
+		{Role: "assistant", Parts: []messagePart{
+			{Type: "tool-foo", ToolCallID: "c", State: "input-streaming"},
+		}},
+	}
+
+	assert.Empty(t, convertMessages(msgs, ""), "a still-streaming tool call yields no model message")
+}
+
+func TestConvertMessages_CoalescesConsecutiveAssistantSteps(t *testing.T) {
+	t.Parallel()
+
+	// Two text-only assistant steps (no intervening tool result) must coalesce
+	// into a single assistant message so roles stay strictly alternating.
+	msgs := []chatMessage{
+		{Role: "user", Parts: []messagePart{{Type: "text", Text: "hi"}}},
+		{Role: "assistant", Parts: []messagePart{
+			{Type: "step-start"},
+			{Type: "text", Text: "a"},
+			{Type: "step-start"},
+			{Type: "text", Text: "b"},
+		}},
+		{Role: "user", Parts: []messagePart{{Type: "text", Text: "next"}}},
+	}
+
+	out := convertMessages(msgs, "")
+
+	require.Len(t, out, 3)
+	assert.Equal(t, llm.RoleUser, out[0].Role)
+	assert.Equal(t, llm.RoleAssistant, out[1].Role)
+	assert.Equal(t, "ab", out[1].TextContent(), "the two assistant steps should be merged")
+	assert.Equal(t, llm.RoleUser, out[2].Role)
+
+	assertRolesAlternate(t, out)
+}
+
+func TestConvertMessages_DroppedAssistantTurnDoesNotBreakAlternation(t *testing.T) {
+	t.Parallel()
+
+	// An assistant turn that reconstructs to nothing (only a streaming tool call)
+	// must not leave two consecutive user messages.
+	msgs := []chatMessage{
+		{Role: "user", Parts: []messagePart{{Type: "text", Text: "q1"}}},
+		{Role: "assistant", Parts: []messagePart{{Type: "tool-x", ToolCallID: "c", State: "input-streaming"}}},
+		{Role: "user", Parts: []messagePart{{Type: "text", Text: "q2"}}},
+	}
+
+	out := convertMessages(msgs, "")
+
+	require.Len(t, out, 1, "the two user turns should coalesce")
+	assert.Equal(t, llm.RoleUser, out[0].Role)
+	assert.Equal(t, "q1q2", out[0].TextContent())
+}
+
+// assertRolesAlternate verifies no two consecutive messages share a role, which
+// providers such as Anthropic require.
+func assertRolesAlternate(t *testing.T, msgs []llm.Message) {
+	t.Helper()
+
+	for i := 1; i < len(msgs); i++ {
+		assert.NotEqualf(t, msgs[i-1].Role, msgs[i].Role, "messages %d and %d must not share a role", i-1, i)
 	}
 }


### PR DESCRIPTION
## What

Bring the Vercel AI SDK UI message stream adapter to full conformance with `ai@7.0.6` and fix the bugs that kept its conformance suite from actually passing. Adds an error mapper, reconstructs inbound tool-call history, and expands the test + conformance coverage.

## Why

The adapter claimed conformance but the suite did not pass: the error path emitted a hardcoded "An error occurred" while the test -- and the reference contract -- expected the real error to be surfaceable. Multi-turn tool conversations were silently dropped because only text was forwarded to the model. Smaller deviations from the reference (finish reason on turn-limit exhaustion, span/error ordering, no abort signal on cancellation, HTML-escaped wire bytes) would surface with any non-trivial model behavior. The v6->v7 protocol change is purely additive -- chunk shapes, SSE framing and headers are unchanged -- so the bump is safe.

## Implementation details

**Error handling.** Add `WithOnError(func(error) string)`, mirroring the reference `onError` option. The default returns the sanitized "An error occurred." (with the trailing period the reference uses). Every error chunk -- terminal, iterator, recoverable `ErrorEvent`, and `tool-output-error` -- routes the real error through the mapper instead of a hardcoded string. The model still receives the real tool error; only the client-facing text is mapped.

**Inbound history.** Reconstruct assistant tool calls and their results from the UI message parts (`tool-<name>` / `dynamic-tool`), split on step boundaries, mirroring `convert-to-model-messages.ts`. Coalesce consecutive same-role messages so roles stay strictly alternating -- the reference leaves this to the provider, and the Go providers do not coalesce. Tool results carry their payload in the sealed-interface `ToolResponsePart` (`IsError` + `Result`). Previously only text was forwarded and multi-turn tool conversations were dropped.

**Other fixes.**
- `maxTurns` exhaustion emits the last turn's real finish reason (`tool-calls`), not a synthetic `other`.
- `closeSpans()` runs before the error chunk on every terminal path, so an error is never wedged inside an open text run.
- Emit an `abort` chunk + `[DONE]` on context cancellation, matching `stream-text.ts`.
- Disable HTML escaping in the SSE encoder so `<`, `>` and `&` in deltas match `JSON.stringify` byte-for-byte.

**Conformance and tests.** Bump the suite to `ai@7.0.6` and add endpoints + tests for reasoning, tool calling, tool errors, multi-step tool loops and mid-stream errors; it now passes 11/11 against the real client, which strict-schema-validates every chunk. Add a `task test:conformance` target and Go-level schema + parse-state-machine invariant checkers.

## References

Original code review: https://github.com/redpanda-data/ai-sdk-go/pull/131#issuecomment-4419245214
