### PR TITLE
test(google): skip integration tests by default

### DIFF
--- a/providers/google/googletest/env.go
+++ b/providers/google/googletest/env.go
@@ -21,8 +21,16 @@ import (
 
 // GetAPIKeyOrSkipTest returns the API key if present,
 // otherwise it skips the test.
+//
+// Google integration tests are skipped by default because the Gemini API
+// frequently returns 503 "high demand" errors that cause flaky CI runs.
+// Set RUN_GOOGLE_INTEGRATION=1 to opt in (e.g. for local debugging).
 func GetAPIKeyOrSkipTest(t *testing.T) string {
 	t.Helper()
+
+	if os.Getenv("RUN_GOOGLE_INTEGRATION") != "1" {
+		t.Skip("skipping Google integration test: set RUN_GOOGLE_INTEGRATION=1 to enable (disabled by default due to frequent 503 high-demand errors)")
+	}
 
 	key := os.Getenv("GOOGLE_API_KEY")
 	if key == "" {


### PR DESCRIPTION
## Summary

Skip the Google conformance and integration tests by default. The Gemini API frequently returns:

```
Error 503, Message: This model is currently experiencing high demand. Spikes in demand are usually
temporary. Please try again later., Status: UNAVAILABLE
```

…which causes flaky CI runs that aren't actionable on our side.

To re-enable locally:
```
RUN_GOOGLE_INTEGRATION=1 GOOGLE_API_KEY=... go test ./providers/google/...
```

Implementation: gates the existing `googletest.GetAPIKeyOrSkipTest` helper on a new `RUN_GOOGLE_INTEGRATION=1` opt-in. The helper is used by both conformance tests and `cache_test.go`, so all three are covered.

## Test plan

- [x] `go test -v -run TestGoogleConformance_Integration$ ./providers/google/` — all subtests SKIP with the explanatory message
- [x] Build passes (`go build ./providers/google/...`)