### PR TITLE
fix(runner): avoid range-over-func panic on per-message save error [AI-1157]

### DIFF
--- a/runner/runner.go
+++ b/runner/runner.go
@@ -215,7 +215,14 @@ func (r *Runner) Run(
 			// Note: Agent already appended the message to sess.Messages, we just save it
 			if _, ok := evt.(agent.MessageEvent); ok {
 				if err := r.config.sessionStore.Save(ctx, sess); err != nil {
-					yield(nil, fmt.Errorf("%w: %w", agent.ErrSessionSave, err))
+					// Capture yield's bool so the defer's guard works if the
+					// consumer breaks here — otherwise the deferred save's
+					// yield panics with "range function continued iteration
+					// after function for loop body returned false".
+					if !yield(nil, fmt.Errorf("%w: %w", agent.ErrSessionSave, err)) {
+						consumerStopped = true
+					}
+
 					return
 				}
 			}

--- a/runner/runner_test.go
+++ b/runner/runner_test.go
@@ -465,6 +465,77 @@ func TestRun_SessionSaveError_ConsumerStopsEarly_Panic(t *testing.T) {
 	t.Log("No panic - test passed")
 }
 
+// TestRun_SessionSaveError_ConsumerBreaksOnMessageSaveError_Panic reproduces AI-1157.
+//
+// BUG: When the per-MessageEvent inner session save fails, the runner yields the error
+// at runner.go:218 WITHOUT capturing yield's bool return. If the consumer breaks on
+// that error, the consumerStopped flag stays false. The function returns, the defer
+// fires, the deferred Save fails again, and the defer's yield panics with:
+//
+//	runtime error: range function continued iteration after function for loop body returned false
+//
+// Distinct from AI-587 (consumer breaks on InvocationEndEvent), which was already
+// handled because line 224 captures yield's return.
+//
+// Reproduction:
+//  1. Agent yields a MessageEvent.
+//  2. Runner's per-message Save (runner.go:217) fails.
+//  3. Runner yields the ErrSessionSave error (runner.go:218).
+//  4. Consumer breaks on the error.
+//  5. Runner returns; defer fires; Save fails again.
+//  6. Defer's yield(...) panics because the iterator was already canceled.
+func TestRun_SessionSaveError_ConsumerBreaksOnMessageSaveError_Panic(t *testing.T) {
+	t.Parallel()
+
+	store := &mockSessionStore{
+		loadFunc: func(_ context.Context, _ string) (*session.State, error) {
+			return nil, session.ErrNotFound
+		},
+		saveFunc: func(_ context.Context, _ *session.State) error {
+			return errors.New("marshal failed")
+		},
+	}
+
+	ag := &mockAgent{
+		name: "test-agent",
+		runFunc: func(_ context.Context, inv *agent.InvocationMetadata) iter.Seq2[agent.Event, error] {
+			return func(yield func(agent.Event, error) bool) {
+				envelope := agent.EventEnvelope{
+					InvocationID: inv.InvocationID(),
+					SessionID:    inv.Session().ID,
+					Turn:         0,
+					At:           time.Now().UTC(),
+				}
+				yield(agent.MessageEvent{
+					Envelope: envelope,
+					Response: llm.Response{
+						Message: llm.NewMessage(llm.RoleAssistant, llm.NewTextPart("hi")),
+					},
+				}, nil)
+			}
+		},
+	}
+
+	r, err := runner.New(ag, store)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	userMsg := llm.NewMessage(llm.RoleUser, llm.NewTextPart("hello"))
+
+	var gotErr error
+
+	for _, err := range r.Run(ctx, "", "test-session", userMsg) {
+		if err != nil {
+			gotErr = err
+
+			break
+		}
+	}
+
+	require.Error(t, gotErr)
+	assert.ErrorIs(t, gotErr, agent.ErrSessionSave)
+}
+
 // TestRun_ContextCancellation verifies context cancellation.
 func TestRun_ContextCancellation(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
## What

In `runner/runner.go`, the per-`MessageEvent` inner session save (line 218) called `yield(nil, err)` without checking its bool return. If the consumer broke on that error, the deferred final save then re-entered `yield` on a canceled iterator and Go panicked with `range function continued iteration after function for loop body returned false`.

Surgical fix: capture `yield`'s return at that site; set `consumerStopped = true` on `false` so the existing defer-time guard (lines 192-198) fires.

## Why

[AI-1157](https://redpandadata.atlassian.net/browse/AI-1157) — observed deterministically in `marketing-agent` (Cloud Run worker pool on `rp-internal-agents`) when an LLM returns a malformed `json.RawMessage` in a tool-args block. `MarshalJSON` on the next session save fails, the consumer breaks on the yielded `ErrSessionSave`, and the deferred save's yield panics — crashing the worker before it can emit the Slack reply.

Distinct from AI-587 (consumer breaks on `InvocationEndEvent`), which was already handled because that yield site at line 224 already captured the bool.

## How

- `runner/runner.go`: capture the bool return at line 218 and set `consumerStopped` on `false`.
- `runner/runner_test.go`: new `TestRun_SessionSaveError_ConsumerBreaksOnMessageSaveError_Panic` — forces `Save` to fail on a `MessageEvent` and breaks on the yielded error. Before the fix it panics with the exact ticket stack (defer's yield at `runner.go:193` ← range body at `runner.go:234`). After the fix the consumer receives `ErrSessionSave` once and the deferred save logs through the "consumer stopped" branch.

[AI-1157]: https://redpandadata.atlassian.net/browse/AI-1157?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ