### PR TITLE
google: add Gemini 3.5 Flash model support

### DIFF
--- a/providers/google/google_conformance_test.go
+++ b/providers/google/google_conformance_test.go
@@ -112,6 +112,7 @@ func TestGoogleConformance_Integration(t *testing.T) {
 	t.Parallel()
 
 	modelsToTest := []string{
+		google.ModelGemini35Flash,       // gemini-3.5-flash
 		google.ModelGemini31ProPreview,  // gemini-3.1-pro-preview
 		google.ModelGemini3FlashPreview, // gemini-3-flash-preview
 	}

--- a/providers/google/googletest/constants.go
+++ b/providers/google/googletest/constants.go
@@ -16,7 +16,7 @@ package googletest
 
 const (
 	// TestModelName is the model to use for integration tests.
-	TestModelName = "gemini-3-flash-preview"
+	TestModelName = "gemini-3.5-flash"
 	// TestReasoningModelName is the model for reasoning tests.
 	TestReasoningModelName = "gemini-3.1-pro-preview"
 )

--- a/providers/google/models.go
+++ b/providers/google/models.go
@@ -23,6 +23,7 @@ import (
 
 // Model ID constants for Google Gemini models.
 const (
+	ModelGemini35Flash       = "gemini-3.5-flash"
 	ModelGemini31ProPreview  = "gemini-3.1-pro-preview"
 	ModelGemini3ProPreview   = "gemini-3-pro-preview"
 	ModelGemini3FlashPreview = "gemini-3-flash-preview"
@@ -67,6 +68,28 @@ func resolveModelFamily(model string) string {
 // supportedModels defines all Gemini models with their capabilities and constraints.
 // Based on https://ai.google.dev/gemini-api/docs/models
 var supportedModels = map[string]ModelDefinition{
+	ModelGemini35Flash: {
+		Name:  ModelGemini35Flash,
+		Label: "Gemini 3.5 Flash",
+		Capabilities: llm.ModelCapabilities{
+			Streaming:        true,
+			Tools:            true,
+			JSONMode:         true,
+			StructuredOutput: true,
+			Vision:           true,
+			MultiTurn:        true,
+			SystemPrompts:    true,
+			Reasoning:        true,
+		},
+		Constraints: llm.ModelConstraints{
+			TemperatureRange:  [2]float64{0.0, 2.0},
+			MaxInputTokens:    1048576,
+			MaxOutputTokens:   65535,
+			SupportedParams:   []string{"temperature", "top_p", "top_k", "max_tokens", "stop", "presence_penalty", "frequency_penalty"},
+			MutuallyExclusive: [][]string{},
+		},
+		Pricing: pricing.FlatInfo(1.50, 9.00, 0.15),
+	},
 	ModelGemini31ProPreview: {
 		Name:  ModelGemini31ProPreview,
 		Label: "Gemini 3.1 Pro Preview",


### PR DESCRIPTION
## What

Add `gemini-3.5-flash` to the Google provider's supported models catalog and conformance test suite.

## Why

Google released Gemini 3.5 Flash as a stable model. It's their current frontier Flash model -- 4x faster output than competing frontier models, strong on agentic and coding tasks. No reason not to support it.

## Implementation details

- Added `ModelGemini35Flash` constant and full model definition (1M context, 65K output, all capabilities including reasoning)
- Flat pricing at $1.50/$9.00/$0.15 per 1M tokens (input/output/cached) per Google's pricing page
- Added to conformance test model list; all 9 test suites pass against the live API
- Updated default integration test model from `gemini-3-flash-preview` to `gemini-3.5-flash`

Gemini 3.5 Pro is announced but not publicly available yet -- will add when it ships.

## References

- https://blog.google/innovation-and-ai/models-and-research/gemini-models/gemini-3-5/
- https://ai.google.dev/gemini-api/docs/pricing