### PR TITLE
openai: add GPT-5.5 model support

### DIFF
--- a/providers/openai/constants.go
+++ b/providers/openai/constants.go
@@ -43,6 +43,10 @@ const (
 	// ModelGPT5_3ChatLatest is the GPT-5.3 Chat Latest model (speed-optimized, medium-only reasoning).
 	ModelGPT5_3ChatLatest = shared.ChatModelGPT5_3ChatLatest
 
+	// ModelGPT5_5 is the GPT-5.5 flagship model (1M context, coding/professional work).
+	// Raw string until the OpenAI SDK adds the constant.
+	ModelGPT5_5 = "gpt-5.5"
+
 	// ModelGPT5_4 is the GPT-5.4 flagship model with full reasoning.
 	ModelGPT5_4 = shared.ChatModelGPT5_4
 	// ModelGPT5_4Mini is the GPT-5.4 Mini model (efficient, full reasoning, 400K context).

--- a/providers/openai/models.go
+++ b/providers/openai/models.go
@@ -259,6 +259,32 @@ var supportedModels = map[string]ModelDefinition{
 		Pricing:                   pricing.FlatInfo(1.75, 14.00, 0.175),
 	},
 
+	// GPT-5.5 (May 2026 Flagship)
+	ModelGPT5_5: {
+		Name:  ModelGPT5_5,
+		Label: "OpenAI GPT-5.5",
+		Capabilities: llm.ModelCapabilities{
+			Streaming:        true,
+			Tools:            true,
+			JSONMode:         true,
+			StructuredOutput: true,
+			Vision:           true,
+			Audio:            true,
+			MultiTurn:        true,
+			SystemPrompts:    true,
+			Reasoning:        true,
+		},
+		Constraints: llm.ModelConstraints{
+			TemperatureRange:  [2]float64{0.0, 2.0},
+			MaxInputTokens:    1048576, // 1M context window
+			MaxOutputTokens:   128000,  // 128K output tokens
+			SupportedParams:   []string{"temperature", "top_p", "max_tokens", "frequency_penalty", "presence_penalty", "seed", "reasoning_effort", "reasoning_summary"},
+			MutuallyExclusive: [][]string{{"temperature", "top_p"}},
+		},
+		SupportedReasoningEfforts: []ReasoningEffort{ReasoningEffortNone, ReasoningEffortLow, ReasoningEffortMedium, ReasoningEffortHigh, ReasoningEffortXHigh},
+		Pricing:                   pricing.FlatInfo(5.00, 30.00, 0.50),
+	},
+
 	// GPT-5.4 Series (March 2026 Flagship)
 	ModelGPT5_4: {
 		Name:  ModelGPT5_4,


### PR DESCRIPTION
## What

Add `gpt-5.5` to the OpenAI provider's supported models catalog.

## Why

OpenAI's latest flagship model is available in the API but missing from our catalog. 1M context window makes it the first OpenAI model at that scale.

## Implementation details

- Added `ModelGPT5_5` constant as raw string (`"gpt-5.5"`) since the OpenAI Go SDK v3.29.0 doesn't have it yet
- Full capabilities: streaming, tools, JSON/structured output, vision, audio, reasoning (none through xhigh)
- 1M input / 128K output context window
- Flat pricing: $5.00/$30.00/$0.50 per 1M tokens (input/output/cached) per OpenAI pricing page
- Conformance tests pass -- `TestAllSupportedModels` auto-discovers and validates it

## References

- https://developers.openai.com/api/docs/models
- https://developers.openai.com/docs/pricing