### PR TITLE
anthropic, bedrock: add Claude Opus 4.8 model support

### DIFF
--- a/providers/anthropic/alias_test.go
+++ b/providers/anthropic/alias_test.go
@@ -60,6 +60,16 @@ func TestModelResolution(t *testing.T) {
 			expectedModel: "claude-opus-4-6",
 		},
 		{
+			name:          "claude-opus-4-8 family name resolves",
+			modelKey:      "claude-opus-4-8",
+			expectedModel: "claude-opus-4-8",
+		},
+		{
+			name:          "claude-opus-4-8 timestamped preserves original",
+			modelKey:      "claude-opus-4-8-20260528",
+			expectedModel: "claude-opus-4-8-20260528",
+		},
+		{
 			name:          "claude-opus-4-7 family name resolves",
 			modelKey:      "claude-opus-4-7",
 			expectedModel: "claude-opus-4-7",

--- a/providers/anthropic/models.go
+++ b/providers/anthropic/models.go
@@ -28,6 +28,7 @@ const (
 	ModelClaudeSonnet46 = "claude-sonnet-4-6"
 	ModelClaudeSonnet45 = "claude-sonnet-4-5"
 	ModelClaudeHaiku45  = "claude-haiku-4-5"
+	ModelClaudeOpus48   = "claude-opus-4-8"
 	ModelClaudeOpus47   = "claude-opus-4-7"
 	ModelClaudeOpus46   = "claude-opus-4-6"
 	ModelClaudeOpus45   = "claude-opus-4-5"
@@ -94,6 +95,44 @@ func resolveModelFamily(model string) string {
 // supportedModels defines all Claude models with their capabilities and constraints.
 // Based on Anthropic API documentation and model specifications.
 var supportedModels = map[string]ModelDefinition{
+	ModelClaudeOpus48: {
+		Name:  ModelClaudeOpus48,
+		Label: "Claude Opus 4.8",
+		Capabilities: llm.ModelCapabilities{
+			Streaming:        true,
+			Tools:            true,
+			JSONMode:         false, // Anthropic doesn't have native JSON mode
+			StructuredOutput: false, // Use tool calling for structured output instead
+			Vision:           true,
+			MultiTurn:        true,
+			SystemPrompts:    true,
+			Reasoning:        true, // Adaptive thinking only; use effort to bias toward more/less thinking
+		},
+		Constraints: llm.ModelConstraints{
+			TemperatureRange: [2]float64{0.0, 1.0},
+			MaxInputTokens:   1000000, // 1M context window
+			MaxOutputTokens:  128000,  // 128K output tokens
+			// Opus 4.8 rejects thinking.type.enabled — thinking budget is not user-controllable.
+			// Use adaptive thinking + effort to bias reasoning depth.
+			SupportedParams:   []string{"temperature", "top_p", "top_k", "max_tokens", "effort", "speed"},
+			MutuallyExclusive: [][]string{},
+		},
+		SupportedEfforts: []Effort{EffortLow, EffortMedium, EffortHigh, EffortXHigh, EffortMax},
+		SupportedSpeeds:  []Speed{SpeedStandard, SpeedFast},
+		AdaptiveThinking: true,
+		Pricing: pricing.FlatInfoFromRates(
+			pricing.NewRates(5.00, 25.00, 0.50).WithCacheCreation(6.25, 10.00, 0),
+		).WithOverride(
+			pricing.Selector{Speed: SpeedFast},
+			pricing.RateCard{
+				// Opus 4.8 fast mode is 3x cheaper than Opus 4.6/4.7's fast mode.
+				// Cache rates derived from Anthropic's prompt-caching multipliers
+				// (5m-write = 1.25x base input, 1h-write = 2x, cache-read = 0.10x).
+				Base: pricing.NewRates(10.00, 50.00, 1.00).
+					WithCacheCreation(12.50, 20.00, 0),
+			},
+		),
+	},
 	ModelClaudeOpus47: {
 		Name:  ModelClaudeOpus47,
 		Label: "Claude Opus 4.7",

--- a/providers/bedrock/models.go
+++ b/providers/bedrock/models.go
@@ -71,6 +71,14 @@ const (
 	ModelClaudeHaiku45EU     = "eu." + ModelClaudeHaiku45
 	ModelClaudeHaiku45AU     = "au." + ModelClaudeHaiku45
 
+	// ModelClaudeOpus48 is the bare Bedrock ID for Claude Opus 4.8
+	// (inference-profile-only — invoke via one of the prefixed variants).
+	ModelClaudeOpus48       = "anthropic.claude-opus-4-8"
+	ModelClaudeOpus48Global = "global." + ModelClaudeOpus48
+	ModelClaudeOpus48US     = "us." + ModelClaudeOpus48
+	ModelClaudeOpus48EU     = "eu." + ModelClaudeOpus48
+	ModelClaudeOpus48JP     = "jp." + ModelClaudeOpus48
+
 	// ModelClaudeOpus47 is the bare Bedrock ID for Claude Opus 4.7
 	// (inference-profile-only — invoke via one of the prefixed variants).
 	ModelClaudeOpus47       = "anthropic.claude-opus-4-7"
@@ -195,6 +203,47 @@ var (
 //   - global. profiles use the "Global Cross-region Inference" rate, which
 //     is exactly 10% cheaper than the geo rate for the same model.
 var supportedModels = map[string]ModelDefinition{
+	// ----------------------------------------------------------------
+	// Claude Opus 4.8 — inference-profile-only, no bare entry. Geo
+	// profiles cover us, eu, jp (au is not published).
+	// ----------------------------------------------------------------
+	ModelClaudeOpus48Global: {
+		Name:         ModelClaudeOpus48Global,
+		Label:        "Claude Opus 4.8 (Global)",
+		Capabilities: claudeStandardCaps,
+		Constraints:  claudeContext1MConstraints,
+		Pricing: pricing.FlatInfoFromRates(
+			pricing.NewRates(5.00, 25.00, 0.50).WithCacheCreation(6.25, 10.00, 0),
+		),
+	},
+	ModelClaudeOpus48US: {
+		Name:         ModelClaudeOpus48US,
+		Label:        "Claude Opus 4.8 (US)",
+		Capabilities: claudeStandardCaps,
+		Constraints:  claudeContext1MConstraints,
+		Pricing: pricing.FlatInfoFromRates(
+			pricing.NewRates(5.50, 27.50, 0.55).WithCacheCreation(6.875, 11.00, 0),
+		),
+	},
+	ModelClaudeOpus48EU: {
+		Name:         ModelClaudeOpus48EU,
+		Label:        "Claude Opus 4.8 (EU)",
+		Capabilities: claudeStandardCaps,
+		Constraints:  claudeContext1MConstraints,
+		Pricing: pricing.FlatInfoFromRates(
+			pricing.NewRates(5.50, 27.50, 0.55).WithCacheCreation(6.875, 11.00, 0),
+		),
+	},
+	ModelClaudeOpus48JP: {
+		Name:         ModelClaudeOpus48JP,
+		Label:        "Claude Opus 4.8 (JP)",
+		Capabilities: claudeStandardCaps,
+		Constraints:  claudeContext1MConstraints,
+		Pricing: pricing.FlatInfoFromRates(
+			pricing.NewRates(5.50, 27.50, 0.55).WithCacheCreation(6.875, 11.00, 0),
+		),
+	},
+
 	// ----------------------------------------------------------------
 	// Claude Opus 4.7 — inference-profile-only, no bare entry. Geo
 	// profiles cover us, eu, jp (au is not published).


### PR DESCRIPTION
## Summary

Adds `claude-opus-4-8` to the anthropic and bedrock providers, mirroring the existing Opus 4.7 entries with the new fast-mode pricing override.

- **Anthropic provider:** new `ModelClaudeOpus48` constant and supportedModels entry. Same capabilities/constraints as Opus 4.7 (1M context, 128k max output, vision, tools, adaptive thinking, full effort range, `speed` param). Standard rates match Opus 4.7.
- **Fast-mode override:** new pricing announced for Opus 4.8 fast mode is wired via `Pricing.WithOverride(Selector{Speed: SpeedFast}, ...)`, mirroring the Opus 4.6 fast-mode pattern. The `TestFastModeModelsHaveFastPricing` test enforces all five rate fields are populated.
- **Bedrock provider:** new constants and supportedModels entries for `anthropic.claude-opus-4-8` across Global + US + EU + JP inference profiles, matching Opus 4.7's geo coverage.
- **Resolver tests:** added family-name and timestamped-variant cases to `TestModelResolution`.

## Bedrock pricing note

AWS hasn't published explicit Opus 4.8 pricing on https://aws.amazon.com/bedrock/pricing/ yet (verified at PR time). Per the repo's consistent convention for every Anthropic Bedrock model in this catalog, the bedrock entries assume:
- Bedrock Global == Anthropic API rates
- Bedrock Geo == 1.10× Global (the standard markup; enforced by `TestGeoGlobalRatio`)

Worth re-verifying against AWS's published numbers once they're listed.

## References

- [Introducing Claude Opus 4.8](https://www.anthropic.com/news/claude-opus-4-8)
- [Anthropic pricing page](https://platform.claude.com/docs/en/about-claude/pricing)
- [Models overview](https://platform.claude.com/docs/en/about-claude/models/overview)

## Test plan

- [x] `task test:unit` — `providers/anthropic` (92 pass) and `providers/bedrock` (193 pass) packages pass. Unrelated kvstore failures are due to missing local Docker for testcontainers, not these changes.
- [x] `task lint:new` — 0 new issues.
- [x] `task license:check` — passes.
- [x] `TestAllModelsHavePricing/claude-opus-4-8` (anthropic + all 4 bedrock variants) — pricing populated.
- [x] `TestFastModeModelsHaveFastPricing/claude-opus-4-8` — fast override present with all five rate fields.
- [x] `TestModelPricingMatchesModels` — length match on both providers.
- [x] `TestModelResolution/claude-opus-4-8 family name resolves` and `…/timestamped preserves original` — longest-prefix resolver.
- [x] `TestGeoGlobalRatio/global.anthropic.claude-opus-4-8` — exact 1.10× ratio between geo and global.