### PR TITLE
openai, anthropic: downgrade dynamic JSON Schema for strict tool input_schema

### DIFF
--- a/internal/jsonschema/downgrade.go
+++ b/internal/jsonschema/downgrade.go
@@ -1,0 +1,237 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package jsonschema holds provider-agnostic helpers for downgrading standard
+// JSON Schema (e.g. schemas exposed by MCP servers) into the narrower subsets
+// individual LLM providers accept as tool input_schema. MCP servers legitimately
+// publish full JSON Schema; per the MCP ecosystem the client is responsible for
+// adapting it per provider (the same way LangChain, the OpenAI Agents SDK and
+// the Vercel AI SDK do).
+package jsonschema
+
+// OpenAISupportedStringFormats is the set of JSON Schema string "format" values
+// OpenAI Structured Outputs / strict function calling accepts. Any other value
+// (e.g. "byte", "uri", "uri-reference") is rejected with a 400.
+// See https://platform.openai.com/docs/guides/structured-outputs.
+var OpenAISupportedStringFormats = map[string]bool{
+	"date-time": true,
+	"time":      true,
+	"date":      true,
+	"duration":  true,
+	"email":     true,
+	"hostname":  true,
+	"ipv4":      true,
+	"ipv6":      true,
+	"uuid":      true,
+}
+
+// StripUnsupportedOpenAIKeywords walks the schema and removes keywords OpenAI
+// strict mode rejects outright. These are all annotations/constraints whose
+// removal does not change a value's type, so dropping them is lossless for
+// decoding (a base64 "bytes" field, for example, is still a string).
+func StripUnsupportedOpenAIKeywords(node any) {
+	walk(node, func(obj map[string]any) {
+		// Object/map keywords OpenAI does not permit.
+		delete(obj, "propertyNames")
+		delete(obj, "patternProperties")
+		delete(obj, "minProperties")
+		delete(obj, "maxProperties")
+		delete(obj, "dependentRequired")
+		delete(obj, "dependentSchemas")
+
+		// Content keywords (e.g. base64 bytes) are not part of the subset.
+		delete(obj, "contentEncoding")
+		delete(obj, "contentMediaType")
+		delete(obj, "contentSchema")
+
+		// "format" survives only for the documented supported values. When a
+		// non-supported format is dropped from a bytes field, fold the base64
+		// hint into the description so the model still knows to base64-encode.
+		if f, ok := obj["format"].(string); ok && !OpenAISupportedStringFormats[f] {
+			if f == "byte" {
+				appendBase64Hint(obj)
+			}
+			delete(obj, "format")
+		}
+	})
+}
+
+func appendBase64Hint(obj map[string]any) {
+	const hint = "Base64-encoded binary data."
+	switch d := obj["description"].(type) {
+	case string:
+		if d == "" {
+			obj["description"] = hint
+		} else {
+			obj["description"] = d + " " + hint
+		}
+	default:
+		obj["description"] = hint
+	}
+}
+
+// CollapseDynamicNodes rewrites schema nodes that describe open-ended / dynamic
+// JSON (no fixed type) into a single JSON-encoded string node. OpenAI strict and
+// Anthropic both reject typeless or open-object schemas as tool input_schema
+// (only Gemini accepts them), so the common-denominator representation is a
+// string the model fills with JSON text; the MCP server parses it back.
+//
+// It targets exactly the protobuf dynamic well-known types as they render in
+// standard JSON Schema:
+//   - google.protobuf.Value     -> typeless node (no "type")
+//   - google.protobuf.Struct    -> {"type":"object","additionalProperties":true}
+//   - google.protobuf.ListValue -> {"type":"array","items":{}}
+//   - google.protobuf.Any.value -> typeless node
+//
+// Closed message objects (with "properties"), maps (additionalProperties is a
+// schema), and typed scalars/arrays are left untouched.
+func CollapseDynamicNodes(node any) {
+	m, ok := node.(map[string]any)
+	if !ok {
+		if arr, ok := node.([]any); ok {
+			for _, e := range arr {
+				CollapseDynamicNodes(e)
+			}
+		}
+		return
+	}
+
+	if isDynamicNode(m) {
+		desc := "JSON value, provided as a JSON-encoded string."
+		if d, ok := m["description"].(string); ok && d != "" {
+			desc = d + " Provide it as a JSON-encoded string."
+		}
+		for k := range m {
+			delete(m, k)
+		}
+		m["type"] = "string"
+		m["description"] = desc
+		return
+	}
+
+	// Recurse into the standard subschema-bearing keywords.
+	if props, ok := m["properties"].(map[string]any); ok {
+		for _, v := range props {
+			CollapseDynamicNodes(v)
+		}
+	}
+	for _, k := range []string{"$defs", "definitions", "patternProperties"} {
+		if defs, ok := m[k].(map[string]any); ok {
+			for _, v := range defs {
+				CollapseDynamicNodes(v)
+			}
+		}
+	}
+	for _, k := range []string{"anyOf", "oneOf", "allOf", "prefixItems"} {
+		if arr, ok := m[k].([]any); ok {
+			for _, v := range arr {
+				CollapseDynamicNodes(v)
+			}
+		}
+	}
+	switch it := m["items"].(type) {
+	case map[string]any:
+		CollapseDynamicNodes(it)
+	case []any:
+		for _, v := range it {
+			CollapseDynamicNodes(v)
+		}
+	}
+	// additionalProperties may be a schema (map value type); recurse so dynamic
+	// values inside a map still collapse.
+	if ap, ok := m["additionalProperties"].(map[string]any); ok {
+		CollapseDynamicNodes(ap)
+	}
+}
+
+// isDynamicNode reports whether m is an open-ended / dynamic JSON node with no
+// fixed, closed type that a strict provider can express.
+func isDynamicNode(m map[string]any) bool {
+	_, hasRef := m["$ref"]
+	if hasRef {
+		return false
+	}
+	for _, k := range []string{"anyOf", "oneOf", "allOf"} {
+		if _, ok := m[k]; ok {
+			return false
+		}
+	}
+
+	t, hasType := m["type"]
+	if !hasType {
+		// Typeless node: google.protobuf.Value, google.protobuf.Any.value.
+		return true
+	}
+
+	_, hasProps := m["properties"]
+	switch ts := t.(type) {
+	case string:
+		// Open object: google.protobuf.Struct (additionalProperties:true, no
+		// fixed properties). Maps render additionalProperties as a schema, not
+		// true, so they are not collapsed here.
+		if ts == "object" && !hasProps && m["additionalProperties"] == true {
+			return true
+		}
+		// Untyped array: google.protobuf.ListValue ({"items":{}}).
+		if ts == "array" {
+			if it, ok := m["items"].(map[string]any); ok && len(it) == 0 {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// walk applies fn to every schema-object node reachable from node, recursing
+// through the standard subschema-bearing keywords.
+func walk(node any, fn func(map[string]any)) {
+	switch n := node.(type) {
+	case map[string]any:
+		fn(n)
+		if props, ok := n["properties"].(map[string]any); ok {
+			for _, v := range props {
+				walk(v, fn)
+			}
+		}
+		for _, k := range []string{"$defs", "definitions", "patternProperties"} {
+			if defs, ok := n[k].(map[string]any); ok {
+				for _, v := range defs {
+					walk(v, fn)
+				}
+			}
+		}
+		for _, k := range []string{"anyOf", "oneOf", "allOf", "prefixItems"} {
+			if arr, ok := n[k].([]any); ok {
+				for _, v := range arr {
+					walk(v, fn)
+				}
+			}
+		}
+		switch it := n["items"].(type) {
+		case map[string]any:
+			walk(it, fn)
+		case []any:
+			for _, v := range it {
+				walk(v, fn)
+			}
+		}
+		if ap, ok := n["additionalProperties"].(map[string]any); ok {
+			walk(ap, fn)
+		}
+	case []any:
+		for _, v := range n {
+			walk(v, fn)
+		}
+	}
+}

--- a/internal/jsonschema/downgrade.go
+++ b/internal/jsonschema/downgrade.go
@@ -112,19 +112,16 @@ func Walk(node any, fn func(map[string]any)) {
 //
 // Closed message objects (with "properties"), maps (additionalProperties is a
 // schema), and typed scalars/arrays are left untouched.
+//
+// It is a Walk pass: collapsing a node clears its children, so Walk finds no
+// subschemas to descend into and the collapse does not recurse into a subtree
+// that no longer exists.
 func CollapseDynamicNodes(node any) {
-	m, ok := node.(map[string]any)
-	if !ok {
-		if arr, ok := node.([]any); ok {
-			for _, e := range arr {
-				CollapseDynamicNodes(e)
-			}
+	Walk(node, func(m map[string]any) {
+		if !isDynamicNode(m) {
+			return
 		}
 
-		return
-	}
-
-	if isDynamicNode(m) {
 		desc := "JSON value, provided as a JSON-encoded string."
 		if d, ok := m["description"].(string); ok && d != "" {
 			desc = d + " Provide it as a JSON-encoded string."
@@ -136,46 +133,7 @@ func CollapseDynamicNodes(node any) {
 
 		m["type"] = "string"
 		m["description"] = desc
-
-		return
-	}
-
-	// Recurse into the standard subschema-bearing keywords.
-	if props, ok := m["properties"].(map[string]any); ok {
-		for _, v := range props {
-			CollapseDynamicNodes(v)
-		}
-	}
-
-	for _, k := range []string{"$defs", "definitions", "patternProperties"} {
-		if defs, ok := m[k].(map[string]any); ok {
-			for _, v := range defs {
-				CollapseDynamicNodes(v)
-			}
-		}
-	}
-
-	for _, k := range []string{"anyOf", "oneOf", "allOf", "prefixItems"} {
-		if arr, ok := m[k].([]any); ok {
-			for _, v := range arr {
-				CollapseDynamicNodes(v)
-			}
-		}
-	}
-
-	switch it := m["items"].(type) {
-	case map[string]any:
-		CollapseDynamicNodes(it)
-	case []any:
-		for _, v := range it {
-			CollapseDynamicNodes(v)
-		}
-	}
-	// additionalProperties may be a schema (map value type); recurse so dynamic
-	// values inside a map still collapse.
-	if ap, ok := m["additionalProperties"].(map[string]any); ok {
-		CollapseDynamicNodes(ap)
-	}
+	})
 }
 
 // isDynamicNode reports whether m is an open-ended / dynamic JSON node with no

--- a/internal/jsonschema/downgrade.go
+++ b/internal/jsonschema/downgrade.go
@@ -62,6 +62,7 @@ func StripUnsupportedOpenAIKeywords(node any) {
 			if f == "byte" {
 				appendBase64Hint(obj)
 			}
+
 			delete(obj, "format")
 		}
 	})
@@ -69,6 +70,7 @@ func StripUnsupportedOpenAIKeywords(node any) {
 
 func appendBase64Hint(obj map[string]any) {
 	const hint = "Base64-encoded binary data."
+
 	switch d := obj["description"].(type) {
 	case string:
 		if d == "" {
@@ -104,6 +106,7 @@ func CollapseDynamicNodes(node any) {
 				CollapseDynamicNodes(e)
 			}
 		}
+
 		return
 	}
 
@@ -112,11 +115,14 @@ func CollapseDynamicNodes(node any) {
 		if d, ok := m["description"].(string); ok && d != "" {
 			desc = d + " Provide it as a JSON-encoded string."
 		}
+
 		for k := range m {
 			delete(m, k)
 		}
+
 		m["type"] = "string"
 		m["description"] = desc
+
 		return
 	}
 
@@ -126,6 +132,7 @@ func CollapseDynamicNodes(node any) {
 			CollapseDynamicNodes(v)
 		}
 	}
+
 	for _, k := range []string{"$defs", "definitions", "patternProperties"} {
 		if defs, ok := m[k].(map[string]any); ok {
 			for _, v := range defs {
@@ -133,6 +140,7 @@ func CollapseDynamicNodes(node any) {
 			}
 		}
 	}
+
 	for _, k := range []string{"anyOf", "oneOf", "allOf", "prefixItems"} {
 		if arr, ok := m[k].([]any); ok {
 			for _, v := range arr {
@@ -140,6 +148,7 @@ func CollapseDynamicNodes(node any) {
 			}
 		}
 	}
+
 	switch it := m["items"].(type) {
 	case map[string]any:
 		CollapseDynamicNodes(it)
@@ -162,6 +171,7 @@ func isDynamicNode(m map[string]any) bool {
 	if hasRef {
 		return false
 	}
+
 	for _, k := range []string{"anyOf", "oneOf", "allOf"} {
 		if _, ok := m[k]; ok {
 			return false
@@ -174,22 +184,27 @@ func isDynamicNode(m map[string]any) bool {
 		return true
 	}
 
+	ts, ok := t.(string)
+	if !ok {
+		return false
+	}
+
 	_, hasProps := m["properties"]
-	switch ts := t.(type) {
-	case string:
-		// Open object: google.protobuf.Struct (additionalProperties:true, no
-		// fixed properties). Maps render additionalProperties as a schema, not
-		// true, so they are not collapsed here.
-		if ts == "object" && !hasProps && m["additionalProperties"] == true {
+
+	// Open object: google.protobuf.Struct (additionalProperties:true, no fixed
+	// properties). Maps render additionalProperties as a schema, not true, so
+	// they are not collapsed here.
+	if ts == "object" && !hasProps && m["additionalProperties"] == true {
+		return true
+	}
+
+	// Untyped array: google.protobuf.ListValue ({"items":{}}).
+	if ts == "array" {
+		if it, ok := m["items"].(map[string]any); ok && len(it) == 0 {
 			return true
 		}
-		// Untyped array: google.protobuf.ListValue ({"items":{}}).
-		if ts == "array" {
-			if it, ok := m["items"].(map[string]any); ok && len(it) == 0 {
-				return true
-			}
-		}
 	}
+
 	return false
 }
 
@@ -199,11 +214,13 @@ func walk(node any, fn func(map[string]any)) {
 	switch n := node.(type) {
 	case map[string]any:
 		fn(n)
+
 		if props, ok := n["properties"].(map[string]any); ok {
 			for _, v := range props {
 				walk(v, fn)
 			}
 		}
+
 		for _, k := range []string{"$defs", "definitions", "patternProperties"} {
 			if defs, ok := n[k].(map[string]any); ok {
 				for _, v := range defs {
@@ -211,6 +228,7 @@ func walk(node any, fn func(map[string]any)) {
 				}
 			}
 		}
+
 		for _, k := range []string{"anyOf", "oneOf", "allOf", "prefixItems"} {
 			if arr, ok := n[k].([]any); ok {
 				for _, v := range arr {
@@ -218,6 +236,7 @@ func walk(node any, fn func(map[string]any)) {
 				}
 			}
 		}
+
 		switch it := n["items"].(type) {
 		case map[string]any:
 			walk(it, fn)
@@ -226,6 +245,7 @@ func walk(node any, fn func(map[string]any)) {
 				walk(v, fn)
 			}
 		}
+
 		if ap, ok := n["additionalProperties"].(map[string]any); ok {
 			walk(ap, fn)
 		}

--- a/internal/jsonschema/downgrade.go
+++ b/internal/jsonschema/downgrade.go
@@ -14,78 +14,92 @@
 
 // Package jsonschema holds provider-agnostic helpers for downgrading standard
 // JSON Schema (e.g. schemas exposed by MCP servers) into the narrower subsets
-// individual LLM providers accept as tool input_schema. MCP servers legitimately
-// publish full JSON Schema; per the MCP ecosystem the client is responsible for
-// adapting it per provider (the same way LangChain, the OpenAI Agents SDK and
-// the Vercel AI SDK do).
+// individual LLM providers accept as a tool input_schema. MCP servers
+// legitimately publish full JSON Schema; per the MCP ecosystem the client is
+// responsible for adapting it per provider (the same way LangChain, the OpenAI
+// Agents SDK and the Vercel AI SDK do).
+//
+// Only transforms common to more than one provider live here. Provider-specific
+// rules (e.g. OpenAI's keyword allowlist) live in the respective provider
+// package and use Walk for traversal.
 package jsonschema
 
-// OpenAISupportedStringFormats is the set of JSON Schema string "format" values
-// OpenAI Structured Outputs / strict function calling accepts. Any other value
-// (e.g. "byte", "uri", "uri-reference") is rejected with a 400.
-// See https://platform.openai.com/docs/guides/structured-outputs.
-var OpenAISupportedStringFormats = map[string]bool{
-	"date-time": true,
-	"time":      true,
-	"date":      true,
-	"duration":  true,
-	"email":     true,
-	"hostname":  true,
-	"ipv4":      true,
-	"ipv6":      true,
-	"uuid":      true,
+import (
+	"bytes"
+	"encoding/json"
+)
+
+// DeepCopy returns a JSON round-tripped deep copy of a schema, so adapters can
+// mutate freely without touching the caller's input.
+func DeepCopy(m map[string]any) (map[string]any, error) {
+	var buf bytes.Buffer
+
+	if err := json.NewEncoder(&buf).Encode(m); err != nil {
+		return nil, err
+	}
+
+	var cp map[string]any
+	if err := json.NewDecoder(&buf).Decode(&cp); err != nil {
+		return nil, err
+	}
+
+	return cp, nil
 }
 
-// StripUnsupportedOpenAIKeywords walks the schema and removes keywords OpenAI
-// strict mode rejects outright. These are all annotations/constraints whose
-// removal does not change a value's type, so dropping them is lossless for
-// decoding (a base64 "bytes" field, for example, is still a string).
-func StripUnsupportedOpenAIKeywords(node any) {
-	walk(node, func(obj map[string]any) {
-		// Object/map keywords OpenAI does not permit.
-		delete(obj, "propertyNames")
-		delete(obj, "patternProperties")
-		delete(obj, "minProperties")
-		delete(obj, "maxProperties")
-		delete(obj, "dependentRequired")
-		delete(obj, "dependentSchemas")
+// Walk applies fn to every schema-object node reachable from node, recursing
+// through the standard subschema-bearing keywords (properties, $defs,
+// definitions, patternProperties, anyOf/oneOf/allOf, prefixItems, items,
+// additionalProperties). fn runs on a node before its children, so a pass that
+// deletes a keyword also prunes that keyword's subtree from the walk.
+func Walk(node any, fn func(map[string]any)) {
+	switch n := node.(type) {
+	case map[string]any:
+		fn(n)
 
-		// Content keywords (e.g. base64 bytes) are not part of the subset.
-		delete(obj, "contentEncoding")
-		delete(obj, "contentMediaType")
-		delete(obj, "contentSchema")
-
-		// "format" survives only for the documented supported values. When a
-		// non-supported format is dropped from a bytes field, fold the base64
-		// hint into the description so the model still knows to base64-encode.
-		if f, ok := obj["format"].(string); ok && !OpenAISupportedStringFormats[f] {
-			if f == "byte" {
-				appendBase64Hint(obj)
+		if props, ok := n["properties"].(map[string]any); ok {
+			for _, v := range props {
+				Walk(v, fn)
 			}
-
-			delete(obj, "format")
 		}
-	})
-}
 
-func appendBase64Hint(obj map[string]any) {
-	const hint = "Base64-encoded binary data."
-
-	switch d := obj["description"].(type) {
-	case string:
-		if d == "" {
-			obj["description"] = hint
-		} else {
-			obj["description"] = d + " " + hint
+		for _, k := range []string{"$defs", "definitions", "patternProperties"} {
+			if defs, ok := n[k].(map[string]any); ok {
+				for _, v := range defs {
+					Walk(v, fn)
+				}
+			}
 		}
-	default:
-		obj["description"] = hint
+
+		for _, k := range []string{"anyOf", "oneOf", "allOf", "prefixItems"} {
+			if arr, ok := n[k].([]any); ok {
+				for _, v := range arr {
+					Walk(v, fn)
+				}
+			}
+		}
+
+		switch it := n["items"].(type) {
+		case map[string]any:
+			Walk(it, fn)
+		case []any:
+			for _, v := range it {
+				Walk(v, fn)
+			}
+		}
+
+		if ap, ok := n["additionalProperties"].(map[string]any); ok {
+			Walk(ap, fn)
+		}
+	case []any:
+		for _, v := range n {
+			Walk(v, fn)
+		}
 	}
 }
 
 // CollapseDynamicNodes rewrites schema nodes that describe open-ended / dynamic
 // JSON (no fixed type) into a single JSON-encoded string node. OpenAI strict and
-// Anthropic both reject typeless or open-object schemas as tool input_schema
+// Anthropic both reject typeless or open-object schemas as a tool input_schema
 // (only Gemini accepts them), so the common-denominator representation is a
 // string the model fills with JSON text; the MCP server parses it back.
 //
@@ -167,8 +181,7 @@ func CollapseDynamicNodes(node any) {
 // isDynamicNode reports whether m is an open-ended / dynamic JSON node with no
 // fixed, closed type that a strict provider can express.
 func isDynamicNode(m map[string]any) bool {
-	_, hasRef := m["$ref"]
-	if hasRef {
+	if _, hasRef := m["$ref"]; hasRef {
 		return false
 	}
 
@@ -206,52 +219,4 @@ func isDynamicNode(m map[string]any) bool {
 	}
 
 	return false
-}
-
-// walk applies fn to every schema-object node reachable from node, recursing
-// through the standard subschema-bearing keywords.
-func walk(node any, fn func(map[string]any)) {
-	switch n := node.(type) {
-	case map[string]any:
-		fn(n)
-
-		if props, ok := n["properties"].(map[string]any); ok {
-			for _, v := range props {
-				walk(v, fn)
-			}
-		}
-
-		for _, k := range []string{"$defs", "definitions", "patternProperties"} {
-			if defs, ok := n[k].(map[string]any); ok {
-				for _, v := range defs {
-					walk(v, fn)
-				}
-			}
-		}
-
-		for _, k := range []string{"anyOf", "oneOf", "allOf", "prefixItems"} {
-			if arr, ok := n[k].([]any); ok {
-				for _, v := range arr {
-					walk(v, fn)
-				}
-			}
-		}
-
-		switch it := n["items"].(type) {
-		case map[string]any:
-			walk(it, fn)
-		case []any:
-			for _, v := range it {
-				walk(v, fn)
-			}
-		}
-
-		if ap, ok := n["additionalProperties"].(map[string]any); ok {
-			walk(ap, fn)
-		}
-	case []any:
-		for _, v := range n {
-			walk(v, fn)
-		}
-	}
 }

--- a/internal/jsonschema/downgrade_test.go
+++ b/internal/jsonschema/downgrade_test.go
@@ -1,0 +1,176 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package jsonschema
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCollapseDynamicNodes(t *testing.T) {
+	t.Parallel()
+
+	t.Run("typeless Value node collapses to string", func(t *testing.T) {
+		// google.protobuf.Value renders typeless.
+		n := map[string]any{"description": "a dynamic JSON value"}
+		CollapseDynamicNodes(n)
+		assert.Equal(t, "string", n["type"])
+		assert.Contains(t, n["description"], "JSON-encoded string")
+	})
+
+	t.Run("open object Struct collapses to string", func(t *testing.T) {
+		n := map[string]any{"type": "object", "additionalProperties": true}
+		CollapseDynamicNodes(n)
+		assert.Equal(t, "string", n["type"])
+		assert.Nil(t, n["additionalProperties"])
+	})
+
+	t.Run("untyped array ListValue collapses to string", func(t *testing.T) {
+		n := map[string]any{"type": "array", "items": map[string]any{}}
+		CollapseDynamicNodes(n)
+		assert.Equal(t, "string", n["type"])
+		assert.Nil(t, n["items"])
+	})
+
+	t.Run("map is NOT collapsed (additionalProperties is a schema)", func(t *testing.T) {
+		n := map[string]any{
+			"type":                 "object",
+			"additionalProperties": map[string]any{"type": "string"},
+		}
+		CollapseDynamicNodes(n)
+		assert.Equal(t, "object", n["type"])
+		assert.IsType(t, map[string]any{}, n["additionalProperties"])
+	})
+
+	t.Run("closed message object is not collapsed; recurses into properties", func(t *testing.T) {
+		n := map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"id":     map[string]any{"type": "string"},
+				"config": map[string]any{"description": "dynamic"}, // Value
+			},
+		}
+		CollapseDynamicNodes(n)
+		assert.Equal(t, "object", n["type"])
+		props := n["properties"].(map[string]any)
+		assert.Equal(t, "string", props["id"].(map[string]any)["type"])
+		// nested Value collapsed
+		assert.Equal(t, "string", props["config"].(map[string]any)["type"])
+	})
+
+	t.Run("Any keeps wrapper, collapses its typeless value", func(t *testing.T) {
+		n := map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"@type": map[string]any{"type": "string"},
+				"value": map[string]any{}, // typeless
+			},
+			"required": []any{"@type"},
+		}
+		CollapseDynamicNodes(n)
+		assert.Equal(t, "object", n["type"]) // wrapper preserved
+		val := n["properties"].(map[string]any)["value"].(map[string]any)
+		assert.Equal(t, "string", val["type"])
+	})
+
+	t.Run("dynamic inside array items collapses", func(t *testing.T) {
+		n := map[string]any{
+			"type":  "array",
+			"items": map[string]any{"description": "dynamic value"}, // Value, not empty
+		}
+		CollapseDynamicNodes(n)
+		// array stays array (items not empty), but item is collapsed
+		assert.Equal(t, "array", n["type"])
+		assert.Equal(t, "string", n["items"].(map[string]any)["type"])
+	})
+
+	t.Run("typed scalar untouched", func(t *testing.T) {
+		n := map[string]any{"type": "string", "format": "uuid"}
+		CollapseDynamicNodes(n)
+		assert.Equal(t, "string", n["type"])
+		assert.Equal(t, "uuid", n["format"])
+	})
+
+	t.Run("preserves original description", func(t *testing.T) {
+		n := map[string]any{"description": "Custom metadata."}
+		CollapseDynamicNodes(n)
+		assert.Contains(t, n["description"], "Custom metadata.")
+	})
+}
+
+func TestStripUnsupportedOpenAIKeywords(t *testing.T) {
+	t.Parallel()
+
+	t.Run("format byte removed, base64 hint folded into description", func(t *testing.T) {
+		n := map[string]any{"type": "string", "format": "byte", "contentEncoding": "base64"}
+		StripUnsupportedOpenAIKeywords(n)
+		_, hasFormat := n["format"]
+		assert.False(t, hasFormat)
+		_, hasEnc := n["contentEncoding"]
+		assert.False(t, hasEnc)
+		assert.Contains(t, n["description"], "Base64")
+	})
+
+	t.Run("supported formats are kept", func(t *testing.T) {
+		for _, f := range []string{"date-time", "uuid", "email"} {
+			n := map[string]any{"type": "string", "format": f}
+			StripUnsupportedOpenAIKeywords(n)
+			assert.Equal(t, f, n["format"], "format %q should survive", f)
+		}
+	})
+
+	t.Run("propertyNames and patternProperties removed", func(t *testing.T) {
+		n := map[string]any{
+			"type":              "object",
+			"propertyNames":     map[string]any{"pattern": "^x"},
+			"patternProperties": map[string]any{"^y": map[string]any{"type": "string"}},
+		}
+		StripUnsupportedOpenAIKeywords(n)
+		_, hasPN := n["propertyNames"]
+		_, hasPP := n["patternProperties"]
+		assert.False(t, hasPN)
+		assert.False(t, hasPP)
+	})
+
+	t.Run("recurses into nested properties and items", func(t *testing.T) {
+		n := map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"blob": map[string]any{"type": "string", "format": "byte"},
+				"list": map[string]any{
+					"type":  "array",
+					"items": map[string]any{"type": "string", "contentEncoding": "base64"},
+				},
+			},
+		}
+		StripUnsupportedOpenAIKeywords(n)
+		props := n["properties"].(map[string]any)
+		_, blobFmt := props["blob"].(map[string]any)["format"]
+		assert.False(t, blobFmt)
+		_, itemEnc := props["list"].(map[string]any)["items"].(map[string]any)["contentEncoding"]
+		assert.False(t, itemEnc)
+	})
+
+	t.Run("does not mutate beyond the listed keywords", func(t *testing.T) {
+		n := map[string]any{"type": "string", "minLength": 3, "maxLength": 5, "pattern": "^a"}
+		StripUnsupportedOpenAIKeywords(n)
+		require.Equal(t, "string", n["type"])
+		assert.Equal(t, 3, n["minLength"])
+		assert.Equal(t, 5, n["maxLength"])
+		assert.Equal(t, "^a", n["pattern"])
+	})
+}

--- a/internal/jsonschema/downgrade_test.go
+++ b/internal/jsonschema/downgrade_test.go
@@ -21,6 +21,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// mp is a checked map type-assertion helper: it keeps errcheck's
+// check-type-assertions satisfied while keeping the assertions readable.
+func mp(v any) map[string]any { m, _ := v.(map[string]any); return m }
+
 func TestCollapseDynamicNodes(t *testing.T) {
 	t.Parallel()
 
@@ -66,10 +70,10 @@ func TestCollapseDynamicNodes(t *testing.T) {
 		}
 		CollapseDynamicNodes(n)
 		assert.Equal(t, "object", n["type"])
-		props := n["properties"].(map[string]any)
-		assert.Equal(t, "string", props["id"].(map[string]any)["type"])
+		props := mp(n["properties"])
+		assert.Equal(t, "string", mp(props["id"])["type"])
 		// nested Value collapsed
-		assert.Equal(t, "string", props["config"].(map[string]any)["type"])
+		assert.Equal(t, "string", mp(props["config"])["type"])
 	})
 
 	t.Run("Any keeps wrapper, collapses its typeless value", func(t *testing.T) {
@@ -83,7 +87,7 @@ func TestCollapseDynamicNodes(t *testing.T) {
 		}
 		CollapseDynamicNodes(n)
 		assert.Equal(t, "object", n["type"]) // wrapper preserved
-		val := n["properties"].(map[string]any)["value"].(map[string]any)
+		val := mp(mp(n["properties"])["value"])
 		assert.Equal(t, "string", val["type"])
 	})
 
@@ -95,7 +99,7 @@ func TestCollapseDynamicNodes(t *testing.T) {
 		CollapseDynamicNodes(n)
 		// array stays array (items not empty), but item is collapsed
 		assert.Equal(t, "array", n["type"])
-		assert.Equal(t, "string", n["items"].(map[string]any)["type"])
+		assert.Equal(t, "string", mp(n["items"])["type"])
 	})
 
 	t.Run("typed scalar untouched", func(t *testing.T) {
@@ -158,10 +162,10 @@ func TestStripUnsupportedOpenAIKeywords(t *testing.T) {
 			},
 		}
 		StripUnsupportedOpenAIKeywords(n)
-		props := n["properties"].(map[string]any)
-		_, blobFmt := props["blob"].(map[string]any)["format"]
+		props := mp(n["properties"])
+		_, blobFmt := mp(props["blob"])["format"]
 		assert.False(t, blobFmt)
-		_, itemEnc := props["list"].(map[string]any)["items"].(map[string]any)["contentEncoding"]
+		_, itemEnc := mp(mp(props["list"])["items"])["contentEncoding"]
 		assert.False(t, itemEnc)
 	})
 

--- a/internal/jsonschema/downgrade_test.go
+++ b/internal/jsonschema/downgrade_test.go
@@ -133,78 +133,54 @@ func TestCollapseDynamicNodes(t *testing.T) {
 	})
 }
 
-func TestStripUnsupportedOpenAIKeywords(t *testing.T) {
+func TestWalk(t *testing.T) {
 	t.Parallel()
 
-	t.Run("format byte removed, base64 hint folded into description", func(t *testing.T) {
-		t.Parallel()
-
-		n := map[string]any{"type": "string", "format": "byte", "contentEncoding": "base64"}
-		StripUnsupportedOpenAIKeywords(n)
-		_, hasFormat := n["format"]
-		assert.False(t, hasFormat)
-
-		_, hasEnc := n["contentEncoding"]
-		assert.False(t, hasEnc)
-		assert.Contains(t, n["description"], "Base64")
-	})
-
-	t.Run("supported formats are kept", func(t *testing.T) {
-		t.Parallel()
-
-		for _, f := range []string{"date-time", "uuid", "email"} {
-			n := map[string]any{"type": "string", "format": f}
-			StripUnsupportedOpenAIKeywords(n)
-			assert.Equal(t, f, n["format"], "format %q should survive", f)
-		}
-	})
-
-	t.Run("propertyNames and patternProperties removed", func(t *testing.T) {
-		t.Parallel()
-
-		n := map[string]any{
-			"type":              "object",
-			"propertyNames":     map[string]any{"pattern": "^x"},
-			"patternProperties": map[string]any{"^y": map[string]any{"type": "string"}},
-		}
-		StripUnsupportedOpenAIKeywords(n)
-		_, hasPN := n["propertyNames"]
-		_, hasPP := n["patternProperties"]
-
-		assert.False(t, hasPN)
-		assert.False(t, hasPP)
-	})
-
-	t.Run("recurses into nested properties and items", func(t *testing.T) {
-		t.Parallel()
-
-		n := map[string]any{
-			"type": "object",
-			"properties": map[string]any{
-				"blob": map[string]any{"type": "string", "format": "byte"},
-				"list": map[string]any{
-					"type":  "array",
-					"items": map[string]any{"type": "string", "contentEncoding": "base64"},
-				},
+	// Walk must visit every schema-object node through the standard
+	// subschema-bearing keywords, and fn runs before recursion.
+	schema := map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"a": map[string]any{"type": "string"},
+			"b": map[string]any{
+				"type":  "array",
+				"items": map[string]any{"type": "object", "additionalProperties": map[string]any{"type": "integer"}},
 			},
-		}
-		StripUnsupportedOpenAIKeywords(n)
-		props := mp(n["properties"])
-		_, blobFmt := mp(props["blob"])["format"]
-		assert.False(t, blobFmt)
+		},
+		"anyOf": []any{map[string]any{"type": "null"}},
+	}
+	var types []string
 
-		_, itemEnc := mp(mp(props["list"])["items"])["contentEncoding"]
-		assert.False(t, itemEnc)
+	Walk(schema, func(obj map[string]any) {
+		if t, ok := obj["type"].(string); ok {
+			types = append(types, t)
+		}
 	})
 
-	t.Run("does not mutate beyond the listed keywords", func(t *testing.T) {
+	for _, want := range []string{"object", "string", "array", "object", "integer", "null"} {
+		assert.Contains(t, types, want)
+	}
+}
+
+func TestDeepCopy(t *testing.T) {
+	t.Parallel()
+
+	t.Run("independent copy", func(t *testing.T) {
 		t.Parallel()
 
-		n := map[string]any{"type": "string", "minLength": 3, "maxLength": 5, "pattern": "^a"}
-		StripUnsupportedOpenAIKeywords(n)
-		require.Equal(t, "string", n["type"])
-		assert.Equal(t, 3, n["minLength"])
-		assert.Equal(t, 5, n["maxLength"])
-		assert.Equal(t, "^a", n["pattern"])
+		orig := map[string]any{"type": "object", "properties": map[string]any{"a": map[string]any{"type": "string"}}}
+		cp, err := DeepCopy(orig)
+		require.NoError(t, err)
+
+		// Mutating the copy (including nested maps) must not touch the original.
+		mp(cp["properties"])["a"] = "mutated"
+		assert.Equal(t, map[string]any{"type": "string"}, mp(orig["properties"])["a"])
+	})
+
+	t.Run("errors on non-JSON-serializable input", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := DeepCopy(map[string]any{"ch": make(chan int)})
+		assert.Error(t, err)
 	})
 }

--- a/internal/jsonschema/downgrade_test.go
+++ b/internal/jsonschema/downgrade_test.go
@@ -29,6 +29,7 @@ func TestCollapseDynamicNodes(t *testing.T) {
 	t.Parallel()
 
 	t.Run("typeless Value node collapses to string", func(t *testing.T) {
+		t.Parallel()
 		// google.protobuf.Value renders typeless.
 		n := map[string]any{"description": "a dynamic JSON value"}
 		CollapseDynamicNodes(n)
@@ -37,6 +38,8 @@ func TestCollapseDynamicNodes(t *testing.T) {
 	})
 
 	t.Run("open object Struct collapses to string", func(t *testing.T) {
+		t.Parallel()
+
 		n := map[string]any{"type": "object", "additionalProperties": true}
 		CollapseDynamicNodes(n)
 		assert.Equal(t, "string", n["type"])
@@ -44,6 +47,8 @@ func TestCollapseDynamicNodes(t *testing.T) {
 	})
 
 	t.Run("untyped array ListValue collapses to string", func(t *testing.T) {
+		t.Parallel()
+
 		n := map[string]any{"type": "array", "items": map[string]any{}}
 		CollapseDynamicNodes(n)
 		assert.Equal(t, "string", n["type"])
@@ -51,6 +56,8 @@ func TestCollapseDynamicNodes(t *testing.T) {
 	})
 
 	t.Run("map is NOT collapsed (additionalProperties is a schema)", func(t *testing.T) {
+		t.Parallel()
+
 		n := map[string]any{
 			"type":                 "object",
 			"additionalProperties": map[string]any{"type": "string"},
@@ -61,6 +68,8 @@ func TestCollapseDynamicNodes(t *testing.T) {
 	})
 
 	t.Run("closed message object is not collapsed; recurses into properties", func(t *testing.T) {
+		t.Parallel()
+
 		n := map[string]any{
 			"type": "object",
 			"properties": map[string]any{
@@ -77,6 +86,8 @@ func TestCollapseDynamicNodes(t *testing.T) {
 	})
 
 	t.Run("Any keeps wrapper, collapses its typeless value", func(t *testing.T) {
+		t.Parallel()
+
 		n := map[string]any{
 			"type": "object",
 			"properties": map[string]any{
@@ -92,6 +103,8 @@ func TestCollapseDynamicNodes(t *testing.T) {
 	})
 
 	t.Run("dynamic inside array items collapses", func(t *testing.T) {
+		t.Parallel()
+
 		n := map[string]any{
 			"type":  "array",
 			"items": map[string]any{"description": "dynamic value"}, // Value, not empty
@@ -103,6 +116,8 @@ func TestCollapseDynamicNodes(t *testing.T) {
 	})
 
 	t.Run("typed scalar untouched", func(t *testing.T) {
+		t.Parallel()
+
 		n := map[string]any{"type": "string", "format": "uuid"}
 		CollapseDynamicNodes(n)
 		assert.Equal(t, "string", n["type"])
@@ -110,6 +125,8 @@ func TestCollapseDynamicNodes(t *testing.T) {
 	})
 
 	t.Run("preserves original description", func(t *testing.T) {
+		t.Parallel()
+
 		n := map[string]any{"description": "Custom metadata."}
 		CollapseDynamicNodes(n)
 		assert.Contains(t, n["description"], "Custom metadata.")
@@ -120,16 +137,21 @@ func TestStripUnsupportedOpenAIKeywords(t *testing.T) {
 	t.Parallel()
 
 	t.Run("format byte removed, base64 hint folded into description", func(t *testing.T) {
+		t.Parallel()
+
 		n := map[string]any{"type": "string", "format": "byte", "contentEncoding": "base64"}
 		StripUnsupportedOpenAIKeywords(n)
 		_, hasFormat := n["format"]
 		assert.False(t, hasFormat)
+
 		_, hasEnc := n["contentEncoding"]
 		assert.False(t, hasEnc)
 		assert.Contains(t, n["description"], "Base64")
 	})
 
 	t.Run("supported formats are kept", func(t *testing.T) {
+		t.Parallel()
+
 		for _, f := range []string{"date-time", "uuid", "email"} {
 			n := map[string]any{"type": "string", "format": f}
 			StripUnsupportedOpenAIKeywords(n)
@@ -138,6 +160,8 @@ func TestStripUnsupportedOpenAIKeywords(t *testing.T) {
 	})
 
 	t.Run("propertyNames and patternProperties removed", func(t *testing.T) {
+		t.Parallel()
+
 		n := map[string]any{
 			"type":              "object",
 			"propertyNames":     map[string]any{"pattern": "^x"},
@@ -146,11 +170,14 @@ func TestStripUnsupportedOpenAIKeywords(t *testing.T) {
 		StripUnsupportedOpenAIKeywords(n)
 		_, hasPN := n["propertyNames"]
 		_, hasPP := n["patternProperties"]
+
 		assert.False(t, hasPN)
 		assert.False(t, hasPP)
 	})
 
 	t.Run("recurses into nested properties and items", func(t *testing.T) {
+		t.Parallel()
+
 		n := map[string]any{
 			"type": "object",
 			"properties": map[string]any{
@@ -165,11 +192,14 @@ func TestStripUnsupportedOpenAIKeywords(t *testing.T) {
 		props := mp(n["properties"])
 		_, blobFmt := mp(props["blob"])["format"]
 		assert.False(t, blobFmt)
+
 		_, itemEnc := mp(mp(props["list"])["items"])["contentEncoding"]
 		assert.False(t, itemEnc)
 	})
 
 	t.Run("does not mutate beyond the listed keywords", func(t *testing.T) {
+		t.Parallel()
+
 		n := map[string]any{"type": "string", "minLength": 3, "maxLength": 5, "pattern": "^a"}
 		StripUnsupportedOpenAIKeywords(n)
 		require.Equal(t, "string", n["type"])

--- a/providers/anthropic/adapt_downgrade_test.go
+++ b/providers/anthropic/adapt_downgrade_test.go
@@ -1,0 +1,48 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package anthropic
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestAdaptSchemaForAnthropic_CollapsesDynamicNodes asserts the Anthropic adapter
+// collapses typeless / open-ended nodes (which Anthropic rejects as invalid
+// draft-2020-12) to strings, while leaving typed fields and maps untouched.
+func TestAdaptSchemaForAnthropic_CollapsesDynamicNodes(t *testing.T) {
+	t.Parallel()
+	in := map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"name":   map[string]any{"type": "string"},
+			"meta":   map[string]any{"type": "object", "additionalProperties": true}, // Struct
+			"val":    map[string]any{"description": "a google.protobuf.Value"},       // Value (typeless)
+			"labels": map[string]any{"type": "object", "additionalProperties": map[string]any{"type": "string"}},
+		},
+	}
+	out := NewSchemaMapper().AdaptSchemaForAnthropic(in)
+	props := out["properties"].(map[string]any)
+
+	assert.Equal(t, "string", props["name"].(map[string]any)["type"])
+	assert.Equal(t, "string", props["meta"].(map[string]any)["type"], "Struct collapses to string")
+	assert.Equal(t, "string", props["val"].(map[string]any)["type"], "typeless Value collapses to string")
+	// Maps are valid for Anthropic and must be preserved.
+	assert.Equal(t, "object", props["labels"].(map[string]any)["type"])
+
+	// Input not mutated.
+	assert.Equal(t, true, in["properties"].(map[string]any)["meta"].(map[string]any)["additionalProperties"])
+}

--- a/providers/anthropic/adapt_downgrade_test.go
+++ b/providers/anthropic/adapt_downgrade_test.go
@@ -20,6 +20,9 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// mp is a checked map type-assertion helper (errcheck check-type-assertions).
+func mp(v any) map[string]any { m, _ := v.(map[string]any); return m }
+
 // TestAdaptSchemaForAnthropic_CollapsesDynamicNodes asserts the Anthropic adapter
 // collapses typeless / open-ended nodes (which Anthropic rejects as invalid
 // draft-2020-12) to strings, while leaving typed fields and maps untouched.
@@ -35,14 +38,14 @@ func TestAdaptSchemaForAnthropic_CollapsesDynamicNodes(t *testing.T) {
 		},
 	}
 	out := NewSchemaMapper().AdaptSchemaForAnthropic(in)
-	props := out["properties"].(map[string]any)
+	props := mp(out["properties"])
 
-	assert.Equal(t, "string", props["name"].(map[string]any)["type"])
-	assert.Equal(t, "string", props["meta"].(map[string]any)["type"], "Struct collapses to string")
-	assert.Equal(t, "string", props["val"].(map[string]any)["type"], "typeless Value collapses to string")
+	assert.Equal(t, "string", mp(props["name"])["type"])
+	assert.Equal(t, "string", mp(props["meta"])["type"], "Struct collapses to string")
+	assert.Equal(t, "string", mp(props["val"])["type"], "typeless Value collapses to string")
 	// Maps are valid for Anthropic and must be preserved.
-	assert.Equal(t, "object", props["labels"].(map[string]any)["type"])
+	assert.Equal(t, "object", mp(props["labels"])["type"])
 
 	// Input not mutated.
-	assert.Equal(t, true, in["properties"].(map[string]any)["meta"].(map[string]any)["additionalProperties"])
+	assert.Equal(t, true, mp(mp(in["properties"])["meta"])["additionalProperties"])
 }

--- a/providers/anthropic/adapt_downgrade_test.go
+++ b/providers/anthropic/adapt_downgrade_test.go
@@ -28,6 +28,7 @@ func mp(v any) map[string]any { m, _ := v.(map[string]any); return m }
 // draft-2020-12) to strings, while leaving typed fields and maps untouched.
 func TestAdaptSchemaForAnthropic_CollapsesDynamicNodes(t *testing.T) {
 	t.Parallel()
+
 	in := map[string]any{
 		"type": "object",
 		"properties": map[string]any{

--- a/providers/anthropic/schema_mapper.go
+++ b/providers/anthropic/schema_mapper.go
@@ -40,6 +40,7 @@ func (*SchemaMapper) AdaptSchemaForAnthropic(schema map[string]any) map[string]a
 	}
 
 	jsonschema.CollapseDynamicNodes(cp)
+
 	return cp
 }
 

--- a/providers/anthropic/schema_mapper.go
+++ b/providers/anthropic/schema_mapper.go
@@ -15,9 +15,6 @@
 package anthropic
 
 import (
-	"bytes"
-	"encoding/json"
-
 	"github.com/redpanda-data/ai-sdk-go/internal/jsonschema"
 )
 
@@ -34,7 +31,7 @@ func NewSchemaMapper() *SchemaMapper { return &SchemaMapper{} }
 // collapsed to a JSON-encoded string. Everything else is standard JSON Schema and
 // passes through unchanged.
 func (*SchemaMapper) AdaptSchemaForAnthropic(schema map[string]any) map[string]any {
-	cp, err := deepCopyMap(schema)
+	cp, err := jsonschema.DeepCopy(schema)
 	if err != nil {
 		return schema
 	}
@@ -42,26 +39,4 @@ func (*SchemaMapper) AdaptSchemaForAnthropic(schema map[string]any) map[string]a
 	jsonschema.CollapseDynamicNodes(cp)
 
 	return cp
-}
-
-// deepCopyMap via JSON (simple and good enough here).
-func deepCopyMap(m map[string]any) (map[string]any, error) {
-	var buf bytes.Buffer
-
-	enc := json.NewEncoder(&buf)
-	dec := json.NewDecoder(&buf)
-
-	err := enc.Encode(m)
-	if err != nil {
-		return nil, err
-	}
-
-	var cp map[string]any
-
-	err = dec.Decode(&cp)
-	if err != nil {
-		return nil, err
-	}
-
-	return cp, nil
 }

--- a/providers/anthropic/schema_mapper.go
+++ b/providers/anthropic/schema_mapper.go
@@ -17,6 +17,8 @@ package anthropic
 import (
 	"bytes"
 	"encoding/json"
+
+	"github.com/redpanda-data/ai-sdk-go/internal/jsonschema"
 )
 
 // SchemaMapper transforms standard JSON Schemas to Anthropic-compatible schemas.
@@ -27,15 +29,17 @@ type SchemaMapper struct{}
 func NewSchemaMapper() *SchemaMapper { return &SchemaMapper{} }
 
 // AdaptSchemaForAnthropic returns a transformed deep copy, never mutating the input.
-// Currently, Anthropic accepts standard JSON Schema, so minimal transformation is needed.
+// Anthropic validates tool input_schema against JSON Schema draft 2020-12 and
+// rejects typeless / open-ended nodes (e.g. protobuf Struct/Value), so those are
+// collapsed to a JSON-encoded string. Everything else is standard JSON Schema and
+// passes through unchanged.
 func (*SchemaMapper) AdaptSchemaForAnthropic(schema map[string]any) map[string]any {
 	cp, err := deepCopyMap(schema)
 	if err != nil {
 		return schema
 	}
 
-	// Anthropic uses standard JSON Schema format
-	// No special transformations needed currently
+	jsonschema.CollapseDynamicNodes(cp)
 	return cp
 }
 

--- a/providers/openai/adapt_downgrade_test.go
+++ b/providers/openai/adapt_downgrade_test.go
@@ -32,6 +32,7 @@ func sl(v any) []any          { s, _ := v.([]any); return s }
 // base64 hint preserved), maps preserved, every object closed.
 func TestAdaptSchemaForOpenAI_MCPShapes(t *testing.T) {
 	t.Parallel()
+
 	in := map[string]any{
 		"type": "object",
 		"properties": map[string]any{
@@ -48,6 +49,7 @@ func TestAdaptSchemaForOpenAI_MCPShapes(t *testing.T) {
 	blob := mp(props["blob"])
 	_, hasFmt := blob["format"]
 	_, hasEnc := blob["contentEncoding"]
+
 	assert.False(t, hasFmt, "format:byte must be stripped")
 	assert.False(t, hasEnc, "contentEncoding must be stripped")
 	assert.Contains(t, blob["description"], "Base64", "base64 hint preserved in description")
@@ -63,11 +65,14 @@ func TestAdaptSchemaForOpenAI_MCPShapes(t *testing.T) {
 
 	// Root object closed and every property required.
 	assert.Equal(t, false, out["additionalProperties"])
+
 	req := map[string]bool{}
+
 	for _, r := range sl(out["required"]) {
 		rs, _ := r.(string)
 		req[rs] = true
 	}
+
 	for name := range props {
 		assert.True(t, req[name], "property %q must be required under strict", name)
 	}
@@ -84,6 +89,7 @@ func typeNoNull(node any) string {
 	if !ok {
 		return ""
 	}
+
 	switch t := m["type"].(type) {
 	case string:
 		return t
@@ -94,5 +100,6 @@ func typeNoNull(node any) string {
 			}
 		}
 	}
+
 	return ""
 }

--- a/providers/openai/adapt_downgrade_test.go
+++ b/providers/openai/adapt_downgrade_test.go
@@ -103,3 +103,79 @@ func typeNoNull(node any) string {
 
 	return ""
 }
+
+func TestStripUnsupportedKeywords(t *testing.T) {
+	t.Parallel()
+
+	t.Run("format byte removed, base64 hint folded into description", func(t *testing.T) {
+		t.Parallel()
+
+		n := map[string]any{"type": "string", "format": "byte", "contentEncoding": "base64"}
+		stripUnsupportedKeywords(n)
+		_, hasFormat := n["format"]
+		assert.False(t, hasFormat)
+
+		_, hasEnc := n["contentEncoding"]
+		assert.False(t, hasEnc)
+		assert.Contains(t, n["description"], "Base64")
+	})
+
+	t.Run("supported formats are kept", func(t *testing.T) {
+		t.Parallel()
+
+		for _, f := range []string{"date-time", "uuid", "email"} {
+			n := map[string]any{"type": "string", "format": f}
+			stripUnsupportedKeywords(n)
+			assert.Equal(t, f, n["format"], "format %q should survive", f)
+		}
+	})
+
+	t.Run("propertyNames and patternProperties removed", func(t *testing.T) {
+		t.Parallel()
+
+		n := map[string]any{
+			"type":              "object",
+			"propertyNames":     map[string]any{"pattern": "^x"},
+			"patternProperties": map[string]any{"^y": map[string]any{"type": "string"}},
+		}
+		stripUnsupportedKeywords(n)
+		_, hasPN := n["propertyNames"]
+		_, hasPP := n["patternProperties"]
+
+		assert.False(t, hasPN)
+		assert.False(t, hasPP)
+	})
+
+	t.Run("recurses into nested properties and items", func(t *testing.T) {
+		t.Parallel()
+
+		n := map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"blob": map[string]any{"type": "string", "format": "byte"},
+				"list": map[string]any{
+					"type":  "array",
+					"items": map[string]any{"type": "string", "contentEncoding": "base64"},
+				},
+			},
+		}
+		stripUnsupportedKeywords(n)
+		props := mp(n["properties"])
+		_, blobFmt := mp(props["blob"])["format"]
+		assert.False(t, blobFmt)
+
+		_, itemEnc := mp(mp(props["list"])["items"])["contentEncoding"]
+		assert.False(t, itemEnc)
+	})
+
+	t.Run("does not touch unrelated constraints", func(t *testing.T) {
+		t.Parallel()
+
+		n := map[string]any{"type": "string", "minLength": 3, "maxLength": 5, "pattern": "^a"}
+		stripUnsupportedKeywords(n)
+		require.Equal(t, "string", n["type"])
+		assert.Equal(t, 3, n["minLength"])
+		assert.Equal(t, 5, n["maxLength"])
+		assert.Equal(t, "^a", n["pattern"])
+	})
+}

--- a/providers/openai/adapt_downgrade_test.go
+++ b/providers/openai/adapt_downgrade_test.go
@@ -1,0 +1,93 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package openai
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAdaptSchemaForOpenAI_MCPShapes feeds a schema shaped like the JSON Schema
+// an MCP server (protoc-gen-go-mcp) emits — base64 bytes, a dynamic Struct, a
+// dynamic Value, and a map — and asserts the adapted result is OpenAI-strict
+// valid: dynamic nodes collapsed to strings, bytes annotations stripped (with a
+// base64 hint preserved), maps preserved, every object closed.
+func TestAdaptSchemaForOpenAI_MCPShapes(t *testing.T) {
+	t.Parallel()
+	in := map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"blob":   map[string]any{"type": "string", "format": "byte", "contentEncoding": "base64"},
+			"meta":   map[string]any{"type": "object", "additionalProperties": true},                                                                                 // Struct
+			"val":    map[string]any{"description": "a google.protobuf.Value"},                                                                                       // Value (typeless)
+			"labels": map[string]any{"type": "object", "propertyNames": map[string]any{"pattern": "^.+$"}, "additionalProperties": map[string]any{"type": "string"}}, // map
+		},
+		"required": []any{"blob"},
+	}
+	out := NewSchemaMapper().AdaptSchemaForOpenAI(in)
+	props := out["properties"].(map[string]any)
+
+	blob := props["blob"].(map[string]any)
+	_, hasFmt := blob["format"]
+	_, hasEnc := blob["contentEncoding"]
+	assert.False(t, hasFmt, "format:byte must be stripped")
+	assert.False(t, hasEnc, "contentEncoding must be stripped")
+	assert.Contains(t, blob["description"], "Base64", "base64 hint preserved in description")
+
+	assert.Equal(t, "string", typeNoNull(props["meta"]), "Struct collapses to string")
+	assert.Equal(t, "string", typeNoNull(props["val"]), "Value collapses to string")
+
+	labels := props["labels"].(map[string]any)
+	_, hasPN := labels["propertyNames"]
+	assert.False(t, hasPN, "propertyNames stripped")
+	// Map stays an object (OpenAI forces additionalProperties:false).
+	assert.Equal(t, false, labels["additionalProperties"])
+
+	// Root object closed and every property required.
+	assert.Equal(t, false, out["additionalProperties"])
+	req := map[string]bool{}
+	for _, r := range out["required"].([]any) {
+		req[r.(string)] = true
+	}
+	for name := range props {
+		assert.True(t, req[name], "property %q must be required under strict", name)
+	}
+
+	// The input must not be mutated.
+	origBlob := in["properties"].(map[string]any)["blob"].(map[string]any)
+	require.Equal(t, "byte", origBlob["format"], "input schema must not be mutated")
+}
+
+// typeNoNull returns the non-null type of a node whose type may be "T" or
+// ["T","null"].
+func typeNoNull(node any) string {
+	m, ok := node.(map[string]any)
+	if !ok {
+		return ""
+	}
+	switch t := m["type"].(type) {
+	case string:
+		return t
+	case []any:
+		for _, e := range t {
+			if s, ok := e.(string); ok && s != "null" {
+				return s
+			}
+		}
+	}
+	return ""
+}

--- a/providers/openai/adapt_downgrade_test.go
+++ b/providers/openai/adapt_downgrade_test.go
@@ -21,6 +21,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// mp / sl are checked type-assertion helpers (errcheck check-type-assertions).
+func mp(v any) map[string]any { m, _ := v.(map[string]any); return m }
+func sl(v any) []any          { s, _ := v.([]any); return s }
+
 // TestAdaptSchemaForOpenAI_MCPShapes feeds a schema shaped like the JSON Schema
 // an MCP server (protoc-gen-go-mcp) emits — base64 bytes, a dynamic Struct, a
 // dynamic Value, and a map — and asserts the adapted result is OpenAI-strict
@@ -39,9 +43,9 @@ func TestAdaptSchemaForOpenAI_MCPShapes(t *testing.T) {
 		"required": []any{"blob"},
 	}
 	out := NewSchemaMapper().AdaptSchemaForOpenAI(in)
-	props := out["properties"].(map[string]any)
+	props := mp(out["properties"])
 
-	blob := props["blob"].(map[string]any)
+	blob := mp(props["blob"])
 	_, hasFmt := blob["format"]
 	_, hasEnc := blob["contentEncoding"]
 	assert.False(t, hasFmt, "format:byte must be stripped")
@@ -51,7 +55,7 @@ func TestAdaptSchemaForOpenAI_MCPShapes(t *testing.T) {
 	assert.Equal(t, "string", typeNoNull(props["meta"]), "Struct collapses to string")
 	assert.Equal(t, "string", typeNoNull(props["val"]), "Value collapses to string")
 
-	labels := props["labels"].(map[string]any)
+	labels := mp(props["labels"])
 	_, hasPN := labels["propertyNames"]
 	assert.False(t, hasPN, "propertyNames stripped")
 	// Map stays an object (OpenAI forces additionalProperties:false).
@@ -60,15 +64,16 @@ func TestAdaptSchemaForOpenAI_MCPShapes(t *testing.T) {
 	// Root object closed and every property required.
 	assert.Equal(t, false, out["additionalProperties"])
 	req := map[string]bool{}
-	for _, r := range out["required"].([]any) {
-		req[r.(string)] = true
+	for _, r := range sl(out["required"]) {
+		rs, _ := r.(string)
+		req[rs] = true
 	}
 	for name := range props {
 		assert.True(t, req[name], "property %q must be required under strict", name)
 	}
 
 	// The input must not be mutated.
-	origBlob := in["properties"].(map[string]any)["blob"].(map[string]any)
+	origBlob := mp(mp(in["properties"])["blob"])
 	require.Equal(t, "byte", origBlob["format"], "input schema must not be mutated")
 }
 

--- a/providers/openai/schema_mapper.go
+++ b/providers/openai/schema_mapper.go
@@ -15,13 +15,70 @@
 package openai
 
 import (
-	"bytes"
-	"encoding/json"
 	"slices"
 	"sort"
 
 	"github.com/redpanda-data/ai-sdk-go/internal/jsonschema"
 )
+
+// openAISupportedStringFormats is the set of JSON Schema string "format" values
+// OpenAI Structured Outputs / strict function calling accepts. Any other value
+// (e.g. "byte", "uri", "uri-reference") is rejected with a 400.
+// See https://platform.openai.com/docs/guides/structured-outputs.
+var openAISupportedStringFormats = map[string]bool{
+	"date-time": true,
+	"time":      true,
+	"date":      true,
+	"duration":  true,
+	"email":     true,
+	"hostname":  true,
+	"ipv4":      true,
+	"ipv6":      true,
+	"uuid":      true,
+}
+
+// stripUnsupportedKeywords removes JSON Schema keywords OpenAI strict mode
+// rejects outright. These are annotations/constraints whose removal does not
+// change a value's type, so dropping them is lossless for decoding (a base64
+// "bytes" field, for example, is still a string).
+func stripUnsupportedKeywords(node any) {
+	jsonschema.Walk(node, func(obj map[string]any) {
+		// Object/map keywords OpenAI does not permit.
+		delete(obj, "propertyNames")
+		delete(obj, "patternProperties")
+		delete(obj, "minProperties")
+		delete(obj, "maxProperties")
+		delete(obj, "dependentRequired")
+		delete(obj, "dependentSchemas")
+
+		// Content keywords (e.g. base64 bytes) are not part of the subset.
+		delete(obj, "contentEncoding")
+		delete(obj, "contentMediaType")
+		delete(obj, "contentSchema")
+
+		// "format" survives only for the documented supported values. When a
+		// non-supported format is dropped from a bytes field, fold the base64
+		// hint into the description so the model still knows to base64-encode.
+		if f, ok := obj["format"].(string); ok && !openAISupportedStringFormats[f] {
+			if f == "byte" {
+				appendBase64Hint(obj)
+			}
+
+			delete(obj, "format")
+		}
+	})
+}
+
+func appendBase64Hint(obj map[string]any) {
+	const hint = "Base64-encoded binary data."
+
+	if d, ok := obj["description"].(string); ok && d != "" {
+		obj["description"] = d + " " + hint
+		return
+	}
+
+	obj["description"] = hint
+}
 
 // SchemaMapper transforms standard JSON Schemas to OpenAI-compatible schemas.
 // Notes:
@@ -35,7 +92,7 @@ func NewSchemaMapper() *SchemaMapper { return &SchemaMapper{} }
 
 // AdaptSchemaForOpenAI returns a transformed deep copy, never mutating the input.
 func (*SchemaMapper) AdaptSchemaForOpenAI(schema map[string]any) map[string]any {
-	cp, err := deepCopyMap(schema)
+	cp, err := jsonschema.DeepCopy(schema)
 	if err != nil {
 		return schema
 	}
@@ -44,7 +101,7 @@ func (*SchemaMapper) AdaptSchemaForOpenAI(schema map[string]any) map[string]any 
 	// JSON-encoded string, then drop keywords OpenAI strict mode rejects, before
 	// applying OpenAI's structural requirements.
 	jsonschema.CollapseDynamicNodes(cp)
-	jsonschema.StripUnsupportedOpenAIKeywords(cp)
+	stripUnsupportedKeywords(cp)
 	transformSchemaForOpenAI(cp)
 
 	return cp
@@ -249,26 +306,4 @@ func toStringSet(v any) map[string]struct{} {
 	}
 
 	return res
-}
-
-// deepCopyMap via JSON (simple and good enough here).
-func deepCopyMap(m map[string]any) (map[string]any, error) {
-	var buf bytes.Buffer
-
-	enc := json.NewEncoder(&buf)
-	dec := json.NewDecoder(&buf)
-
-	err := enc.Encode(m)
-	if err != nil {
-		return nil, err
-	}
-
-	var cp map[string]any
-
-	err = dec.Decode(&cp)
-	if err != nil {
-		return nil, err
-	}
-
-	return cp, nil
 }

--- a/providers/openai/schema_mapper.go
+++ b/providers/openai/schema_mapper.go
@@ -19,6 +19,8 @@ import (
 	"encoding/json"
 	"slices"
 	"sort"
+
+	"github.com/redpanda-data/ai-sdk-go/internal/jsonschema"
 )
 
 // SchemaMapper transforms standard JSON Schemas to OpenAI-compatible schemas.
@@ -38,6 +40,11 @@ func (*SchemaMapper) AdaptSchemaForOpenAI(schema map[string]any) map[string]any 
 		return schema
 	}
 
+	// Collapse open-ended/dynamic nodes (e.g. protobuf Struct/Value) to a
+	// JSON-encoded string, then drop keywords OpenAI strict mode rejects, before
+	// applying OpenAI's structural requirements.
+	jsonschema.CollapseDynamicNodes(cp)
+	jsonschema.StripUnsupportedOpenAIKeywords(cp)
 	transformSchemaForOpenAI(cp)
 
 	return cp

--- a/providers/openai/schema_mapper_test.go
+++ b/providers/openai/schema_mapper_test.go
@@ -20,6 +20,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/redpanda-data/ai-sdk-go/internal/jsonschema"
 )
 
 func TestTransformSchemaForOpenAI(t *testing.T) {
@@ -503,67 +505,6 @@ func TestSchemaMapperWithCaching(t *testing.T) {
 	})
 }
 
-func TestDeepCopyMap(t *testing.T) {
-	t.Parallel()
-
-	t.Run("successful deep copy", func(t *testing.T) {
-		t.Parallel()
-
-		original := map[string]any{
-			"type": "object",
-			"properties": map[string]any{
-				"nested": map[string]any{
-					"type":  "string",
-					"items": []any{"a", "b", "c"},
-				},
-			},
-			"numbers": []any{1, 2, 3},
-		}
-
-		copied, err := deepCopyMap(original)
-		require.NoError(t, err)
-
-		// Should be equal in content (use JSONEq to handle JSON type conversion)
-		originalJSON, err := json.Marshal(original)
-		require.NoError(t, err)
-		copiedJSON, err := json.Marshal(copied)
-		require.NoError(t, err)
-		assert.JSONEq(t, string(originalJSON), string(copiedJSON))
-
-		// But different objects (not same reference)
-		// Modify copied to verify independence
-		copied["type"] = "modified"
-		assert.NotEqual(t, original["type"], copied["type"])
-
-		// Modify nested structure
-		copiedProps, ok := copied["properties"].(map[string]any)
-		require.True(t, ok, "copied properties should be a map[string]any")
-		copiedNested, ok := copiedProps["nested"].(map[string]any)
-		require.True(t, ok, "copied nested should be a map[string]any")
-
-		copiedNested["type"] = "modified_nested"
-
-		originalProps, ok := original["properties"].(map[string]any)
-		require.True(t, ok, "original properties should be a map[string]any")
-		originalNested, ok := originalProps["nested"].(map[string]any)
-		require.True(t, ok, "original nested should be a map[string]any")
-		assert.NotEqual(t, originalNested["type"], copiedNested["type"])
-	})
-
-	t.Run("handles invalid JSON gracefully", func(t *testing.T) {
-		t.Parallel()
-
-		// This shouldn't normally happen with valid map[string]any,
-		// but test error handling
-		invalidMap := map[string]any{
-			"channel": make(chan int), // channels can't be JSON marshaled
-		}
-
-		_, err := deepCopyMap(invalidMap)
-		assert.Error(t, err, "Should return error for non-JSON-serializable data")
-	})
-}
-
 func TestOptionalEnumBecomesNullable(t *testing.T) {
 	t.Parallel()
 
@@ -633,7 +574,7 @@ func TestTupleItemsAreTransformed(t *testing.T) {
 func deepCopyMapForTest(t *testing.T, m map[string]any) map[string]any {
 	t.Helper()
 
-	copied, err := deepCopyMap(m)
+	copied, err := jsonschema.DeepCopy(m)
 	require.NoError(t, err)
 
 	return copied

--- a/providers/openaicompat/openaicompattest/constants.go
+++ b/providers/openaicompat/openaicompattest/constants.go
@@ -35,5 +35,5 @@ const (
 	// GoogleDefaultBaseURL is the Google Gemini OpenAI-compatible endpoint.
 	GoogleDefaultBaseURL = "https://generativelanguage.googleapis.com/v1beta/openai/"
 	// GoogleDefaultModel is the default model for Google compat tests.
-	GoogleDefaultModel = "gemini-2.0-flash"
+	GoogleDefaultModel = "gemini-3.5-flash"
 )


### PR DESCRIPTION
## What

Downgrade standard JSON Schema to each provider's accepted tool `input_schema`
subset in the OpenAI and Anthropic schema mappers. Adds a shared
`internal/jsonschema` package used by both. Google and openaicompat are
unchanged.

## Why

MCP servers expose full JSON Schema as tool parameters. OpenAI strict mode and
Anthropic reject several of those features outright (HTTP 400), so the model
never sees the tool. This broke real protoc-gen-go-mcp schemas containing
`bytes` fields, maps, and protobuf dynamic well-known types. The MCP ecosystem
(LangChain, Vercel AI SDK, OpenAI Agents SDK, RooCode) puts this adaptation on
the client, not the server; ai-sdk-go is that client.

Verified against the live providers:
- OpenAI strict rejects `format:"byte"`, `contentEncoding`, `propertyNames`, and
  any typeless node ("schema must have a 'type' key").
- Anthropic rejects typeless / open-ended nodes as invalid draft 2020-12.
- Gemini accepts all of it, hence no Google change.

## Implementation details

`internal/jsonschema`:
- `StripUnsupportedOpenAIKeywords`: removes `propertyNames`, `patternProperties`,
  `min/maxProperties`, `dependentRequired/Schemas`,
  `contentEncoding/MediaType/Schema`, and `format` values outside OpenAI's
  documented set (date-time, time, date, duration, email, hostname, ipv4, ipv6,
  uuid). Dropping `format:"byte"` folds a base64 hint into the description so the
  encoding signal survives the strip.
- `CollapseDynamicNodes`: rewrites typeless nodes, open objects
  (`additionalProperties: true`) and untyped arrays to a single JSON-encoded
  `string`. Targets exactly protobuf `Struct`/`Value`/`ListValue`/`Any.value` as
  they render in JSON Schema; leaves closed message objects, maps
  (`additionalProperties` is a schema), and typed scalars/arrays untouched.

`AdaptSchemaForOpenAI` = collapse + strip + the existing strict transform.
`AdaptSchemaForAnthropic` = collapse. Both deep-copy; inputs are never mutated.

The matching server-side piece (parsing a stringified dynamic WKT back to native
JSON on decode) lives in the consumer, protoc-gen-go-mcp, so the round trip is
closed there.

`openaicompat` is deliberately untouched: its endpoints range from strict to
fully permissive, so imposing the downgrade is the caller's decision.

Drive-by: the openaicompat Google compat test pinned `gemini-2.0-flash`, which is
retired and now 404s. Bumped to `gemini-3.5-flash`.

## References

protoc-gen-go-mcp PR: redpanda-data/protoc-gen-go-mcp#44
