### PR TITLE
anthropic: add Claude Fable 5 model support

### DIFF
--- a/providers/anthropic/alias_test.go
+++ b/providers/anthropic/alias_test.go
@@ -30,6 +30,16 @@ func TestModelResolution(t *testing.T) {
 		expectedModel string
 	}{
 		{
+			name:          "claude-fable-5 family name resolves",
+			modelKey:      "claude-fable-5",
+			expectedModel: "claude-fable-5",
+		},
+		{
+			name:          "claude-fable-5 timestamped preserves original",
+			modelKey:      "claude-fable-5-20260604",
+			expectedModel: "claude-fable-5-20260604",
+		},
+		{
 			name:          "claude-sonnet-4-6 family name resolves",
 			modelKey:      "claude-sonnet-4-6",
 			expectedModel: "claude-sonnet-4-6",

--- a/providers/anthropic/models.go
+++ b/providers/anthropic/models.go
@@ -25,6 +25,7 @@ import (
 // These are model family identifiers (non-timestamped). The Anthropic API
 // accepts them directly and resolves to the latest snapshot.
 const (
+	ModelClaudeFable5   = "claude-fable-5"
 	ModelClaudeSonnet46 = "claude-sonnet-4-6"
 	ModelClaudeSonnet45 = "claude-sonnet-4-5"
 	ModelClaudeHaiku45  = "claude-haiku-4-5"
@@ -95,6 +96,36 @@ func resolveModelFamily(model string) string {
 // supportedModels defines all Claude models with their capabilities and constraints.
 // Based on Anthropic API documentation and model specifications.
 var supportedModels = map[string]ModelDefinition{
+	ModelClaudeFable5: {
+		Name:  ModelClaudeFable5,
+		Label: "Claude Fable 5",
+		Capabilities: llm.ModelCapabilities{
+			Streaming:        true,
+			Tools:            true,
+			JSONMode:         false, // Anthropic doesn't have native JSON mode
+			StructuredOutput: false, // Use tool calling for structured output instead
+			Vision:           true,
+			MultiTurn:        true,
+			SystemPrompts:    true,
+			Reasoning:        true, // Adaptive thinking only; use effort to bias toward more/less thinking
+		},
+		Constraints: llm.ModelConstraints{
+			TemperatureRange: [2]float64{0.0, 1.0},
+			MaxInputTokens:   1000000, // 1M context window
+			MaxOutputTokens:  128000,  // 128K output tokens
+			// Fable 5 rejects thinking.type.enabled — thinking budget is not user-controllable.
+			// Use adaptive thinking + effort to bias reasoning depth. No fast mode, so no "speed".
+			SupportedParams:   []string{"temperature", "top_p", "top_k", "max_tokens", "effort"},
+			MutuallyExclusive: [][]string{},
+		},
+		SupportedEfforts: []Effort{EffortLow, EffortMedium, EffortHigh, EffortXHigh, EffortMax},
+		AdaptiveThinking: true,
+		Pricing: pricing.FlatInfoFromRates(
+			// Cache rates derived from Anthropic's prompt-caching multipliers
+			// (5m-write = 1.25x base input, 1h-write = 2x, cache-read = 0.10x).
+			pricing.NewRates(10.00, 50.00, 1.00).WithCacheCreation(12.50, 20.00, 0),
+		),
+	},
 	ModelClaudeOpus48: {
 		Name:  ModelClaudeOpus48,
 		Label: "Claude Opus 4.8",


### PR DESCRIPTION
## Summary

Adds `claude-fable-5` — Anthropic's new top tier above Opus — to the Anthropic provider's model registry, mirroring the conventions of the recent Opus 4.8 addition (ac7b174).

- **Model**: `ModelClaudeFable5 = "claude-fable-5"`, label "Claude Fable 5"
- **Constraints**: 1M context window, 128K output tokens
- **Thinking**: adaptive only (`AdaptiveThinking: true`); `thinking_budget` excluded from `SupportedParams` since the API rejects `thinking.type: enabled` on this model, same as Opus 4.7/4.8
- **Effort**: `low` / `medium` / `high` / `xhigh` / `max` all supported
- **Speed**: no fast mode for Fable 5, so no `speed` param, `SupportedSpeeds`, or fast pricing override
- **Pricing**: $10 / $50 / $1.00 input / output / cache-read per MTok; cache writes $12.50 (5m) / $20.00 (1h) via the standard prompt-caching multipliers (1.25x / 2x base input)

Tests: model-resolution cases for the family name and a timestamped variant, following the Opus 4.8 pattern. The map-driven `TestAllModelsHavePricing` / `TestModelPricingMatchesModels` cover the new entry automatically.

## Notes for reviewers

- **Bedrock intentionally left out**: unlike the Opus 4.8 commit, this doesn't touch `providers/bedrock` — I couldn't find a documented Bedrock model ID / geo-profile availability for Fable 5, and guessing IDs there seemed worse than a follow-up once AWS publishes them.
- `temperature` / `top_p` / `top_k` are kept in `SupportedParams` to match the existing Opus 4.7/4.8 entries, though the API rejects sampling params on this whole model family — happy to drop them here (or in a follow-up for 4.7/4.8 too) if you'd rather fail fast client-side.

## Test plan

- `go test ./providers/anthropic/... -short` — 96 passed
- `task test:unit` — all packages pass
- `task lint:new` — 0 issues; `task license:check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)