### PR TITLE
fix(providers): tighten fable 5 model support

### DIFF
--- a/llm/types.go
+++ b/llm/types.go
@@ -318,4 +318,7 @@ type ModelDiscoveryInfo struct {
 
 	// Provider is the name of the provider that offers this model
 	Provider string
+
+	// Metadata carries provider-specific model metadata for discovery surfaces.
+	Metadata map[string]string
 }

--- a/providers/anthropic/alias_test.go
+++ b/providers/anthropic/alias_test.go
@@ -209,6 +209,14 @@ func TestWithThinkingBudget(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "thinking_budget")
 	})
+
+	t.Run("rejected on Fable 5", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := provider.NewModel(ModelClaudeFable5, WithThinkingBudget(2048))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "thinking_budget")
+	})
 }
 
 func TestWithEffort(t *testing.T) {
@@ -249,6 +257,20 @@ func TestWithEffort(t *testing.T) {
 		require.True(t, ok)
 		require.NotNil(t, m.config.Effort)
 		assert.Equal(t, EffortMax, *m.config.Effort)
+	})
+
+	t.Run("all effort levels accepted on Fable 5", func(t *testing.T) {
+		t.Parallel()
+
+		for _, effort := range []Effort{EffortLow, EffortMedium, EffortHigh, EffortXHigh, EffortMax} {
+			model, err := provider.NewModel(ModelClaudeFable5, WithEffort(effort))
+			require.NoError(t, err)
+
+			m, ok := model.(*Model)
+			require.True(t, ok)
+			require.NotNil(t, m.config.Effort)
+			assert.Equal(t, effort, *m.config.Effort)
+		}
 	})
 
 	t.Run("rejected on model without effort support", func(t *testing.T) {
@@ -305,4 +327,39 @@ func TestWithSpeed(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "speed")
 	})
+
+	t.Run("rejected on Fable 5", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := provider.NewModel(ModelClaudeFable5, WithSpeed(SpeedFast))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "speed")
+	})
+}
+
+func TestFable5SamplingParametersRejected(t *testing.T) {
+	t.Parallel()
+
+	provider, err := NewProvider("test-key")
+	require.NoError(t, err)
+
+	tests := []struct {
+		name string
+		opt  Option
+		want string
+	}{
+		{name: "temperature", opt: WithTemperature(0.5), want: "temperature"},
+		{name: "top_p", opt: WithTopP(0.9), want: "top_p"},
+		{name: "top_k", opt: WithTopK(10), want: "top_k"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := provider.NewModel(ModelClaudeFable5, tt.opt)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.want)
+		})
+	}
 }

--- a/providers/anthropic/models.go
+++ b/providers/anthropic/models.go
@@ -115,7 +115,7 @@ var supportedModels = map[string]ModelDefinition{
 			MaxOutputTokens:  128000,  // 128K output tokens
 			// Fable 5 rejects thinking.type.enabled — thinking budget is not user-controllable.
 			// Use adaptive thinking + effort to bias reasoning depth. No fast mode, so no "speed".
-			SupportedParams:   []string{"temperature", "top_p", "top_k", "max_tokens", "effort"},
+			SupportedParams:   []string{"max_tokens", "effort"},
 			MutuallyExclusive: [][]string{},
 		},
 		SupportedEfforts: []Effort{EffortLow, EffortMedium, EffortHigh, EffortXHigh, EffortMax},

--- a/providers/bedrock/bedrock_conformance_test.go
+++ b/providers/bedrock/bedrock_conformance_test.go
@@ -16,9 +16,11 @@ package bedrock_test
 
 import (
 	"context"
+	"errors"
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/redpanda-data/ai-sdk-go/internal/testsuite"
 	"github.com/redpanda-data/ai-sdk-go/llm"
@@ -101,12 +103,158 @@ func (f *BedrockFixture) Models() []llm.ModelDiscoveryInfo {
 	filtered := make([]llm.ModelDiscoveryInfo, 0, len(all))
 
 	for _, m := range all {
+		// Fable 5 requires Bedrock provider data sharing. Keep the generic
+		// all-model conformance loop on models that CI can fully generate with;
+		// the dedicated Fable integration below still verifies Bedrock wiring by
+		// accepting either a successful response or AWS's explicit Fable access gate.
+		if modelRequiresProviderDataSharing(m) {
+			continue
+		}
+
 		if strings.HasPrefix(m.Name, geoPrefix) {
 			filtered = append(filtered, m)
 		}
 	}
 
 	return filtered
+}
+
+func modelRequiresProviderDataSharing(model llm.ModelDiscoveryInfo) bool {
+	return model.Metadata[bedrock.ModelMetadataRequiresProviderDataSharing] == "true"
+}
+
+func TestModelRequiresProviderDataSharing(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		model llm.ModelDiscoveryInfo
+		want  bool
+	}{
+		{
+			name: "Fable 5",
+			model: llm.ModelDiscoveryInfo{
+				Name: bedrock.ModelClaudeFable5US,
+				Metadata: map[string]string{
+					bedrock.ModelMetadataRequiresProviderDataSharing: "true",
+				},
+			},
+			want: true,
+		},
+		{
+			name:  "other Claude",
+			model: llm.ModelDiscoveryInfo{Name: bedrock.ModelClaudeSonnet46US},
+			want:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := modelRequiresProviderDataSharing(tt.model)
+			if got != tt.want {
+				t.Fatalf("modelRequiresProviderDataSharing(%q) = %v, want %v", tt.model.Name, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsProviderDataSharingGate(t *testing.T) {
+	t.Parallel()
+
+	err := &llm.ProviderError{
+		Base:    llm.ErrInvalidInput,
+		Code:    "ValidationException",
+		Message: "provider rejected request because data retention is not enabled",
+	}
+
+	if !isProviderDataSharingGate(err) {
+		t.Fatal("expected provider data sharing gate to be detected")
+	}
+}
+
+func TestIsFableAccessGate(t *testing.T) {
+	t.Parallel()
+
+	err := &llm.ProviderError{
+		Base:    llm.ErrAPICall,
+		Code:    "AccessDeniedException",
+		Message: "access denied",
+	}
+
+	if !isFableAccessGate(err) {
+		t.Fatal("expected Fable access gate to be detected")
+	}
+}
+
+func TestBedrockFable5Invocation_Integration(t *testing.T) {
+	t.Parallel()
+
+	bedrocktest.SkipUnlessAWSCredentials(t)
+
+	region := os.Getenv("AWS_REGION")
+	if region == "" {
+		region = bedrocktest.TestRegion
+	}
+
+	provider, err := bedrock.NewProvider(context.Background(), bedrock.WithRegion(region))
+	if err != nil {
+		t.Fatalf("Failed to create provider: %v", err)
+	}
+
+	model, err := provider.NewModel(bedrock.ModelClaudeFable5, bedrock.WithMaxTokens(16))
+	if err != nil {
+		t.Fatalf("Failed to create Fable 5 model: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+
+	resp, err := model.Generate(ctx, &llm.Request{
+		Messages: []llm.Message{
+			llm.NewMessage(llm.RoleUser, llm.NewTextPart("Reply with ok.")),
+		},
+	})
+	if err != nil {
+		if isFableAccessGate(err) {
+			t.Skipf("Fable 5 reached Bedrock but account is not enabled for Fable access: %v", err)
+		}
+
+		t.Fatalf("Fable 5 Bedrock invocation failed: %v", err)
+	}
+
+	if resp == nil {
+		t.Fatal("Fable 5 Bedrock invocation returned nil response")
+	}
+}
+
+func isProviderDataSharingGate(err error) bool {
+	var providerErr *llm.ProviderError
+	if !errors.As(err, &providerErr) {
+		return false
+	}
+
+	if providerErr.Code != "ValidationException" {
+		return false
+	}
+
+	message := strings.ToLower(providerErr.Message)
+
+	return strings.Contains(message, "data retention") || strings.Contains(message, "provider_data")
+}
+
+func isAccessDeniedGate(providerErr *llm.ProviderError) bool {
+	return providerErr.Code == "AccessDeniedException"
+}
+
+func isFableAccessGate(err error) bool {
+	var providerErr *llm.ProviderError
+	if !errors.As(err, &providerErr) {
+		return false
+	}
+
+	return isProviderDataSharingGate(err) || isAccessDeniedGate(providerErr)
 }
 
 func (f *BedrockFixture) NewModel(modelName string) (llm.Model, error) {

--- a/providers/bedrock/models.go
+++ b/providers/bedrock/models.go
@@ -35,17 +35,21 @@ import (
 //     and the two side-by-side Anthropic tables on
 //     https://aws.amazon.com/bedrock/pricing/.
 //
-// Every 4.5+ Anthropic model on Bedrock is inference-profile-only:
-// invoking the bare ID via bedrock-runtime returns ValidationException
-// "Invocation of model ID … with on-demand throughput isn't supported.
-// Retry your request with the ID or ARN of an inference profile that
-// contains this model." Verified empirically (2026-04) for Opus 4.5/4.6/4.7,
-// Sonnet 4.5/4.6, and Haiku 4.5 in us-east-2 (and Sonnet 4.5 in us-east-1,
-// Opus 4.7 in eu-west-1) — both AWS doc tables describing bare-ID
-// invokability are unreliable, so the bare consts below exist only as
-// building blocks for the prefixed variants and are NOT registered in
+// This catalog registers inference-profile variants instead of bare Claude
+// IDs so each entry carries the correct routing and pricing metadata. For
+// earlier 4.5+ models, invoking the bare ID via bedrock-runtime returned
+// ValidationException "Invocation of model ID … with on-demand throughput
+// isn't supported" in empirical checks (2026-04); the bare consts below exist
+// only as building blocks for the prefixed variants and are NOT registered in
 // supportedModels.
 const (
+	// ModelClaudeFable5 is the bare Bedrock ID for Claude Fable 5
+	// (inference-profile-only — invoke via one of the prefixed variants).
+	ModelClaudeFable5       = "anthropic.claude-fable-5"
+	ModelClaudeFable5Global = "global." + ModelClaudeFable5
+	ModelClaudeFable5US     = "us." + ModelClaudeFable5
+	ModelClaudeFable5EU     = "eu." + ModelClaudeFable5
+
 	// ModelClaudeSonnet46 is the bare Bedrock ID for Claude Sonnet 4.6
 	// (inference-profile-only — invoke via one of the prefixed variants).
 	ModelClaudeSonnet46       = "anthropic.claude-sonnet-4-6"
@@ -105,11 +109,26 @@ const (
 
 // ModelDefinition defines a model with its capabilities and constraints.
 type ModelDefinition struct {
-	Name         string // Real Bedrock model ID (e.g. "us.anthropic.claude-sonnet-4-6")
-	Label        string
-	Capabilities llm.ModelCapabilities
-	Constraints  llm.ModelConstraints
-	Pricing      pricing.Info
+	Name                        string // Real Bedrock model ID (e.g. "us.anthropic.claude-sonnet-4-6")
+	Label                       string
+	Capabilities                llm.ModelCapabilities
+	Constraints                 llm.ModelConstraints
+	Pricing                     pricing.Info
+	RequiresProviderDataSharing bool
+}
+
+// ModelMetadataRequiresProviderDataSharing is set to "true" on discovery
+// metadata for Bedrock models that require provider data sharing.
+const ModelMetadataRequiresProviderDataSharing = "requires_provider_data_sharing"
+
+func (d ModelDefinition) discoveryMetadata() map[string]string {
+	if !d.RequiresProviderDataSharing {
+		return nil
+	}
+
+	return map[string]string{
+		ModelMetadataRequiresProviderDataSharing: "true",
+	}
 }
 
 // InferenceProfileRegion maps an AWS region to the Bedrock cross-region
@@ -183,6 +202,13 @@ var (
 		SupportedParams:  []string{"temperature", "top_p", "max_tokens", "stop"},
 	}
 
+	claudeFable5Constraints = llm.ModelConstraints{
+		TemperatureRange: [2]float64{0.0, 1.0},
+		MaxInputTokens:   1000000,
+		MaxOutputTokens:  128000,
+		SupportedParams:  []string{"max_tokens", "stop"},
+	}
+
 	claudeContext200kConstraints = llm.ModelConstraints{
 		TemperatureRange: [2]float64{0.0, 1.0},
 		MaxInputTokens:   200000,
@@ -203,6 +229,41 @@ var (
 //   - global. profiles use the "Global Cross-region Inference" rate, which
 //     is exactly 10% cheaper than the geo rate for the same model.
 var supportedModels = map[string]ModelDefinition{
+	// ----------------------------------------------------------------
+	// Claude Fable 5 — inference-profile-only, no bare entry. Geo
+	// profiles cover us and eu (jp/au are not published).
+	// ----------------------------------------------------------------
+	ModelClaudeFable5Global: {
+		Name:                        ModelClaudeFable5Global,
+		Label:                       "Claude Fable 5 (Global)",
+		Capabilities:                claudeStandardCaps,
+		Constraints:                 claudeFable5Constraints,
+		RequiresProviderDataSharing: true,
+		Pricing: pricing.FlatInfoFromRates(
+			pricing.NewRates(10.00, 50.00, 1.00).WithCacheCreation(12.50, 20.00, 0),
+		),
+	},
+	ModelClaudeFable5US: {
+		Name:                        ModelClaudeFable5US,
+		Label:                       "Claude Fable 5 (US)",
+		Capabilities:                claudeStandardCaps,
+		Constraints:                 claudeFable5Constraints,
+		RequiresProviderDataSharing: true,
+		Pricing: pricing.FlatInfoFromRates(
+			pricing.NewRates(11.00, 55.00, 1.10).WithCacheCreation(13.75, 22.00, 0),
+		),
+	},
+	ModelClaudeFable5EU: {
+		Name:                        ModelClaudeFable5EU,
+		Label:                       "Claude Fable 5 (EU)",
+		Capabilities:                claudeStandardCaps,
+		Constraints:                 claudeFable5Constraints,
+		RequiresProviderDataSharing: true,
+		Pricing: pricing.FlatInfoFromRates(
+			pricing.NewRates(11.00, 55.00, 1.10).WithCacheCreation(13.75, 22.00, 0),
+		),
+	},
+
 	// ----------------------------------------------------------------
 	// Claude Opus 4.8 — inference-profile-only, no bare entry. Geo
 	// profiles cover us, eu, jp (au is not published).

--- a/providers/bedrock/provider.go
+++ b/providers/bedrock/provider.go
@@ -213,6 +213,7 @@ func (p *Provider) Models() []llm.ModelDiscoveryInfo {
 			Label:        def.Label,
 			Capabilities: def.Capabilities,
 			Provider:     p.Name(),
+			Metadata:     def.discoveryMetadata(),
 		})
 	}
 

--- a/providers/bedrock/provider_test.go
+++ b/providers/bedrock/provider_test.go
@@ -108,10 +108,35 @@ func TestLookupModel(t *testing.T) {
 			wantOK: false,
 		},
 		{
+			// The Bedrock catalog registers inference-profile variants so
+			// pricing and routing metadata stay explicit per profile.
+			name:   "Fable 5 bare ID is not in the catalog",
+			input:  ModelClaudeFable5,
+			wantOK: false,
+		},
+		{
 			name:    "geo profile is its own entry",
 			input:   ModelClaudeSonnet46EU,
 			wantOK:  true,
 			wantDef: ModelClaudeSonnet46EU,
+		},
+		{
+			name:    "Fable 5 US profile is its own entry",
+			input:   ModelClaudeFable5US,
+			wantOK:  true,
+			wantDef: ModelClaudeFable5US,
+		},
+		{
+			name:    "Fable 5 EU profile is its own entry",
+			input:   ModelClaudeFable5EU,
+			wantOK:  true,
+			wantDef: ModelClaudeFable5EU,
+		},
+		{
+			name:    "Fable 5 global profile is its own entry",
+			input:   ModelClaudeFable5Global,
+			wantOK:  true,
+			wantDef: ModelClaudeFable5Global,
 		},
 		{
 			name:    "global profile is its own entry",
@@ -292,6 +317,7 @@ func TestNewModel_SupportedModels(t *testing.T) {
 		{"with region prefix", "eu." + ModelClaudeSonnet46},
 		{"opus with region", "global." + ModelClaudeOpus46},
 		{"haiku with region", "eu." + ModelClaudeHaiku45},
+		{"Fable 5 with region prefix", ModelClaudeFable5EU},
 	}
 
 	for _, tt := range tests {
@@ -347,6 +373,44 @@ func TestNewModel_EURegionPrefix(t *testing.T) {
 	m, ok := model.(*Model)
 	require.True(t, ok)
 	assert.Equal(t, "eu."+ModelClaudeSonnet46, m.config.APIModelID)
+}
+
+func TestNewModel_Fable5RegionPrefix(t *testing.T) {
+	t.Parallel()
+
+	p := &Provider{client: nil, region: "us-east-1"}
+
+	model, err := p.NewModel(ModelClaudeFable5)
+	require.NoError(t, err)
+
+	m, ok := model.(*Model)
+	require.True(t, ok)
+	assert.Equal(t, ModelClaudeFable5US, m.config.APIModelID)
+}
+
+func TestNewModel_Fable5SamplingParametersRejected(t *testing.T) {
+	t.Parallel()
+
+	p := &Provider{client: nil, region: "us-east-1"}
+
+	tests := []struct {
+		name string
+		opt  Option
+		want string
+	}{
+		{name: "temperature", opt: WithTemperature(0.5), want: "temperature"},
+		{name: "top_p", opt: WithTopP(0.9), want: "top_p"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := p.NewModel(ModelClaudeFable5, tt.opt)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.want)
+		})
+	}
 }
 
 func TestNewModel_UnsupportedModel(t *testing.T) {
@@ -635,9 +699,10 @@ func TestRequestMapper_ToolResponseError(t *testing.T) {
 		Messages: []llm.Message{
 			llm.NewMessage(llm.RoleUser,
 				&llm.ToolResponsePart{
-					ID:    "toolu_123",
-					Name:  "search",
-					IsError: true, Result: json.RawMessage(`{"error":"API rate limited"}`),				},
+					ID:      "toolu_123",
+					Name:    "search",
+					IsError: true, Result: json.RawMessage(`{"error":"API rate limited"}`),
+				},
 			),
 		},
 	}
@@ -960,6 +1025,25 @@ func TestModelsDiscovery(t *testing.T) {
 		assert.Less(t, models[i-1].Name, models[i].Name,
 			"Models() should be sorted by Name: %s should come before %s", models[i-1].Name, models[i].Name)
 	}
+}
+
+func TestModelsDiscovery_ProviderDataSharingMetadata(t *testing.T) {
+	t.Parallel()
+
+	p := &Provider{}
+
+	models := p.Models()
+
+	metadataByName := make(map[string]map[string]string, len(models))
+	for _, m := range models {
+		metadataByName[m.Name] = m.Metadata
+	}
+
+	for _, name := range []string{ModelClaudeFable5Global, ModelClaudeFable5US, ModelClaudeFable5EU} {
+		assert.Equal(t, "true", metadataByName[name][ModelMetadataRequiresProviderDataSharing])
+	}
+
+	assert.Empty(t, metadataByName[ModelClaudeSonnet46US])
 }
 
 // ---------- Options validation ----------


### PR DESCRIPTION
## Summary

Follow-up to #146.

- removes unsupported sampling params (`temperature`, `top_p`, `top_k`) from first-party Anthropic `claude-fable-5` so callers fail fast client-side instead of getting API 400s
- adds Fable 5 option coverage for sampling rejection, thinking-budget rejection, speed rejection, and supported effort levels
- adds Bedrock Fable 5 catalog entries for documented `global.`, `us.`, and `eu.` inference profiles
- exposes `requires_provider_data_sharing=true` in model discovery metadata for Bedrock Fable 5 entries
- adds Bedrock lookup, region-prefix, sampling-param, pricing, discovery-metadata, and conformance coverage for the new entries
- adds a dedicated Bedrock Fable 5 integration that hits Bedrock and either generates successfully or skips on AWS's explicit Fable access gates (provider data sharing / account access)

Docs checked:

- Anthropic Fable 5 migration notes: https://platform.claude.com/docs/en/about-claude/models/migration-guide
- AWS Fable 5 Bedrock model card: https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-fable-5.html
- AWS Bedrock data retention docs: https://docs.aws.amazon.com/bedrock/latest/userguide/data-retention.html

## Test plan

- `go test ./providers/anthropic/... -short`
- `go test ./providers/bedrock/... -short`
- `go test ./providers/bedrock -run 'TestModelRequiresProviderDataSharing|TestIsProviderDataSharingGate|TestIsFableAccessGate|TestBedrockFable5Invocation_Integration|TestBedrockConformance_Integration|TestModelsDiscovery_ProviderDataSharingMetadata' -count=1`
- `go test ./llm -count=1`
- `task test:unit`
- `task lint:new`
- `task license:check`
