### PR TITLE
mcp: force mangled tool names to start with a letter

### DIFF
--- a/tool/mcp/mangle.go
+++ b/tool/mcp/mangle.go
@@ -60,6 +60,20 @@ func mangleHeadIfTooLong(name string, maxLen int) string {
 	if len(hashPrefix) > 10 {
 		hashPrefix = hashPrefix[:10]
 	}
+	// Providers disagree on the leading character of a tool name: Gemini
+	// requires a letter or underscore, while OpenAI/Anthropic/Bedrock also
+	// accept digits. A base-36 hash starts with a digit ~88% of the time,
+	// and the mangled name leads with the hash -- Gemini then rejects the
+	// entire request with "Invalid function name" (live failure:
+	// morningstar-portfolio via the namespaced
+	// "...__nnhz8bnl3a_rningstarPortfolioService_CalculatePortfolioRiskScore",
+	// 2026-06-10). Map a leading digit onto 'g'..'p', mirroring
+	// protoc-gen-go-mcp's MangleHeadIfTooLong so names mangled at either
+	// layer keep using the same scheme; hashes already starting with a
+	// letter are unchanged.
+	if c := hashPrefix[0]; c >= '0' && c <= '9' {
+		hashPrefix = string('g'+(c-'0')) + hashPrefix[1:]
+	}
 
 	if maxLen <= len(hashPrefix) {
 		return hashPrefix[:maxLen]

--- a/tool/mcp/mangle_test.go
+++ b/tool/mcp/mangle_test.go
@@ -135,3 +135,30 @@ func TestNamespaceToolMangling(t *testing.T) {
 		assert.Equal(t, a, b)
 	})
 }
+
+// Mangled names must be valid tool names on every provider. Gemini is
+// the strictest: the name must start with a letter or underscore. A
+// base-36 hash prefix starts with a digit ~88% of the time — without
+// the leading-digit remap, the exact name below was sent to Gemini and
+// 400-failed every generation of the financial-advisor agent
+// (2026-06-10).
+func TestMangleHeadIfTooLong_GeminiSafeLeadingChar(t *testing.T) {
+	const live = "morningstar-portfolio__nnhz8bnl3a_rningstarPortfolioService_CalculatePortfolioRiskScore"
+	got := mangleHeadIfTooLong(live, maxToolNameLen)
+	assert.Len(t, got, maxToolNameLen)
+	// The raw hash for this name is "1hqljtt9c2..." — '1' maps to 'h'.
+	assert.Equal(t, "hhqljtt9c2_rningstarPortfolioService_CalculatePortfolioRiskScore", got)
+	assert.Regexp(t, `^[a-zA-Z_]`, got)
+
+	// Deterministic, and letter-leading for any input.
+	assert.Equal(t, got, mangleHeadIfTooLong(live, maxToolNameLen))
+	inputs := []string{
+		"0" + strings.Repeat("y", 100),
+		strings.Repeat("x", 100),
+		"server__" + strings.Repeat("a", 80),
+	}
+	for _, in := range inputs {
+		m := mangleHeadIfTooLong(in, maxToolNameLen)
+		assert.Regexp(t, `^[a-zA-Z_]`, m, "input %q", in)
+	}
+}


### PR DESCRIPTION
## What

Map a leading digit of the mangled-name hash prefix onto `'g'..'p'`, mirroring protoc-gen-go-mcp's `MangleHeadIfTooLong` (fixed there in protoc-gen-go-mcp#46). Hashes already starting with a letter are byte-identical to before.

## Why

Live failure, today, second occurrence of the class. #133's `serverID__` overflow mangling copied protoc-gen-go-mcp's scheme faithfully — including the bug: the base-36 hash prefix starts with a digit ~88% of the time, and Gemini rejects function names that don't start with a letter or underscore. One over-64 namespaced name (`morningstar-portfolio__nnhz8bnl3a_…` → `1hqljtt9c2_…`) 400-failed **every** generation of the financial-advisor agent on the integration cluster.

The two mangling layers must keep the same scheme; this brings them back in sync. The regression test pins the exact live-failure name and asserts letter-leading output for arbitrary inputs.

## References

- protoc-gen-go-mcp fix: https://github.com/redpanda-data/protoc-gen-go-mcp/pull/46
- Origin of this code path: #133
- cloudv2 consumer-side fixes: redpanda-data/cloudv2#26975 (merged), redpanda-data/cloudv2#26983 (Short anchor for mid-word truncation — independently removes this specific name from the over-64 set)