### PR TITLE
fix: never send tool-call arguments as JSON null

### DIFF
--- a/providers/openai/model.go
+++ b/providers/openai/model.go
@@ -16,7 +16,6 @@ package openai
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"iter"
 
@@ -143,7 +142,7 @@ func (m *Model) GenerateEvents(ctx context.Context, req *llm.Request) iter.Seq2[
 						Part: llm.NewToolRequestPart(
 							toolCall.CallID,
 							toolCall.Name,
-							json.RawMessage(toolCall.Arguments),
+							normalizeToolArguments(toolCall.Arguments),
 						),
 					}, nil) {
 						return

--- a/providers/openai/response_mapper.go
+++ b/providers/openai/response_mapper.go
@@ -100,7 +100,7 @@ func (m *ResponseMapper) FromProvider(r *responses.Response) (*llm.Response, err
 
 			hasToolCalls = true
 
-			content = append(content, llm.NewToolRequestPart(fc.CallID, fc.Name, json.RawMessage(fc.Arguments)))
+			content = append(content, llm.NewToolRequestPart(fc.CallID, fc.Name, normalizeToolArguments(fc.Arguments)))
 
 		case outputTypeReasoning:
 			for i, s := range out.Summary {
@@ -214,4 +214,17 @@ var codeToBaseErr = map[responses.ResponseErrorCode]error{
 	responses.ResponseErrorCodeImageParseError:       llm.ErrServerError,
 	responses.ResponseErrorCodeFailedToDownloadImage: llm.ErrServerError,
 	responses.ResponseErrorCodeImageFileNotFound:     llm.ErrServerError,
+}
+
+// normalizeToolArguments converts a raw function-call arguments string into
+// a JSON object payload. OpenAI emits an empty arguments string for
+// zero-parameter tool calls; passed through verbatim, downstream tool
+// executors serialize the call as `"arguments": null`, which strict MCP
+// servers reject. Mirrors the Bedrock mapper, which defaults absent tool
+// input to {}.
+func normalizeToolArguments(args string) json.RawMessage {
+	if args == "" {
+		return json.RawMessage(`{}`)
+	}
+	return json.RawMessage(args)
 }

--- a/providers/openai/response_mapper.go
+++ b/providers/openai/response_mapper.go
@@ -226,5 +226,6 @@ func normalizeToolArguments(args string) json.RawMessage {
 	if args == "" {
 		return json.RawMessage(`{}`)
 	}
+
 	return json.RawMessage(args)
 }

--- a/providers/openai/response_mapper_test.go
+++ b/providers/openai/response_mapper_test.go
@@ -15,6 +15,8 @@
 package openai
 
 import (
+	"encoding/json"
+	"fmt"
 	"testing"
 
 	"github.com/openai/openai-go/v3/responses"
@@ -130,6 +132,62 @@ func TestResponseMapper_FinishReasonTruncationWithToolCalls(t *testing.T) {
 			})
 			require.NoError(t, err)
 			assert.Equal(t, tc.want, resp.FinishReason)
+		})
+	}
+}
+
+// TestResponseMapper_FunctionCallArgumentsNormalization locks in how raw
+// function-call argument strings map to ToolRequestPart.Arguments. OpenAI
+// emits an empty arguments string for zero-parameter tool calls; passing
+// that through as an empty RawMessage makes downstream tool executors
+// serialize the call as `"arguments": null`, which strict MCP servers
+// reject. The Bedrock mapper already defaults absent input to {} — this
+// keeps providers consistent.
+//
+// The response is built from JSON because the openai-go output-item union
+// reconstructs variants from the captured raw JSON (AsFunctionCall reads
+// u.JSON.raw); struct-literal unions carry no field data into AsAny().
+func TestResponseMapper_FunctionCallArgumentsNormalization(t *testing.T) {
+	t.Parallel()
+
+	mapper := NewResponseMapper(supportedModels[ModelGPT5Mini])
+
+	cases := []struct {
+		name string
+		args string
+		want string
+	}{
+		{"empty arguments become an object", ``, `{}`},
+		{"populated arguments pass through", `{\"q\":\"SELECT 1\"}`, `{"q":"SELECT 1"}`},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			payload := fmt.Sprintf(`{
+				"id": "resp_args",
+				"model": "%s",
+				"status": "completed",
+				"output": [{
+					"type": "function_call",
+					"call_id": "call_1",
+					"name": "get_me",
+					"arguments": "%s"
+				}],
+				"usage": {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2}
+			}`, ModelGPT5Mini, tc.args)
+
+			var r responses.Response
+			require.NoError(t, json.Unmarshal([]byte(payload), &r))
+
+			resp, err := mapper.FromProvider(&r)
+			require.NoError(t, err)
+
+			require.Len(t, resp.Message.Content, 1)
+			part, ok := resp.Message.Content[0].(*llm.ToolRequestPart)
+			require.True(t, ok, "expected *llm.ToolRequestPart, got %T", resp.Message.Content[0])
+			assert.JSONEq(t, tc.want, string(part.Arguments))
 		})
 	}
 }

--- a/tool/mcp/client_test.go
+++ b/tool/mcp/client_test.go
@@ -333,30 +333,6 @@ func TestExecuteToolArgValidation(t *testing.T) {
 func TestExecuteToolEmptyArgumentsSentAsObject(t *testing.T) {
 	t.Parallel()
 
-	ctx := t.Context()
-
-	server := newMockMCPServer()
-
-	var (
-		gotArgs map[string]any
-		called  bool
-	)
-	server.toolExecutor = func(_ string, args map[string]any) ([]sdkmcp.Content, error) {
-		gotArgs = args
-		called = true
-		return []sdkmcp.Content{&sdkmcp.TextContent{Text: "ok"}}, nil
-	}
-
-	transport, err := server.start(ctx)
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = server.stop() })
-
-	client, err := NewClient("test-server", func() (sdkmcp.Transport, error) { return transport, nil })
-	require.NoError(t, err)
-	require.NoError(t, client.Start(ctx))
-	t.Cleanup(func() { _ = client.Close() })
-
-	// Sequential on purpose: the subtests share gotArgs/called.
 	for _, tc := range []struct {
 		name string
 		args json.RawMessage
@@ -366,15 +342,37 @@ func TestExecuteToolEmptyArgumentsSentAsObject(t *testing.T) {
 		{"json null", json.RawMessage("null")},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			gotArgs, called = nil, false
+			t.Parallel()
 
-			_, err := client.ExecuteTool(ctx, "test-server__echo", tc.args)
+			ctx := t.Context()
+
+			server := newMockMCPServer()
+			// The mock handler unmarshals the wire arguments before this
+			// hook: a JSON object (even empty) produces a non-nil map,
+			// while null or absent arguments leave it nil. Report which
+			// one arrived through the tool result.
+			server.toolExecutor = func(_ string, args map[string]any) ([]sdkmcp.Content, error) {
+				text := "args-object"
+				if args == nil {
+					text = "args-nil"
+				}
+
+				return []sdkmcp.Content{&sdkmcp.TextContent{Text: text}}, nil
+			}
+
+			transport, err := server.start(ctx)
 			require.NoError(t, err)
-			require.True(t, called)
-			// The mock handler unmarshals the wire arguments: a JSON
-			// object (even empty) produces a non-nil map, while null or
-			// absent arguments leave it nil.
-			assert.NotNil(t, gotArgs, "server must receive {}, not null/absent arguments")
+			t.Cleanup(func() { _ = server.stop() })
+
+			client, err := NewClient("test-server", func() (sdkmcp.Transport, error) { return transport, nil })
+			require.NoError(t, err)
+			require.NoError(t, client.Start(ctx))
+			t.Cleanup(func() { _ = client.Close() })
+
+			result, err := client.ExecuteTool(ctx, "test-server__echo", tc.args)
+			require.NoError(t, err)
+			assert.Contains(t, string(result), "args-object",
+				"server must receive {}, not null/absent arguments")
 		})
 	}
 }

--- a/tool/mcp/client_test.go
+++ b/tool/mcp/client_test.go
@@ -322,6 +322,63 @@ func TestExecuteToolArgValidation(t *testing.T) {
 	})
 }
 
+// TestExecuteToolEmptyArgumentsSentAsObject verifies that empty tool-call
+// arguments reach the server as an empty JSON object. A nil arguments map
+// assigned to CallToolParams.Arguments (an `any` field with omitempty) is
+// not omitted by encoding/json — it serializes as `"arguments": null`,
+// which strict servers reject (e.g. protojson-backed handlers fail with
+// "unexpected token null" on every zero-parameter tool call). Empty
+// arguments are routine: OpenAI-format models emit `"arguments": ""` for
+// tools with no parameters.
+func TestExecuteToolEmptyArgumentsSentAsObject(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	server := newMockMCPServer()
+
+	var (
+		gotArgs map[string]any
+		called  bool
+	)
+	server.toolExecutor = func(_ string, args map[string]any) ([]sdkmcp.Content, error) {
+		gotArgs = args
+		called = true
+		return []sdkmcp.Content{&sdkmcp.TextContent{Text: "ok"}}, nil
+	}
+
+	transport, err := server.start(ctx)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = server.stop() })
+
+	client, err := NewClient("test-server", func() (sdkmcp.Transport, error) { return transport, nil })
+	require.NoError(t, err)
+	require.NoError(t, client.Start(ctx))
+	t.Cleanup(func() { _ = client.Close() })
+
+	// Sequential on purpose: the subtests share gotArgs/called.
+	for _, tc := range []struct {
+		name string
+		args json.RawMessage
+	}{
+		{"nil raw message", nil},
+		{"empty raw message", json.RawMessage("")},
+		{"json null", json.RawMessage("null")},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			gotArgs, called = nil, false
+
+			_, err := client.ExecuteTool(ctx, "test-server__echo", tc.args)
+			require.NoError(t, err)
+			require.True(t, called)
+			// The mock handler unmarshals the wire arguments: a JSON
+			// object (even empty) produces a non-nil map, while null or
+			// absent arguments leave it nil.
+			assert.NotNil(t, gotArgs, "server must receive {}, not null/absent arguments")
+		})
+	}
+}
+
 func TestNamespaceTool(t *testing.T) {
 	t.Parallel()
 

--- a/tool/mcp/tools.go
+++ b/tool/mcp/tools.go
@@ -105,6 +105,16 @@ func (c *clientImpl) ExecuteTool(ctx context.Context, toolName string, args json
 		}
 	}
 
+	// Always send a JSON object. The MCP spec types tools/call arguments as
+	// an object, but a nil map here is not dropped by omitempty (the
+	// interface field holds a typed-nil map) and serializes as
+	// `"arguments": null`, which strict servers reject. Empty arguments are
+	// routine for zero-parameter tools: OpenAI-format models emit
+	// `"arguments": ""`, and JSON null unmarshals to a nil map above.
+	if argsMap == nil {
+		argsMap = map[string]any{}
+	}
+
 	// Create operation context that respects both client lifetime and caller's deadline
 	opCtx, cancel := opContext(bgCtx, ctx)
 	defer cancel()


### PR DESCRIPTION
## Summary

Two compounding gaps made every zero-parameter MCP tool call fail when driven by an OpenAI-format model (first hit: Redpanda Cloud managed Pylon MCP `get_me`, companion server-side fix in redpanda-data/cloudv2#26995):

1. **`tool/mcp` ExecuteTool** left the arguments map nil for empty/null input. `CallToolParams.Arguments` is an `any` field with `omitempty`, and a non-nil interface holding a typed-nil map is **not** omitted by `encoding/json` — the wire carried `"arguments": null`. The MCP spec types arguments as an object; strict servers reject the null (protojson-backed handlers fail with `unexpected token null` before the tool runs).
2. **`providers/openai`** passed the model's raw arguments string through verbatim in both the response mapper and the streaming `output_item.done` path. OpenAI emits an empty arguments string for zero-parameter tool calls, producing a `ToolRequestPart` with an empty `RawMessage`.

## Fix

- `ExecuteTool` always sends a JSON object: nil map → `{}`.
- New `normalizeToolArguments` in the openai provider maps `""` → `{}` at both call sites, mirroring the Bedrock mapper's `marshalToolInput` default (the only provider that already normalized).

## Tests

- `TestExecuteToolEmptyArgumentsSentAsObject` — full in-memory client↔server round-trip for nil / empty / JSON-null arguments, asserting the server receives an object.
- `TestResponseMapper_FunctionCallArgumentsNormalization` — empty arguments normalize to `{}`, populated arguments pass through untouched (response built from raw JSON because the openai-go union reconstructs variants from captured raw JSON).

All fail before the fix; full `go test ./...` and `golangci-lint --new-from-rev=origin/main` are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)