### PR TITLE
fix(providers): remove Fable 5 models

### DIFF
--- a/providers/anthropic/alias_test.go
+++ b/providers/anthropic/alias_test.go
@@ -30,16 +30,6 @@ func TestModelResolution(t *testing.T) {
 		expectedModel string
 	}{
 		{
-			name:          "claude-fable-5 family name resolves",
-			modelKey:      "claude-fable-5",
-			expectedModel: "claude-fable-5",
-		},
-		{
-			name:          "claude-fable-5 timestamped preserves original",
-			modelKey:      "claude-fable-5-20260604",
-			expectedModel: "claude-fable-5-20260604",
-		},
-		{
 			name:          "claude-sonnet-4-6 family name resolves",
 			modelKey:      "claude-sonnet-4-6",
 			expectedModel: "claude-sonnet-4-6",
@@ -210,13 +200,6 @@ func TestWithThinkingBudget(t *testing.T) {
 		assert.Contains(t, err.Error(), "thinking_budget")
 	})
 
-	t.Run("rejected on Fable 5", func(t *testing.T) {
-		t.Parallel()
-
-		_, err := provider.NewModel(ModelClaudeFable5, WithThinkingBudget(2048))
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "thinking_budget")
-	})
 }
 
 func TestWithEffort(t *testing.T) {
@@ -257,20 +240,6 @@ func TestWithEffort(t *testing.T) {
 		require.True(t, ok)
 		require.NotNil(t, m.config.Effort)
 		assert.Equal(t, EffortMax, *m.config.Effort)
-	})
-
-	t.Run("all effort levels accepted on Fable 5", func(t *testing.T) {
-		t.Parallel()
-
-		for _, effort := range []Effort{EffortLow, EffortMedium, EffortHigh, EffortXHigh, EffortMax} {
-			model, err := provider.NewModel(ModelClaudeFable5, WithEffort(effort))
-			require.NoError(t, err)
-
-			m, ok := model.(*Model)
-			require.True(t, ok)
-			require.NotNil(t, m.config.Effort)
-			assert.Equal(t, effort, *m.config.Effort)
-		}
 	})
 
 	t.Run("rejected on model without effort support", func(t *testing.T) {
@@ -328,38 +297,4 @@ func TestWithSpeed(t *testing.T) {
 		assert.Contains(t, err.Error(), "speed")
 	})
 
-	t.Run("rejected on Fable 5", func(t *testing.T) {
-		t.Parallel()
-
-		_, err := provider.NewModel(ModelClaudeFable5, WithSpeed(SpeedFast))
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "speed")
-	})
-}
-
-func TestFable5SamplingParametersRejected(t *testing.T) {
-	t.Parallel()
-
-	provider, err := NewProvider("test-key")
-	require.NoError(t, err)
-
-	tests := []struct {
-		name string
-		opt  Option
-		want string
-	}{
-		{name: "temperature", opt: WithTemperature(0.5), want: "temperature"},
-		{name: "top_p", opt: WithTopP(0.9), want: "top_p"},
-		{name: "top_k", opt: WithTopK(10), want: "top_k"},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			_, err := provider.NewModel(ModelClaudeFable5, tt.opt)
-			require.Error(t, err)
-			assert.Contains(t, err.Error(), tt.want)
-		})
-	}
 }

--- a/providers/anthropic/models.go
+++ b/providers/anthropic/models.go
@@ -25,7 +25,6 @@ import (
 // These are model family identifiers (non-timestamped). The Anthropic API
 // accepts them directly and resolves to the latest snapshot.
 const (
-	ModelClaudeFable5   = "claude-fable-5"
 	ModelClaudeSonnet46 = "claude-sonnet-4-6"
 	ModelClaudeSonnet45 = "claude-sonnet-4-5"
 	ModelClaudeHaiku45  = "claude-haiku-4-5"
@@ -96,36 +95,6 @@ func resolveModelFamily(model string) string {
 // supportedModels defines all Claude models with their capabilities and constraints.
 // Based on Anthropic API documentation and model specifications.
 var supportedModels = map[string]ModelDefinition{
-	ModelClaudeFable5: {
-		Name:  ModelClaudeFable5,
-		Label: "Claude Fable 5",
-		Capabilities: llm.ModelCapabilities{
-			Streaming:        true,
-			Tools:            true,
-			JSONMode:         false, // Anthropic doesn't have native JSON mode
-			StructuredOutput: false, // Use tool calling for structured output instead
-			Vision:           true,
-			MultiTurn:        true,
-			SystemPrompts:    true,
-			Reasoning:        true, // Adaptive thinking only; use effort to bias toward more/less thinking
-		},
-		Constraints: llm.ModelConstraints{
-			TemperatureRange: [2]float64{0.0, 1.0},
-			MaxInputTokens:   1000000, // 1M context window
-			MaxOutputTokens:  128000,  // 128K output tokens
-			// Fable 5 rejects thinking.type.enabled — thinking budget is not user-controllable.
-			// Use adaptive thinking + effort to bias reasoning depth. No fast mode, so no "speed".
-			SupportedParams:   []string{"max_tokens", "effort"},
-			MutuallyExclusive: [][]string{},
-		},
-		SupportedEfforts: []Effort{EffortLow, EffortMedium, EffortHigh, EffortXHigh, EffortMax},
-		AdaptiveThinking: true,
-		Pricing: pricing.FlatInfoFromRates(
-			// Cache rates derived from Anthropic's prompt-caching multipliers
-			// (5m-write = 1.25x base input, 1h-write = 2x, cache-read = 0.10x).
-			pricing.NewRates(10.00, 50.00, 1.00).WithCacheCreation(12.50, 20.00, 0),
-		),
-	},
 	ModelClaudeOpus48: {
 		Name:  ModelClaudeOpus48,
 		Label: "Claude Opus 4.8",

--- a/providers/bedrock/bedrock_conformance_test.go
+++ b/providers/bedrock/bedrock_conformance_test.go
@@ -16,11 +16,9 @@ package bedrock_test
 
 import (
 	"context"
-	"errors"
 	"os"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/redpanda-data/ai-sdk-go/internal/testsuite"
 	"github.com/redpanda-data/ai-sdk-go/llm"
@@ -103,158 +101,12 @@ func (f *BedrockFixture) Models() []llm.ModelDiscoveryInfo {
 	filtered := make([]llm.ModelDiscoveryInfo, 0, len(all))
 
 	for _, m := range all {
-		// Fable 5 requires Bedrock provider data sharing. Keep the generic
-		// all-model conformance loop on models that CI can fully generate with;
-		// the dedicated Fable integration below still verifies Bedrock wiring by
-		// accepting either a successful response or AWS's explicit Fable access gate.
-		if modelRequiresProviderDataSharing(m) {
-			continue
-		}
-
 		if strings.HasPrefix(m.Name, geoPrefix) {
 			filtered = append(filtered, m)
 		}
 	}
 
 	return filtered
-}
-
-func modelRequiresProviderDataSharing(model llm.ModelDiscoveryInfo) bool {
-	return model.Metadata[bedrock.ModelMetadataRequiresProviderDataSharing] == "true"
-}
-
-func TestModelRequiresProviderDataSharing(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name  string
-		model llm.ModelDiscoveryInfo
-		want  bool
-	}{
-		{
-			name: "Fable 5",
-			model: llm.ModelDiscoveryInfo{
-				Name: bedrock.ModelClaudeFable5US,
-				Metadata: map[string]string{
-					bedrock.ModelMetadataRequiresProviderDataSharing: "true",
-				},
-			},
-			want: true,
-		},
-		{
-			name:  "other Claude",
-			model: llm.ModelDiscoveryInfo{Name: bedrock.ModelClaudeSonnet46US},
-			want:  false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			got := modelRequiresProviderDataSharing(tt.model)
-			if got != tt.want {
-				t.Fatalf("modelRequiresProviderDataSharing(%q) = %v, want %v", tt.model.Name, got, tt.want)
-			}
-		})
-	}
-}
-
-func TestIsProviderDataSharingGate(t *testing.T) {
-	t.Parallel()
-
-	err := &llm.ProviderError{
-		Base:    llm.ErrInvalidInput,
-		Code:    "ValidationException",
-		Message: "provider rejected request because data retention is not enabled",
-	}
-
-	if !isProviderDataSharingGate(err) {
-		t.Fatal("expected provider data sharing gate to be detected")
-	}
-}
-
-func TestIsFableAccessGate(t *testing.T) {
-	t.Parallel()
-
-	err := &llm.ProviderError{
-		Base:    llm.ErrAPICall,
-		Code:    "AccessDeniedException",
-		Message: "access denied",
-	}
-
-	if !isFableAccessGate(err) {
-		t.Fatal("expected Fable access gate to be detected")
-	}
-}
-
-func TestBedrockFable5Invocation_Integration(t *testing.T) {
-	t.Parallel()
-
-	bedrocktest.SkipUnlessAWSCredentials(t)
-
-	region := os.Getenv("AWS_REGION")
-	if region == "" {
-		region = bedrocktest.TestRegion
-	}
-
-	provider, err := bedrock.NewProvider(context.Background(), bedrock.WithRegion(region))
-	if err != nil {
-		t.Fatalf("Failed to create provider: %v", err)
-	}
-
-	model, err := provider.NewModel(bedrock.ModelClaudeFable5, bedrock.WithMaxTokens(16))
-	if err != nil {
-		t.Fatalf("Failed to create Fable 5 model: %v", err)
-	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
-	defer cancel()
-
-	resp, err := model.Generate(ctx, &llm.Request{
-		Messages: []llm.Message{
-			llm.NewMessage(llm.RoleUser, llm.NewTextPart("Reply with ok.")),
-		},
-	})
-	if err != nil {
-		if isFableAccessGate(err) {
-			t.Skipf("Fable 5 reached Bedrock but account is not enabled for Fable access: %v", err)
-		}
-
-		t.Fatalf("Fable 5 Bedrock invocation failed: %v", err)
-	}
-
-	if resp == nil {
-		t.Fatal("Fable 5 Bedrock invocation returned nil response")
-	}
-}
-
-func isProviderDataSharingGate(err error) bool {
-	var providerErr *llm.ProviderError
-	if !errors.As(err, &providerErr) {
-		return false
-	}
-
-	if providerErr.Code != "ValidationException" {
-		return false
-	}
-
-	message := strings.ToLower(providerErr.Message)
-
-	return strings.Contains(message, "data retention") || strings.Contains(message, "provider_data")
-}
-
-func isAccessDeniedGate(providerErr *llm.ProviderError) bool {
-	return providerErr.Code == "AccessDeniedException"
-}
-
-func isFableAccessGate(err error) bool {
-	var providerErr *llm.ProviderError
-	if !errors.As(err, &providerErr) {
-		return false
-	}
-
-	return isProviderDataSharingGate(err) || isAccessDeniedGate(providerErr)
 }
 
 func (f *BedrockFixture) NewModel(modelName string) (llm.Model, error) {

--- a/providers/bedrock/models.go
+++ b/providers/bedrock/models.go
@@ -43,13 +43,6 @@ import (
 // only as building blocks for the prefixed variants and are NOT registered in
 // supportedModels.
 const (
-	// ModelClaudeFable5 is the bare Bedrock ID for Claude Fable 5
-	// (inference-profile-only — invoke via one of the prefixed variants).
-	ModelClaudeFable5       = "anthropic.claude-fable-5"
-	ModelClaudeFable5Global = "global." + ModelClaudeFable5
-	ModelClaudeFable5US     = "us." + ModelClaudeFable5
-	ModelClaudeFable5EU     = "eu." + ModelClaudeFable5
-
 	// ModelClaudeSonnet46 is the bare Bedrock ID for Claude Sonnet 4.6
 	// (inference-profile-only — invoke via one of the prefixed variants).
 	ModelClaudeSonnet46       = "anthropic.claude-sonnet-4-6"
@@ -109,26 +102,11 @@ const (
 
 // ModelDefinition defines a model with its capabilities and constraints.
 type ModelDefinition struct {
-	Name                        string // Real Bedrock model ID (e.g. "us.anthropic.claude-sonnet-4-6")
-	Label                       string
-	Capabilities                llm.ModelCapabilities
-	Constraints                 llm.ModelConstraints
-	Pricing                     pricing.Info
-	RequiresProviderDataSharing bool
-}
-
-// ModelMetadataRequiresProviderDataSharing is set to "true" on discovery
-// metadata for Bedrock models that require provider data sharing.
-const ModelMetadataRequiresProviderDataSharing = "requires_provider_data_sharing"
-
-func (d ModelDefinition) discoveryMetadata() map[string]string {
-	if !d.RequiresProviderDataSharing {
-		return nil
-	}
-
-	return map[string]string{
-		ModelMetadataRequiresProviderDataSharing: "true",
-	}
+	Name         string // Real Bedrock model ID (e.g. "us.anthropic.claude-sonnet-4-6")
+	Label        string
+	Capabilities llm.ModelCapabilities
+	Constraints  llm.ModelConstraints
+	Pricing      pricing.Info
 }
 
 // InferenceProfileRegion maps an AWS region to the Bedrock cross-region
@@ -202,13 +180,6 @@ var (
 		SupportedParams:  []string{"temperature", "top_p", "max_tokens", "stop"},
 	}
 
-	claudeFable5Constraints = llm.ModelConstraints{
-		TemperatureRange: [2]float64{0.0, 1.0},
-		MaxInputTokens:   1000000,
-		MaxOutputTokens:  128000,
-		SupportedParams:  []string{"max_tokens", "stop"},
-	}
-
 	claudeContext200kConstraints = llm.ModelConstraints{
 		TemperatureRange: [2]float64{0.0, 1.0},
 		MaxInputTokens:   200000,
@@ -229,41 +200,6 @@ var (
 //   - global. profiles use the "Global Cross-region Inference" rate, which
 //     is exactly 10% cheaper than the geo rate for the same model.
 var supportedModels = map[string]ModelDefinition{
-	// ----------------------------------------------------------------
-	// Claude Fable 5 — inference-profile-only, no bare entry. Geo
-	// profiles cover us and eu (jp/au are not published).
-	// ----------------------------------------------------------------
-	ModelClaudeFable5Global: {
-		Name:                        ModelClaudeFable5Global,
-		Label:                       "Claude Fable 5 (Global)",
-		Capabilities:                claudeStandardCaps,
-		Constraints:                 claudeFable5Constraints,
-		RequiresProviderDataSharing: true,
-		Pricing: pricing.FlatInfoFromRates(
-			pricing.NewRates(10.00, 50.00, 1.00).WithCacheCreation(12.50, 20.00, 0),
-		),
-	},
-	ModelClaudeFable5US: {
-		Name:                        ModelClaudeFable5US,
-		Label:                       "Claude Fable 5 (US)",
-		Capabilities:                claudeStandardCaps,
-		Constraints:                 claudeFable5Constraints,
-		RequiresProviderDataSharing: true,
-		Pricing: pricing.FlatInfoFromRates(
-			pricing.NewRates(11.00, 55.00, 1.10).WithCacheCreation(13.75, 22.00, 0),
-		),
-	},
-	ModelClaudeFable5EU: {
-		Name:                        ModelClaudeFable5EU,
-		Label:                       "Claude Fable 5 (EU)",
-		Capabilities:                claudeStandardCaps,
-		Constraints:                 claudeFable5Constraints,
-		RequiresProviderDataSharing: true,
-		Pricing: pricing.FlatInfoFromRates(
-			pricing.NewRates(11.00, 55.00, 1.10).WithCacheCreation(13.75, 22.00, 0),
-		),
-	},
-
 	// ----------------------------------------------------------------
 	// Claude Opus 4.8 — inference-profile-only, no bare entry. Geo
 	// profiles cover us, eu, jp (au is not published).

--- a/providers/bedrock/provider.go
+++ b/providers/bedrock/provider.go
@@ -213,7 +213,6 @@ func (p *Provider) Models() []llm.ModelDiscoveryInfo {
 			Label:        def.Label,
 			Capabilities: def.Capabilities,
 			Provider:     p.Name(),
-			Metadata:     def.discoveryMetadata(),
 		})
 	}
 

--- a/providers/bedrock/provider_test.go
+++ b/providers/bedrock/provider_test.go
@@ -108,35 +108,10 @@ func TestLookupModel(t *testing.T) {
 			wantOK: false,
 		},
 		{
-			// The Bedrock catalog registers inference-profile variants so
-			// pricing and routing metadata stay explicit per profile.
-			name:   "Fable 5 bare ID is not in the catalog",
-			input:  ModelClaudeFable5,
-			wantOK: false,
-		},
-		{
 			name:    "geo profile is its own entry",
 			input:   ModelClaudeSonnet46EU,
 			wantOK:  true,
 			wantDef: ModelClaudeSonnet46EU,
-		},
-		{
-			name:    "Fable 5 US profile is its own entry",
-			input:   ModelClaudeFable5US,
-			wantOK:  true,
-			wantDef: ModelClaudeFable5US,
-		},
-		{
-			name:    "Fable 5 EU profile is its own entry",
-			input:   ModelClaudeFable5EU,
-			wantOK:  true,
-			wantDef: ModelClaudeFable5EU,
-		},
-		{
-			name:    "Fable 5 global profile is its own entry",
-			input:   ModelClaudeFable5Global,
-			wantOK:  true,
-			wantDef: ModelClaudeFable5Global,
 		},
 		{
 			name:    "global profile is its own entry",
@@ -317,7 +292,6 @@ func TestNewModel_SupportedModels(t *testing.T) {
 		{"with region prefix", "eu." + ModelClaudeSonnet46},
 		{"opus with region", "global." + ModelClaudeOpus46},
 		{"haiku with region", "eu." + ModelClaudeHaiku45},
-		{"Fable 5 with region prefix", ModelClaudeFable5EU},
 	}
 
 	for _, tt := range tests {
@@ -373,44 +347,6 @@ func TestNewModel_EURegionPrefix(t *testing.T) {
 	m, ok := model.(*Model)
 	require.True(t, ok)
 	assert.Equal(t, "eu."+ModelClaudeSonnet46, m.config.APIModelID)
-}
-
-func TestNewModel_Fable5RegionPrefix(t *testing.T) {
-	t.Parallel()
-
-	p := &Provider{client: nil, region: "us-east-1"}
-
-	model, err := p.NewModel(ModelClaudeFable5)
-	require.NoError(t, err)
-
-	m, ok := model.(*Model)
-	require.True(t, ok)
-	assert.Equal(t, ModelClaudeFable5US, m.config.APIModelID)
-}
-
-func TestNewModel_Fable5SamplingParametersRejected(t *testing.T) {
-	t.Parallel()
-
-	p := &Provider{client: nil, region: "us-east-1"}
-
-	tests := []struct {
-		name string
-		opt  Option
-		want string
-	}{
-		{name: "temperature", opt: WithTemperature(0.5), want: "temperature"},
-		{name: "top_p", opt: WithTopP(0.9), want: "top_p"},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			_, err := p.NewModel(ModelClaudeFable5, tt.opt)
-			require.Error(t, err)
-			assert.Contains(t, err.Error(), tt.want)
-		})
-	}
 }
 
 func TestNewModel_UnsupportedModel(t *testing.T) {
@@ -1026,27 +962,6 @@ func TestModelsDiscovery(t *testing.T) {
 			"Models() should be sorted by Name: %s should come before %s", models[i-1].Name, models[i].Name)
 	}
 }
-
-func TestModelsDiscovery_ProviderDataSharingMetadata(t *testing.T) {
-	t.Parallel()
-
-	p := &Provider{}
-
-	models := p.Models()
-
-	metadataByName := make(map[string]map[string]string, len(models))
-	for _, m := range models {
-		metadataByName[m.Name] = m.Metadata
-	}
-
-	for _, name := range []string{ModelClaudeFable5Global, ModelClaudeFable5US, ModelClaudeFable5EU} {
-		assert.Equal(t, "true", metadataByName[name][ModelMetadataRequiresProviderDataSharing])
-	}
-
-	assert.Empty(t, metadataByName[ModelClaudeSonnet46US])
-}
-
-// ---------- Options validation ----------
 
 func TestWithStop_TooMany(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
## Summary
- remove Claude Fable 5 from Anthropic model constants/catalog
- remove Claude Fable 5 Bedrock catalog entries and special provider-data-sharing metadata
- remove Fable-specific tests and integration coverage

## Context
Anthropic announced on June 12, 2026 that access to Fable 5 and Mythos 5 is being disabled for all customers: https://www.anthropic.com/news/fable-mythos-access

## Tests
- go test ./providers/anthropic ./providers/bedrock
- go test ./...
