### PR TITLE
feat(agenttool): share parent session id with in-process sub-agents

### DIFF
--- a/agent/context.go
+++ b/agent/context.go
@@ -1,0 +1,43 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agent
+
+import "context"
+
+// invocationCtxKey is the unexported key under which the active invocation
+// metadata is stored in a context.
+type invocationCtxKey struct{}
+
+// ContextWithInvocation returns a copy of ctx carrying the given invocation
+// metadata. Agents put their invocation into the context before executing tools
+// so that tools (notably agenttool) can access the calling agent's invocation —
+// for example to share the parent's session id with an in-process sub-agent.
+//
+// A nil invocation returns ctx unchanged.
+func ContextWithInvocation(ctx context.Context, inv *InvocationMetadata) context.Context {
+	if inv == nil {
+		return ctx
+	}
+
+	return context.WithValue(ctx, invocationCtxKey{}, inv)
+}
+
+// InvocationFromContext returns the invocation metadata stored in ctx by
+// ContextWithInvocation, if any. The second return value reports whether an
+// invocation was present.
+func InvocationFromContext(ctx context.Context) (*InvocationMetadata, bool) {
+	inv, ok := ctx.Value(invocationCtxKey{}).(*InvocationMetadata)
+	return inv, ok
+}

--- a/agent/context_test.go
+++ b/agent/context_test.go
@@ -1,0 +1,57 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agent_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/redpanda-data/ai-sdk-go/agent"
+	"github.com/redpanda-data/ai-sdk-go/store/session"
+)
+
+func TestContextWithInvocation_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	inv := agent.NewInvocationMetadata(&session.State{ID: "sess-1"}, agent.Info{Name: "a"})
+
+	ctx := agent.ContextWithInvocation(context.Background(), inv)
+
+	got, ok := agent.InvocationFromContext(ctx)
+	require.True(t, ok)
+	assert.Same(t, inv, got)
+}
+
+func TestInvocationFromContext_Absent(t *testing.T) {
+	t.Parallel()
+
+	got, ok := agent.InvocationFromContext(context.Background())
+	assert.False(t, ok)
+	assert.Nil(t, got)
+}
+
+func TestContextWithInvocation_Nil(t *testing.T) {
+	t.Parallel()
+
+	// A nil invocation must not be stored; the context is returned unchanged.
+	ctx := agent.ContextWithInvocation(context.Background(), nil)
+
+	got, ok := agent.InvocationFromContext(ctx)
+	assert.False(t, ok)
+	assert.Nil(t, got)
+}

--- a/agent/llmagent/llmagent.go
+++ b/agent/llmagent/llmagent.go
@@ -537,6 +537,10 @@ func (a *LLMAgent) executeTools(
 
 	// Create base tool executor
 	baseExecutor := func(ctx context.Context, info *agent.ToolCallInfo) (*llm.ToolResponsePart, error) {
+		// Expose the calling agent's invocation to the tool so tools such as
+		// agenttool can access the parent session (e.g. to share its id with an
+		// in-process sub-agent). Tools that do not read it are unaffected.
+		ctx = agent.ContextWithInvocation(ctx, info.Inv)
 		return a.config.tools.Execute(ctx, info.Req)
 	}
 

--- a/plugins/otel/attributes.go
+++ b/plugins/otel/attributes.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/redpanda-data/ai-sdk-go/agent"
 	"github.com/redpanda-data/ai-sdk-go/plugins/otel/genai"
+	"github.com/redpanda-data/ai-sdk-go/store/session"
 )
 
 // Redpanda-specific and error attributes (not part of OTel Gen AI semconv).
@@ -38,7 +39,38 @@ const (
 	attrToolExecutionDuration = "redpanda.tool.execution.duration"
 	attrToolResultAvailable   = "redpanda.tool.result.available"
 	attrErrorType             = "error.type"
+
+	// Sub-agent linkage attributes. Emitted on a sub-agent's invocation span so
+	// its activity can be told apart from the parent's even though they share a
+	// conversation (session) id.
+	attrAgentIsSidechain        = "redpanda.agent.is_sidechain"
+	attrAgentParentInvocationID = "redpanda.agent.parent_invocation_id"
+	attrAgentPath               = "redpanda.agent.path"
 )
+
+// sidechainAttrs derives sub-agent linkage span attributes from a session's
+// metadata (set by agenttool when a sub-agent shares the parent's session id).
+// Returns nil when the session carries no linkage.
+func sidechainAttrs(s *session.State) []attribute.KeyValue {
+	if s == nil {
+		return nil
+	}
+
+	var attrs []attribute.KeyValue
+	if v, _ := s.Metadata[session.MetadataIsSidechain].(bool); v {
+		attrs = append(attrs, attribute.Bool(attrAgentIsSidechain, true))
+	}
+
+	if v, _ := s.Metadata[session.MetadataParentInvocationID].(string); v != "" {
+		attrs = append(attrs, attribute.String(attrAgentParentInvocationID, v))
+	}
+
+	if v, _ := s.Metadata[session.MetadataAgentPath].(string); v != "" {
+		attrs = append(attrs, attribute.String(attrAgentPath, v))
+	}
+
+	return attrs
+}
 
 // errorTypeToolError is the error.type value for tool-level errors
 // (analogous to MCP isError=true). Per OTel MCP semconv.

--- a/plugins/otel/attributes.go
+++ b/plugins/otel/attributes.go
@@ -43,24 +43,19 @@ const (
 	// Sub-agent linkage attributes. Emitted on a sub-agent's invocation span so
 	// its activity can be told apart from the parent's even though they share a
 	// conversation (session) id.
-	attrAgentIsSidechain        = "redpanda.agent.is_sidechain"
 	attrAgentParentInvocationID = "redpanda.agent.parent_invocation_id"
 	attrAgentPath               = "redpanda.agent.path"
 )
 
-// sidechainAttrs derives sub-agent linkage span attributes from a session's
+// subagentAttrs derives sub-agent linkage span attributes from a session's
 // metadata (set by agenttool when a sub-agent shares the parent's session id).
-// Returns nil when the session carries no linkage.
-func sidechainAttrs(s *session.State) []attribute.KeyValue {
+// Returns nil when the session carries no linkage (i.e. it is not a sub-agent run).
+func subagentAttrs(s *session.State) []attribute.KeyValue {
 	if s == nil {
 		return nil
 	}
 
 	var attrs []attribute.KeyValue
-	if v, _ := s.Metadata[session.MetadataIsSidechain].(bool); v {
-		attrs = append(attrs, attribute.Bool(attrAgentIsSidechain, true))
-	}
-
 	if v, _ := s.Metadata[session.MetadataParentInvocationID].(string); v != "" {
 		attrs = append(attrs, attribute.String(attrAgentParentInvocationID, v))
 	}

--- a/plugins/otel/interceptor.go
+++ b/plugins/otel/interceptor.go
@@ -170,8 +170,8 @@ func (t *TracingInterceptor) startInvocationSpan(
 			attrs = append(attrs, genAIConversationID(session.ID))
 		}
 
-		// Sub-agent linkage (present when this is a shared-session sidechain run).
-		attrs = append(attrs, sidechainAttrs(session)...)
+		// Sub-agent linkage (present when this is a shared-session sub-agent run).
+		attrs = append(attrs, subagentAttrs(session)...)
 	}
 
 	agentSnap := inv.Agent()

--- a/plugins/otel/interceptor.go
+++ b/plugins/otel/interceptor.go
@@ -169,6 +169,9 @@ func (t *TracingInterceptor) startInvocationSpan(
 		if session.ID != "" {
 			attrs = append(attrs, genAIConversationID(session.ID))
 		}
+
+		// Sub-agent linkage (present when this is a shared-session sidechain run).
+		attrs = append(attrs, sidechainAttrs(session)...)
 	}
 
 	agentSnap := inv.Agent()

--- a/store/session/store.go
+++ b/store/session/store.go
@@ -72,6 +72,21 @@ type Store interface {
 	Delete(ctx context.Context, sessionID string) error
 }
 
+// Metadata keys recording parent→sub-agent linkage on a session's Metadata.
+//
+// When a sub-agent is invoked in-process as part of a parent agent's turn it
+// shares the parent's session ID (so the two group into one conversation for
+// tracing/reconstruction). These keys preserve the discriminator and back-
+// reference needed to tell the sub-agent's activity apart from the parent's.
+const (
+	// MetadataIsSidechain (bool) marks the session as a sub-agent (sidechain) run.
+	MetadataIsSidechain = "is_sidechain"
+	// MetadataParentInvocationID (string) references the parent agent's invocation ID.
+	MetadataParentInvocationID = "parent_invocation_id"
+	// MetadataAgentPath (string) identifies which sub-agent produced the session.
+	MetadataAgentPath = "agent_path"
+)
+
 // State represents the persistent state of a conversation session.
 //
 // The Messages slice contains the conversation history excluding any system prompts,

--- a/store/session/store.go
+++ b/store/session/store.go
@@ -76,11 +76,10 @@ type Store interface {
 //
 // When a sub-agent is invoked in-process as part of a parent agent's turn it
 // shares the parent's session ID (so the two group into one conversation for
-// tracing/reconstruction). These keys preserve the discriminator and back-
-// reference needed to tell the sub-agent's activity apart from the parent's.
+// tracing/reconstruction). These keys carry the back-reference and identity
+// needed to tell the sub-agent's activity apart from the parent's. Their
+// presence is itself the signal that a session is a sub-agent run.
 const (
-	// MetadataIsSidechain (bool) marks the session as a sub-agent (sidechain) run.
-	MetadataIsSidechain = "is_sidechain"
 	// MetadataParentInvocationID (string) references the parent agent's invocation ID.
 	MetadataParentInvocationID = "parent_invocation_id"
 	// MetadataAgentPath (string) identifies which sub-agent produced the session.

--- a/tool/agenttool/agenttool.go
+++ b/tool/agenttool/agenttool.go
@@ -123,7 +123,6 @@ func (at *AgentTool) Execute(ctx context.Context, args json.RawMessage) (json.Ra
 	// linkage needed to reconstruct the parent→sub-agent tree.
 	if parent, ok := agent.InvocationFromContext(ctx); ok && parent.Session() != nil {
 		sessionID = parent.Session().ID
-		metadata[session.MetadataIsSidechain] = true
 		metadata[session.MetadataParentInvocationID] = parent.InvocationID()
 		metadata[session.MetadataAgentPath] = info.Name
 	}

--- a/tool/agenttool/agenttool.go
+++ b/tool/agenttool/agenttool.go
@@ -97,17 +97,41 @@ type Result struct {
 //   - Token usage is tracked separately via interceptors on the agent
 //
 // Session Isolation:
-//   - Each invocation creates a fresh session (no context sharing)
-//   - This prevents context pollution and keeps parent/child boundaries clear
+//   - The sub-agent always runs with a fresh, in-memory Messages slice and its
+//     state is never loaded or persisted, so it cannot observe the parent's
+//     conversation history. Context is isolated regardless of the session id.
 //   - For context sharing, pass relevant information explicitly in args
+//
+// Session ID:
+//   - When invoked as part of a parent agent's turn (the parent invocation is
+//     present in ctx), the sub-agent shares the parent's session id so the two
+//     group into one conversation for tracing/reconstruction, and linkage is
+//     recorded in session metadata (see the Metadata* constants). Isolation is
+//     preserved because the Messages slice is still built fresh and never loaded.
+//   - Otherwise a unique session id is minted, preserving the previous behavior.
 func (at *AgentTool) Execute(ctx context.Context, args json.RawMessage) (json.RawMessage, error) {
 	info := at.agent.Info()
 
-	// 1. Create fresh session with unique ID to prevent collisions in state stores
+	// 1. Determine the session id and linkage. Default to a freshly minted,
+	// unique id (used when there is no parent invocation in context, e.g. the
+	// agent tool is invoked outside of a parent agent turn).
+	sessionID := fmt.Sprintf("agent-tool-%s-%d", info.Name, time.Now().UnixNano())
+	metadata := map[string]any{}
+
+	// When the parent invocation is available, share its session id so the
+	// sub-agent groups with the parent in tracing/observability, and stamp the
+	// linkage needed to reconstruct the parent→sub-agent tree.
+	if parent, ok := agent.InvocationFromContext(ctx); ok && parent.Session() != nil {
+		sessionID = parent.Session().ID
+		metadata[session.MetadataIsSidechain] = true
+		metadata[session.MetadataParentInvocationID] = parent.InvocationID()
+		metadata[session.MetadataAgentPath] = info.Name
+	}
+
 	sess := &session.State{
-		ID:       fmt.Sprintf("agent-tool-%s-%d", info.Name, time.Now().UnixNano()),
+		ID:       sessionID,
 		Messages: []llm.Message{},
-		Metadata: map[string]any{},
+		Metadata: metadata,
 	}
 
 	// 2. Convert args to user message

--- a/tool/agenttool/agenttool.go
+++ b/tool/agenttool/agenttool.go
@@ -127,6 +127,11 @@ func (at *AgentTool) Execute(ctx context.Context, args json.RawMessage) (json.Ra
 		metadata[session.MetadataAgentPath] = info.Name
 	}
 
+	// NOTE: when shared with the parent (above), this id is no longer unique
+	// across the parent and concurrent sub-agents. That is safe ONLY because this
+	// session is never loaded or persisted — it runs in memory via at.agent.Run.
+	// If a store is ever introduced on this path, key it on the unique invocation
+	// id / agent_path, not this (now non-unique) session id.
 	sess := &session.State{
 		ID:       sessionID,
 		Messages: []llm.Message{},

--- a/tool/agenttool/shared_session_test.go
+++ b/tool/agenttool/shared_session_test.go
@@ -78,8 +78,8 @@ func TestExecute_SharesParentSessionID(t *testing.T) {
 	// Shares the parent's session id for conversation grouping.
 	assert.Equal(t, "parent-sess-123", child.gotSessionID)
 
-	// Linkage metadata records the discriminator + back-reference.
-	assert.Equal(t, true, child.gotMetadata[session.MetadataIsSidechain])
+	// Linkage metadata records the back-reference + sub-agent identity; its
+	// presence is the signal that this is a sub-agent run.
 	assert.Equal(t, parentInv.InvocationID(), child.gotMetadata[session.MetadataParentInvocationID])
 	assert.Equal(t, "search", child.gotMetadata[session.MetadataAgentPath])
 }

--- a/tool/agenttool/shared_session_test.go
+++ b/tool/agenttool/shared_session_test.go
@@ -1,0 +1,137 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agenttool_test
+
+import (
+	"context"
+	"encoding/json"
+	"iter"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/redpanda-data/ai-sdk-go/agent"
+	"github.com/redpanda-data/ai-sdk-go/llm"
+	"github.com/redpanda-data/ai-sdk-go/store/session"
+	"github.com/redpanda-data/ai-sdk-go/tool/agenttool"
+)
+
+// capturingAgent records the session it is invoked with, so tests can assert on
+// the session id, messages, and metadata that agenttool builds for the child.
+type capturingAgent struct {
+	mockAgent
+
+	gotSessionID string
+	gotMessages  []llm.Message
+	gotMetadata  map[string]any
+}
+
+func (m *capturingAgent) Run(_ context.Context, inv *agent.InvocationMetadata) iter.Seq2[agent.Event, error] {
+	return func(yield func(agent.Event, error) bool) {
+		s := inv.Session()
+		m.gotSessionID = s.ID
+		m.gotMessages = s.Messages
+		m.gotMetadata = s.Metadata
+
+		msg := llm.NewMessage(llm.RoleAssistant, llm.NewTextPart(m.response))
+		if !yield(agent.MessageEvent{Response: llm.Response{Message: msg}}, nil) {
+			return
+		}
+
+		yield(agent.InvocationEndEvent{FinishReason: agent.FinishReasonStop}, nil)
+	}
+}
+
+func parentContext(id string, messages ...llm.Message) (context.Context, *agent.InvocationMetadata) {
+	parentSess := &session.State{ID: id, Messages: messages}
+	parentInv := agent.NewInvocationMetadata(parentSess, agent.Info{Name: "root"})
+
+	return agent.ContextWithInvocation(context.Background(), parentInv), parentInv
+}
+
+func TestExecute_SharesParentSessionID(t *testing.T) {
+	t.Parallel()
+
+	ctx, parentInv := parentContext("parent-sess-123",
+		llm.NewMessage(llm.RoleUser, llm.NewTextPart("parent secret")))
+
+	child := &capturingAgent{mockAgent: mockAgent{name: "search", response: "ok"}}
+	at := agenttool.New(child)
+
+	_, err := at.Execute(ctx, json.RawMessage(`{"query":"x"}`))
+	require.NoError(t, err)
+
+	// Shares the parent's session id for conversation grouping.
+	assert.Equal(t, "parent-sess-123", child.gotSessionID)
+
+	// Linkage metadata records the discriminator + back-reference.
+	assert.Equal(t, true, child.gotMetadata[session.MetadataIsSidechain])
+	assert.Equal(t, parentInv.InvocationID(), child.gotMetadata[session.MetadataParentInvocationID])
+	assert.Equal(t, "search", child.gotMetadata[session.MetadataAgentPath])
+}
+
+func TestExecute_ContextIsolatedDespiteSharedID(t *testing.T) {
+	t.Parallel()
+
+	ctx, _ := parentContext("parent-sess-123",
+		llm.NewMessage(llm.RoleUser, llm.NewTextPart("parent secret")))
+
+	child := &capturingAgent{mockAgent: mockAgent{name: "search", response: "ok"}}
+	at := agenttool.New(child)
+
+	_, err := at.Execute(ctx, json.RawMessage(`{"query":"x"}`))
+	require.NoError(t, err)
+
+	// The sub-agent must NOT observe the parent's history: exactly the args
+	// message and nothing from the parent.
+	require.Len(t, child.gotMessages, 1)
+	assert.JSONEq(t, `{"query":"x"}`, child.gotMessages[0].TextContent())
+}
+
+func TestExecute_NoParentInvocation_MintsUniqueID(t *testing.T) {
+	t.Parallel()
+
+	child := &capturingAgent{mockAgent: mockAgent{name: "search", response: "ok"}}
+	at := agenttool.New(child)
+
+	_, err := at.Execute(context.Background(), json.RawMessage(`{}`))
+	require.NoError(t, err)
+
+	// Falls back to the previous behavior: a freshly minted, unique id.
+	assert.True(t, strings.HasPrefix(child.gotSessionID, "agent-tool-search-"),
+		"got %q", child.gotSessionID)
+	// No linkage metadata when there is no parent.
+	assert.Empty(t, child.gotMetadata)
+}
+
+func TestExecute_ParentWithNilSession_MintsUniqueID(t *testing.T) {
+	t.Parallel()
+
+	// Invocation present in ctx, but it has no session.
+	parentInv := agent.NewInvocationMetadata(nil, agent.Info{Name: "root"})
+	ctx := agent.ContextWithInvocation(context.Background(), parentInv)
+
+	child := &capturingAgent{mockAgent: mockAgent{name: "search", response: "ok"}}
+	at := agenttool.New(child)
+
+	_, err := at.Execute(ctx, json.RawMessage(`{}`))
+	require.NoError(t, err)
+
+	assert.True(t, strings.HasPrefix(child.gotSessionID, "agent-tool-search-"),
+		"got %q", child.gotSessionID)
+	assert.Empty(t, child.gotMetadata)
+}


### PR DESCRIPTION
## What

In-process sub-agents (`agenttool`) minted a fresh `agent-tool-<name>-<nano>` session id per call, so the OTel conversation id differed from the parent and the two appeared as **separate conversations** in session-oriented observability (e.g. Langfuse) — even though the trace tree is already connected via `ctx` propagation.

This makes an `agenttool` sub-agent **share its parent's session id** when invoked as part of a parent agent's turn, so the two group into one conversation for tracing/reconstruction. Context stays fully isolated.

## How

- **`agent`**: new `ContextWithInvocation` / `InvocationFromContext` — the missing channel that lets a tool see its parent invocation. `llmagent.executeTools` injects the invocation into `ctx` before executing tools (additive; tools that don't read it are unaffected).
- **`agenttool`**: when a parent invocation is in `ctx`, the sub-agent shares the parent's session id and stamps linkage (`parent_invocation_id`, `agent_path`) into session metadata. Falls back to the previous minted id when there is no parent invocation.
- **`store/session`**: canonical `Metadata*` linkage key constants (single source of truth).
- **`plugins/otel`**: emits `redpanda.agent.parent_invocation_id` / `redpanda.agent.path` span attributes on the invocation span.

## Isolation & safety

- Isolation is preserved: the sub-agent's `Messages` are still built **fresh in memory and never loaded**, so it cannot observe the parent's history — sharing the id only affects grouping, not context.
- The sub-agent path never persists (no Runner, no store on `llmagent`), so the shared id is safe as a non-storage-key. A code comment records the guard: if persistence is ever added on this path, key on the unique invocation id / `agent_path`, **not** the shared session id.

## Linkage surface (maps to Claude's model)

| Concern | Field | Claude analog |
|---|---|---|
| Grouping | shared `session.ID` | `sessionId` |
| Per-sub-agent identity | child `InvocationID` | `agentId` |
| Parent back-reference | `parent_invocation_id` | `parentUuid` / `toolUseId` |

(An earlier `is_sidechain` boolean was dropped — it was Claude-internal jargon and redundant with `parent_invocation_id`, whose presence is itself the sub-agent signal.)

## Tests

`agent/context_test.go` and `tool/agenttool/shared_session_test.go` cover: round-trip ctx helpers, shared id, **context isolation despite shared id**, no-parent fallback, and nil-session fallback. Existing `agent`/`llmagent`/`otel`/`runner` suites pass; `go vet`, `golangci-lint`, `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)