### PR TITLE
test: unbreak Anthropic conformance for decommissioned/gated models

### DIFF
--- a/providers/conformance/suite.go
+++ b/providers/conformance/suite.go
@@ -17,6 +17,7 @@ package conformance
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
@@ -1517,6 +1518,11 @@ func testAllSupportedModels(t *testing.T, fixture Fixture) { //nolint:thelper //
 				}
 
 				resp, err := model.Generate(t.Context(), reqObj)
+				if err != nil && isModelAccessGate(err) {
+					t.Skipf("Skipping model %s: not available to this account: %v", modelName, err)
+					return
+				}
+
 				require.NoError(t, err)
 
 				require.NotNil(t, resp)
@@ -1530,4 +1536,19 @@ func testAllSupportedModels(t *testing.T, fixture Fixture) { //nolint:thelper //
 			})
 		}
 	})
+}
+
+// isModelAccessGate reports whether err indicates the model exists in the
+// provider's catalog but is not accessible to the test account. For example,
+// Anthropic returns a 404 not_found_error with "<model> is not available" for
+// gated models such as Fable 5 (which requires Mythos access). Such models
+// should be skipped rather than failing conformance, while accounts that do
+// have access still exercise them.
+func isModelAccessGate(err error) bool {
+	var perr *llm.ProviderError
+	if !errors.As(err, &perr) {
+		return false
+	}
+
+	return strings.Contains(perr.Message, "is not available")
 }

--- a/providers/openaicompat/openaicompattest/constants.go
+++ b/providers/openaicompat/openaicompattest/constants.go
@@ -30,7 +30,7 @@ const (
 	// AnthropicDefaultBaseURL is the Anthropic OpenAI-compatible endpoint.
 	AnthropicDefaultBaseURL = "https://api.anthropic.com/v1"
 	// AnthropicDefaultModel is the default model for Anthropic compat tests.
-	AnthropicDefaultModel = "claude-sonnet-4-20250514"
+	AnthropicDefaultModel = "claude-sonnet-4-6"
 
 	// GoogleDefaultBaseURL is the Google Gemini OpenAI-compatible endpoint.
 	GoogleDefaultBaseURL = "https://generativelanguage.googleapis.com/v1beta/openai/"


### PR DESCRIPTION
## Summary

Fixes two integration-test failures seen in CI (e.g. [this run](https://github.com/redpanda-data/ai-sdk-go/actions/runs/27669645845/job/81830924533)). Both are caused by model-availability changes on the Anthropic API, not code regressions.

### 1. `TestOpenAICompatProviders/Anthropic`
The test pinned `claude-sonnet-4-20250514`, which the Anthropic API now rejects with `not_found_error` (decommissioned). Bumped to `claude-sonnet-4-6`.

That ID only ever lived in the `openaicompattest` constant — it was never an entry in the Anthropic model catalog (which starts at Sonnet 4.5), and the `openaicompat` provider passes model strings straight through without catalog validation. So the constant was the only consumer; no catalog cleanup needed.

### 2. `TestAnthropicConformance_Integration/.../model_claude-fable-5`
Anthropic now gates Fable 5 behind Mythos access:

> `404 not_found_error: "Claude Fable 5 is not available. Please use Opus 4.8."`

`TestAllSupportedModels` iterates the full provider catalog and 404s on `claude-fable-5` for accounts without access. Added an `isModelAccessGate` helper to the conformance suite that **skips** a catalog model the test account isn't entitled to, rather than failing — mirroring the existing Bedrock `isFableAccessGate` skip. Accounts that *do* have Fable access still exercise it.

## Testing

Ran the affected integration tests against the live Anthropic API:

- `TestOpenAICompatProviders/Anthropic` → **PASS**
- `TestAnthropicConformance_Integration/TestAllSupportedModels` → **PASS**, with `claude-fable-5` **SKIP**ped (clear reason) and all other models (Opus 4.8/4.7/4.6/4.5/4.1, Sonnet 4.6/4.5, Haiku 4.5) passing.

`golangci-lint run --new-from-rev=origin/main` reports 0 issues in the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)