### PR TITLE
build(deps): bump a2a-go v0.3.10 -> v0.3.15

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ ignore ./build
 ignore ./examples
 
 require (
-	github.com/a2aproject/a2a-go v0.3.10
+	github.com/a2aproject/a2a-go v0.3.15
 	github.com/anthropics/anthropic-sdk-go v1.27.1
 	github.com/aws/aws-sdk-go-v2 v1.41.7
 	github.com/aws/aws-sdk-go-v2/config v1.32.12

--- a/go.sum
+++ b/go.sum
@@ -32,8 +32,8 @@ github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA
 github.com/PuerkitoBio/goquery v1.9.2/go.mod h1:GHPCaP0ODyyxqcNoFGYlAprUFH81NuRPd0GX3Zu2Mvk=
 github.com/PuerkitoBio/goquery v1.12.0 h1:pAcL4g3WRXekcB9AU/y1mbKez2dbY2AajVhtkO8RIBo=
 github.com/PuerkitoBio/goquery v1.12.0/go.mod h1:802ej+gV2y7bbIhOIoPY5sT183ZW0YFofScC4q/hIpQ=
-github.com/a2aproject/a2a-go v0.3.10 h1:oiwxhxe6HlJiYupASW04aHixZeiZq1Y/fha2N1EWJyI=
-github.com/a2aproject/a2a-go v0.3.10/go.mod h1:I7Cm+a1oL+UT6zMoP+roaRE5vdfUa1iQGVN8aSOuZ0I=
+github.com/a2aproject/a2a-go v0.3.15 h1:h5YpCiPq3jxQ5rIns7oDjPag3ivP8u817AzdA4F+NiI=
+github.com/a2aproject/a2a-go v0.3.15/go.mod h1:I7Cm+a1oL+UT6zMoP+roaRE5vdfUa1iQGVN8aSOuZ0I=
 github.com/ajstarks/deck v0.0.0-20200831202436-30c9fc6549a9/go.mod h1:JynElWSGnm/4RlzPXRlREEwqTHAN3T56Bv2ITsFT3gY=
 github.com/ajstarks/deck/generate v0.0.0-20210309230005-c3f852c02e19/go.mod h1:T13YZdzov6OU0A1+RfKZiZN9ca6VeKdBdyDV+BY97Tk=
 github.com/ajstarks/svgo v0.0.0-20211024235047-1546f124cd8b h1:slYM766cy2nI3BwyRiyQj/Ud48djTMtMebDqepE95rw=


### PR DESCRIPTION
## What

Bump `github.com/a2aproject/a2a-go` from **v0.3.10 → v0.3.15** (latest stable v0.3.x). Diff is one line in `go.mod` plus the two checksum lines in `go.sum` — no source changes.

## Why

v0.3.11–v0.3.15 fix correctness/race issues in the a2a-go server runtime that **drives this repo's `adapter/a2a` `Executor` and `KVTaskStore`** — i.e. the exact paths this adapter exercises:

- **v0.3.15** — fix an `input_required` resumption race during execution cleanup.
- **v0.3.13** — harden concurrent-cancellation cleanup + panic handling, fix `TaskStore.Save` no-data correctness, and fix an infinite JSON-RPC SSE loop on panic in the streaming path.

These are part of the A2A spec-0.3 generation, so the protocol data model is unchanged and the change is contract-compatible with the spec-0.3 A2A clients that talk to it (e.g. ADP UI on `@a2a-js/sdk` 0.3.x). v1.0.0-alpha is intentionally **not** adopted — it would require migrating the `a2asrv` interface implementations and is still pre-release.

## Verification

```
go build ./...            # Success
go vet ./adapter/a2a/...  # No issues found
go test ./adapter/a2a/... # 41 passed in 2 packages
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
