### PR TITLE
feat(agenttool): group in-process sub-agents by conversation id (not shared session id)

### DIFF
--- a/agent/context.go
+++ b/agent/context.go
@@ -1,0 +1,43 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agent
+
+import "context"
+
+// invocationCtxKey is the unexported key under which the active invocation
+// metadata is stored in a context.
+type invocationCtxKey struct{}
+
+// ContextWithInvocation returns a copy of ctx carrying the given invocation
+// metadata. Agents put their invocation into the context before executing tools
+// so that tools (notably agenttool) can access the calling agent's invocation —
+// for example to share the parent's session id with an in-process sub-agent.
+//
+// A nil invocation returns ctx unchanged.
+func ContextWithInvocation(ctx context.Context, inv *InvocationMetadata) context.Context {
+	if inv == nil {
+		return ctx
+	}
+
+	return context.WithValue(ctx, invocationCtxKey{}, inv)
+}
+
+// InvocationFromContext returns the invocation metadata stored in ctx by
+// ContextWithInvocation, if any. The second return value reports whether an
+// invocation was present.
+func InvocationFromContext(ctx context.Context) (*InvocationMetadata, bool) {
+	inv, ok := ctx.Value(invocationCtxKey{}).(*InvocationMetadata)
+	return inv, ok
+}

--- a/agent/context_test.go
+++ b/agent/context_test.go
@@ -1,0 +1,57 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agent_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/redpanda-data/ai-sdk-go/agent"
+	"github.com/redpanda-data/ai-sdk-go/store/session"
+)
+
+func TestContextWithInvocation_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	inv := agent.NewInvocationMetadata(&session.State{ID: "sess-1"}, agent.Info{Name: "a"})
+
+	ctx := agent.ContextWithInvocation(context.Background(), inv)
+
+	got, ok := agent.InvocationFromContext(ctx)
+	require.True(t, ok)
+	assert.Same(t, inv, got)
+}
+
+func TestInvocationFromContext_Absent(t *testing.T) {
+	t.Parallel()
+
+	got, ok := agent.InvocationFromContext(context.Background())
+	assert.False(t, ok)
+	assert.Nil(t, got)
+}
+
+func TestContextWithInvocation_Nil(t *testing.T) {
+	t.Parallel()
+
+	// A nil invocation must not be stored; the context is returned unchanged.
+	ctx := agent.ContextWithInvocation(context.Background(), nil)
+
+	got, ok := agent.InvocationFromContext(ctx)
+	assert.False(t, ok)
+	assert.Nil(t, got)
+}

--- a/agent/llmagent/llmagent.go
+++ b/agent/llmagent/llmagent.go
@@ -554,6 +554,10 @@ func (a *LLMAgent) executeTools(
 
 	// Create base tool executor
 	baseExecutor := func(ctx context.Context, info *agent.ToolCallInfo) (*llm.ToolResponsePart, error) {
+		// Expose the calling agent's invocation to the tool so tools such as
+		// agenttool can access the parent session (e.g. to share its id with an
+		// in-process sub-agent). Tools that do not read it are unaffected.
+		ctx = agent.ContextWithInvocation(ctx, info.Inv)
 		return a.config.tools.Execute(ctx, info.Req)
 	}
 

--- a/plugins/otel/attributes.go
+++ b/plugins/otel/attributes.go
@@ -39,32 +39,17 @@ const (
 	attrToolExecutionDuration = "redpanda.tool.execution.duration"
 	attrToolResultAvailable   = "redpanda.tool.result.available"
 	attrErrorType             = "error.type"
-
-	// Sub-agent linkage attributes. Emitted on a sub-agent's invocation span so
-	// its activity can be told apart from the parent's even though they share a
-	// conversation (session) id.
-	attrAgentParentInvocationID = "redpanda.agent.parent_invocation_id"
-	attrAgentPath               = "redpanda.agent.path"
 )
 
-// subagentAttrs derives sub-agent linkage span attributes from a session's
-// metadata (set by agenttool when a sub-agent shares the parent's session id).
-// Returns nil when the session carries no linkage (i.e. it is not a sub-agent run).
-func subagentAttrs(s *session.State) []attribute.KeyValue {
-	if s == nil {
-		return nil
-	}
-
-	var attrs []attribute.KeyValue
-	if v, _ := s.Metadata[session.MetadataParentInvocationID].(string); v != "" {
-		attrs = append(attrs, attribute.String(attrAgentParentInvocationID, v))
-	}
-
-	if v, _ := s.Metadata[session.MetadataAgentPath].(string); v != "" {
-		attrs = append(attrs, attribute.String(attrAgentPath, v))
-	}
-
-	return attrs
+// conversationID resolves the conversation grouping id for a session
+// (gen_ai.conversation.id). For a sub-agent it is the parent/root conversation
+// id recorded in metadata, so the whole parent→sub-agent tree groups under one
+// conversation; otherwise it is the session's own id. Empty for a nil session.
+//
+// This keeps grouping decoupled from the storage session id: the id stays
+// globally unique while grouping is a derived value used only by telemetry.
+func conversationID(s *session.State) string {
+	return session.ConversationID(s)
 }
 
 // errorTypeToolError is the error.type value for tool-level errors

--- a/plugins/otel/attributes.go
+++ b/plugins/otel/attributes.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/redpanda-data/ai-sdk-go/agent"
 	"github.com/redpanda-data/ai-sdk-go/plugins/otel/genai"
+	"github.com/redpanda-data/ai-sdk-go/store/session"
 )
 
 // Redpanda-specific and error attributes (not part of OTel Gen AI semconv).
@@ -38,7 +39,38 @@ const (
 	attrToolExecutionDuration = "redpanda.tool.execution.duration"
 	attrToolResultAvailable   = "redpanda.tool.result.available"
 	attrErrorType             = "error.type"
+
+	// Sub-agent linkage attributes. Emitted on a sub-agent's invocation span so
+	// its activity can be told apart from the parent's even though they share a
+	// conversation (session) id.
+	attrAgentIsSidechain        = "redpanda.agent.is_sidechain"
+	attrAgentParentInvocationID = "redpanda.agent.parent_invocation_id"
+	attrAgentPath               = "redpanda.agent.path"
 )
+
+// sidechainAttrs derives sub-agent linkage span attributes from a session's
+// metadata (set by agenttool when a sub-agent shares the parent's session id).
+// Returns nil when the session carries no linkage.
+func sidechainAttrs(s *session.State) []attribute.KeyValue {
+	if s == nil {
+		return nil
+	}
+
+	var attrs []attribute.KeyValue
+	if v, _ := s.Metadata[session.MetadataIsSidechain].(bool); v {
+		attrs = append(attrs, attribute.Bool(attrAgentIsSidechain, true))
+	}
+
+	if v, _ := s.Metadata[session.MetadataParentInvocationID].(string); v != "" {
+		attrs = append(attrs, attribute.String(attrAgentParentInvocationID, v))
+	}
+
+	if v, _ := s.Metadata[session.MetadataAgentPath].(string); v != "" {
+		attrs = append(attrs, attribute.String(attrAgentPath, v))
+	}
+
+	return attrs
+}
 
 // errorTypeToolError is the error.type value for tool-level errors
 // (analogous to MCP isError=true). Per OTel MCP semconv.

--- a/plugins/otel/attributes.go
+++ b/plugins/otel/attributes.go
@@ -99,7 +99,10 @@ type SpanContext struct {
 	// SpanName is the computed span name (e.g., "invoke_agent my-assistant").
 	SpanName string
 
-	// SessionID is the session/conversation identifier.
+	// SessionID is the conversation grouping id for the span
+	// (gen_ai.conversation.id): for a sub-agent it is the parent/root
+	// conversation id, NOT the sub-agent's own (unique) storage session id.
+	// See session.ConversationID. Use Inv.Session().ID for the storage id.
 	// Empty string if no session is available.
 	SessionID string
 

--- a/plugins/otel/attributes.go
+++ b/plugins/otel/attributes.go
@@ -43,24 +43,19 @@ const (
 	// Sub-agent linkage attributes. Emitted on a sub-agent's invocation span so
 	// its activity can be told apart from the parent's even though they share a
 	// conversation (session) id.
-	attrAgentIsSidechain        = "redpanda.agent.is_sidechain"
 	attrAgentParentInvocationID = "redpanda.agent.parent_invocation_id"
 	attrAgentPath               = "redpanda.agent.path"
 )
 
-// sidechainAttrs derives sub-agent linkage span attributes from a session's
+// subagentAttrs derives sub-agent linkage span attributes from a session's
 // metadata (set by agenttool when a sub-agent shares the parent's session id).
-// Returns nil when the session carries no linkage.
-func sidechainAttrs(s *session.State) []attribute.KeyValue {
+// Returns nil when the session carries no linkage (i.e. it is not a sub-agent run).
+func subagentAttrs(s *session.State) []attribute.KeyValue {
 	if s == nil {
 		return nil
 	}
 
 	var attrs []attribute.KeyValue
-	if v, _ := s.Metadata[session.MetadataIsSidechain].(bool); v {
-		attrs = append(attrs, attribute.Bool(attrAgentIsSidechain, true))
-	}
-
 	if v, _ := s.Metadata[session.MetadataParentInvocationID].(string); v != "" {
 		attrs = append(attrs, attribute.String(attrAgentParentInvocationID, v))
 	}

--- a/plugins/otel/interceptor.go
+++ b/plugins/otel/interceptor.go
@@ -166,12 +166,11 @@ func (t *TracingInterceptor) startInvocationSpan(
 
 	session := inv.Session()
 	if session != nil {
-		if session.ID != "" {
-			attrs = append(attrs, genAIConversationID(session.ID))
+		// Group under the conversation id (the parent/root for a sub-agent),
+		// not necessarily this session's own (unique) storage id.
+		if cid := conversationID(session); cid != "" {
+			attrs = append(attrs, genAIConversationID(cid))
 		}
-
-		// Sub-agent linkage (present when this is a shared-session sub-agent run).
-		attrs = append(attrs, subagentAttrs(session)...)
 	}
 
 	agentSnap := inv.Agent()
@@ -221,15 +220,12 @@ func (t *TracingInterceptor) startInvocationSpan(
 
 	// Call attribute injector if configured (before span creation for sampling)
 	if t.cfg.attributeInjector != nil {
-		var sessionID string
-		if session != nil {
-			sessionID = session.ID
-		}
-
+		// Expose the conversation grouping id (parent/root for a sub-agent) so
+		// session-oriented sinks (e.g. langfuse.session.id) group the tree.
 		spanCtx := SpanContext{
 			SpanType:  SpanTypeInvocation,
 			SpanName:  spanName,
-			SessionID: sessionID,
+			SessionID: conversationID(session),
 			Inv:       inv,
 		}
 

--- a/plugins/otel/interceptor.go
+++ b/plugins/otel/interceptor.go
@@ -170,8 +170,8 @@ func (t *TracingInterceptor) startInvocationSpan(
 			attrs = append(attrs, genAIConversationID(session.ID))
 		}
 
-		// Sub-agent linkage (present when this is a shared-session sidechain run).
-		attrs = append(attrs, sidechainAttrs(session)...)
+		// Sub-agent linkage (present when this is a shared-session sub-agent run).
+		attrs = append(attrs, subagentAttrs(session)...)
 	}
 
 	agentSnap := inv.Agent()

--- a/plugins/otel/interceptor.go
+++ b/plugins/otel/interceptor.go
@@ -169,6 +169,9 @@ func (t *TracingInterceptor) startInvocationSpan(
 		if session.ID != "" {
 			attrs = append(attrs, genAIConversationID(session.ID))
 		}
+
+		// Sub-agent linkage (present when this is a shared-session sidechain run).
+		attrs = append(attrs, sidechainAttrs(session)...)
 	}
 
 	agentSnap := inv.Agent()

--- a/plugins/otel/interceptor.go
+++ b/plugins/otel/interceptor.go
@@ -221,7 +221,7 @@ func (t *TracingInterceptor) startInvocationSpan(
 	// Call attribute injector if configured (before span creation for sampling)
 	if t.cfg.attributeInjector != nil {
 		// Expose the conversation grouping id (parent/root for a sub-agent) so
-		// session-oriented sinks (e.g. langfuse.session.id) group the tree.
+		// session-oriented sinks group the tree.
 		spanCtx := SpanContext{
 			SpanType:  SpanTypeInvocation,
 			SpanName:  spanName,

--- a/plugins/otel/model.go
+++ b/plugins/otel/model.go
@@ -34,11 +34,9 @@ func (t *TracingInterceptor) InterceptModel(
 	next agent.ModelCallHandler,
 ) agent.ModelCallHandler {
 	// Pass the context through - it already has the invocation span as parent
-	// from InterceptTurn calling next(ctx, info)
-	convID := ""
-	if session := info.InvocationMetadata.Session(); session != nil {
-		convID = session.ID
-	}
+	// from InterceptTurn calling next(ctx, info). Group under the conversation
+	// id (the parent/root for a sub-agent), not the unique storage session id.
+	convID := conversationID(info.InvocationMetadata.Session())
 
 	return &tracingModelHandler{
 		tracer:    t.tracer,

--- a/plugins/otel/options.go
+++ b/plugins/otel/options.go
@@ -138,8 +138,8 @@ func WithRecordToolDefinitions(enabled bool) Option {
 //
 // Note that SpanContext.SessionID carries the conversation grouping id: for an
 // in-process sub-agent it is the parent/root conversation id, not the
-// sub-agent's own storage session id, so session-oriented sinks (like the
-// langfuse.session.id above) group the whole parent→sub-agent tree together.
+// sub-agent's own storage session id, so session-oriented sinks group the
+// whole parent→sub-agent tree together.
 //
 // Important notes:
 //   - The injector must be thread-safe (tools may execute concurrently)

--- a/plugins/otel/options.go
+++ b/plugins/otel/options.go
@@ -136,6 +136,11 @@ func WithRecordToolDefinitions(enabled bool) Option {
 //	    }),
 //	)
 //
+// Note that SpanContext.SessionID carries the conversation grouping id: for an
+// in-process sub-agent it is the parent/root conversation id, not the
+// sub-agent's own storage session id, so session-oriented sinks (like the
+// langfuse.session.id above) group the whole parent→sub-agent tree together.
+//
 // Important notes:
 //   - The injector must be thread-safe (tools may execute concurrently)
 //   - Return nil or empty slice if no attributes should be added

--- a/plugins/otel/tool.go
+++ b/plugins/otel/tool.go
@@ -44,9 +44,10 @@ func (t *TracingInterceptor) InterceptToolExecution(
 		genAIToolCallID(req.ID),
 	}
 
-	// Add conversation ID if session is available
-	if session := info.Inv.Session(); session != nil && session.ID != "" {
-		attrs = append(attrs, genAIConversationID(session.ID))
+	// Add conversation ID (the parent/root for a sub-agent, not the unique
+	// storage session id) if a session is available.
+	if cid := conversationID(info.Inv.Session()); cid != "" {
+		attrs = append(attrs, genAIConversationID(cid))
 	}
 
 	// Add tool type and description if definition is available
@@ -71,15 +72,10 @@ func (t *TracingInterceptor) InterceptToolExecution(
 
 	// Call attribute injector if configured (before span creation for sampling)
 	if t.cfg.attributeInjector != nil {
-		sessionID := ""
-		if session := info.Inv.Session(); session != nil {
-			sessionID = session.ID
-		}
-
 		spanCtx := SpanContext{
 			SpanType:  SpanTypeTool,
 			SpanName:  spanName,
-			SessionID: sessionID,
+			SessionID: conversationID(info.Inv.Session()),
 			Inv:       info.Inv,
 		}
 		if customAttrs := t.cfg.attributeInjector(ctx, spanCtx); len(customAttrs) > 0 {

--- a/store/session/store.go
+++ b/store/session/store.go
@@ -88,11 +88,10 @@ type Store interface {
 //
 // When a sub-agent is invoked in-process as part of a parent agent's turn it
 // shares the parent's session ID (so the two group into one conversation for
-// tracing/reconstruction). These keys preserve the discriminator and back-
-// reference needed to tell the sub-agent's activity apart from the parent's.
+// tracing/reconstruction). These keys carry the back-reference and identity
+// needed to tell the sub-agent's activity apart from the parent's. Their
+// presence is itself the signal that a session is a sub-agent run.
 const (
-	// MetadataIsSidechain (bool) marks the session as a sub-agent (sidechain) run.
-	MetadataIsSidechain = "is_sidechain"
 	// MetadataParentInvocationID (string) references the parent agent's invocation ID.
 	MetadataParentInvocationID = "parent_invocation_id"
 	// MetadataAgentPath (string) identifies which sub-agent produced the session.

--- a/store/session/store.go
+++ b/store/session/store.go
@@ -84,19 +84,44 @@ type Store interface {
 	List(ctx context.Context, req *ListRequest) (*ListResponse, error)
 }
 
-// Metadata keys recording parent→sub-agent linkage on a session's Metadata.
+// MetadataConversationID records the conversation grouping id on a session's
+// Metadata.
 //
 // When a sub-agent is invoked in-process as part of a parent agent's turn it
-// shares the parent's session ID (so the two group into one conversation for
-// tracing/reconstruction). These keys carry the back-reference and identity
-// needed to tell the sub-agent's activity apart from the parent's. Their
-// presence is itself the signal that a session is a sub-agent run.
-const (
-	// MetadataParentInvocationID (string) references the parent agent's invocation ID.
-	MetadataParentInvocationID = "parent_invocation_id"
-	// MetadataAgentPath (string) identifies which sub-agent produced the session.
-	MetadataAgentPath = "agent_path"
-)
+// keeps its own unique session ID (so it can never collide with the parent's or
+// a sibling's session in a store) but records the parent's conversation id here.
+// This lets observability group the whole parent→sub-agent tree under one
+// conversation (see ConversationID) without overloading the storage id.
+//
+// The key is namespaced under "redpanda.agent." so it cannot be mistaken for
+// caller-supplied Metadata, and it matches the OTel span attribute
+// (gen_ai.conversation.id) emitted for the same grouping.
+//
+// MetadataConversationID (string) is the conversation grouping id propagated
+// from the parent (transitively, the root conversation). See ConversationID.
+const MetadataConversationID = "redpanda.agent.conversation_id"
+
+// ConversationID returns the conversation grouping id for a session: the id
+// under which the session's activity should be grouped in conversation-oriented
+// observability (mapped to gen_ai.conversation.id). For a sub-agent session it
+// is the parent/root conversation id recorded in Metadata, so the whole
+// parent→sub-agent tree groups under one conversation; otherwise it is the
+// session's own ID. Returns "" for a nil session.
+//
+// This deliberately decouples the conversation/grouping id from the storage
+// session ID: the ID stays globally unique and safe as a store key, while
+// grouping is expressed purely as a derived value consumed by telemetry.
+func ConversationID(s *State) string {
+	if s == nil {
+		return ""
+	}
+
+	if v, _ := s.Metadata[MetadataConversationID].(string); v != "" {
+		return v
+	}
+
+	return s.ID
+}
 
 // State represents the persistent state of a conversation session.
 //

--- a/store/session/store.go
+++ b/store/session/store.go
@@ -84,6 +84,21 @@ type Store interface {
 	List(ctx context.Context, req *ListRequest) (*ListResponse, error)
 }
 
+// Metadata keys recording parent→sub-agent linkage on a session's Metadata.
+//
+// When a sub-agent is invoked in-process as part of a parent agent's turn it
+// shares the parent's session ID (so the two group into one conversation for
+// tracing/reconstruction). These keys preserve the discriminator and back-
+// reference needed to tell the sub-agent's activity apart from the parent's.
+const (
+	// MetadataIsSidechain (bool) marks the session as a sub-agent (sidechain) run.
+	MetadataIsSidechain = "is_sidechain"
+	// MetadataParentInvocationID (string) references the parent agent's invocation ID.
+	MetadataParentInvocationID = "parent_invocation_id"
+	// MetadataAgentPath (string) identifies which sub-agent produced the session.
+	MetadataAgentPath = "agent_path"
+)
+
 // State represents the persistent state of a conversation session.
 //
 // The Messages slice contains the conversation history excluding any system prompts,

--- a/tool/agenttool/agenttool.go
+++ b/tool/agenttool/agenttool.go
@@ -125,8 +125,10 @@ func (at *AgentTool) Execute(ctx context.Context, args json.RawMessage) (json.Ra
 	// (transitively, the root conversation) so the otel plugin groups this
 	// sub-agent under the same gen_ai.conversation.id as the parent without
 	// reusing the parent's session id.
-	if parent, ok := agent.InvocationFromContext(ctx); ok && parent.Session() != nil {
-		metadata[session.MetadataConversationID] = session.ConversationID(parent.Session())
+	if parent, ok := agent.InvocationFromContext(ctx); ok {
+		if cid := session.ConversationID(parent.Session()); cid != "" {
+			metadata[session.MetadataConversationID] = cid
+		}
 	}
 
 	sess := &session.State{

--- a/tool/agenttool/agenttool.go
+++ b/tool/agenttool/agenttool.go
@@ -143,6 +143,7 @@ func (at *AgentTool) Execute(ctx context.Context, args json.RawMessage) (json.Ra
 
 	// 3. Create invocation metadata
 	inv := agent.NewInvocationMetadata(sess, info)
+	ctx = agent.ContextWithInvocation(ctx, inv)
 
 	// 4. Run agent and collect response
 	var result string

--- a/tool/agenttool/agenttool.go
+++ b/tool/agenttool/agenttool.go
@@ -123,7 +123,6 @@ func (at *AgentTool) Execute(ctx context.Context, args json.RawMessage) (json.Ra
 	// linkage needed to reconstruct the parent→sub-agent tree.
 	if parent, ok := agent.InvocationFromContext(ctx); ok && parent.Session() != nil {
 		sessionID = parent.Session().ID
-		metadata[session.MetadataIsSidechain] = true
 		metadata[session.MetadataParentInvocationID] = parent.InvocationID()
 		metadata[session.MetadataAgentPath] = info.Name
 	}

--- a/tool/agenttool/agenttool.go
+++ b/tool/agenttool/agenttool.go
@@ -102,36 +102,33 @@ type Result struct {
 //     conversation history. Context is isolated regardless of the session id.
 //   - For context sharing, pass relevant information explicitly in args
 //
-// Session ID:
+// Session ID & conversation grouping:
+//   - The sub-agent always gets its own freshly minted, globally unique session
+//     id. It never reuses the parent's id, so it can never collide with the
+//     parent's or a sibling sub-agent's session if it ever reaches a store —
+//     there is no "safe only while unpersisted" caveat.
 //   - When invoked as part of a parent agent's turn (the parent invocation is
-//     present in ctx), the sub-agent shares the parent's session id so the two
-//     group into one conversation for tracing/reconstruction, and linkage is
-//     recorded in session metadata (see the Metadata* constants). Isolation is
-//     preserved because the Messages slice is still built fresh and never loaded.
-//   - Otherwise a unique session id is minted, preserving the previous behavior.
+//     present in ctx), the sub-agent records the parent's conversation id in
+//     session metadata (see session.MetadataConversationID). Observability uses
+//     that to group the parent→sub-agent tree under one conversation
+//     (gen_ai.conversation.id) without overloading the storage id.
 func (at *AgentTool) Execute(ctx context.Context, args json.RawMessage) (json.RawMessage, error) {
 	info := at.agent.Info()
 
-	// 1. Determine the session id and linkage. Default to a freshly minted,
-	// unique id (used when there is no parent invocation in context, e.g. the
-	// agent tool is invoked outside of a parent agent turn).
+	// 1. Mint a unique session id for the sub-agent. Conversation grouping does
+	// NOT rely on this id; it is carried separately in metadata (below) so the
+	// storage id stays unique and safe as a store key.
 	sessionID := fmt.Sprintf("agent-tool-%s-%d", info.Name, time.Now().UnixNano())
 	metadata := map[string]any{}
 
-	// When the parent invocation is available, share its session id so the
-	// sub-agent groups with the parent in tracing/observability, and stamp the
-	// linkage needed to reconstruct the parent→sub-agent tree.
+	// When the parent invocation is available, propagate its conversation id
+	// (transitively, the root conversation) so the otel plugin groups this
+	// sub-agent under the same gen_ai.conversation.id as the parent without
+	// reusing the parent's session id.
 	if parent, ok := agent.InvocationFromContext(ctx); ok && parent.Session() != nil {
-		sessionID = parent.Session().ID
-		metadata[session.MetadataParentInvocationID] = parent.InvocationID()
-		metadata[session.MetadataAgentPath] = info.Name
+		metadata[session.MetadataConversationID] = session.ConversationID(parent.Session())
 	}
 
-	// NOTE: when shared with the parent (above), this id is no longer unique
-	// across the parent and concurrent sub-agents. That is safe ONLY because this
-	// session is never loaded or persisted — it runs in memory via at.agent.Run.
-	// If a store is ever introduced on this path, key it on the unique invocation
-	// id / agent_path, not this (now non-unique) session id.
 	sess := &session.State{
 		ID:       sessionID,
 		Messages: []llm.Message{},

--- a/tool/agenttool/agenttool.go
+++ b/tool/agenttool/agenttool.go
@@ -97,17 +97,41 @@ type Result struct {
 //   - Token usage is tracked separately via interceptors on the agent
 //
 // Session Isolation:
-//   - Each invocation creates a fresh session (no context sharing)
-//   - This prevents context pollution and keeps parent/child boundaries clear
+//   - The sub-agent always runs with a fresh, in-memory Messages slice and its
+//     state is never loaded or persisted, so it cannot observe the parent's
+//     conversation history. Context is isolated regardless of the session id.
 //   - For context sharing, pass relevant information explicitly in args
+//
+// Session ID:
+//   - When invoked as part of a parent agent's turn (the parent invocation is
+//     present in ctx), the sub-agent shares the parent's session id so the two
+//     group into one conversation for tracing/reconstruction, and linkage is
+//     recorded in session metadata (see the Metadata* constants). Isolation is
+//     preserved because the Messages slice is still built fresh and never loaded.
+//   - Otherwise a unique session id is minted, preserving the previous behavior.
 func (at *AgentTool) Execute(ctx context.Context, args json.RawMessage) (json.RawMessage, error) {
 	info := at.agent.Info()
 
-	// 1. Create fresh session with unique ID to prevent collisions in state stores
+	// 1. Determine the session id and linkage. Default to a freshly minted,
+	// unique id (used when there is no parent invocation in context, e.g. the
+	// agent tool is invoked outside of a parent agent turn).
+	sessionID := fmt.Sprintf("agent-tool-%s-%d", info.Name, time.Now().UnixNano())
+	metadata := map[string]any{}
+
+	// When the parent invocation is available, share its session id so the
+	// sub-agent groups with the parent in tracing/observability, and stamp the
+	// linkage needed to reconstruct the parent→sub-agent tree.
+	if parent, ok := agent.InvocationFromContext(ctx); ok && parent.Session() != nil {
+		sessionID = parent.Session().ID
+		metadata[session.MetadataIsSidechain] = true
+		metadata[session.MetadataParentInvocationID] = parent.InvocationID()
+		metadata[session.MetadataAgentPath] = info.Name
+	}
+
 	sess := &session.State{
-		ID:       fmt.Sprintf("agent-tool-%s-%d", info.Name, time.Now().UnixNano()),
+		ID:       sessionID,
 		Messages: []llm.Message{},
-		Metadata: map[string]any{},
+		Metadata: metadata,
 	}
 
 	// 2. Convert args to user message

--- a/tool/agenttool/agenttool.go
+++ b/tool/agenttool/agenttool.go
@@ -127,6 +127,11 @@ func (at *AgentTool) Execute(ctx context.Context, args json.RawMessage) (json.Ra
 		metadata[session.MetadataAgentPath] = info.Name
 	}
 
+	// NOTE: when shared with the parent (above), this id is no longer unique
+	// across the parent and concurrent sub-agents. That is safe ONLY because this
+	// session is never loaded or persisted — it runs in memory via at.agent.Run.
+	// If a store is ever introduced on this path, key it on the unique invocation
+	// id / agent_path, not this (now non-unique) session id.
 	sess := &session.State{
 		ID:       sessionID,
 		Messages: []llm.Message{},

--- a/tool/agenttool/session_grouping_test.go
+++ b/tool/agenttool/session_grouping_test.go
@@ -191,3 +191,19 @@ func TestExecute_ParentWithNilSession_MintsUniqueID(t *testing.T) {
 		"got %q", child.gotSessionID)
 	assert.Empty(t, child.gotMetadata)
 }
+
+func TestExecute_ParentWithEmptySessionID_NoMetadata(t *testing.T) {
+	t.Parallel()
+
+	// Parent session exists but resolves to an empty conversation id; no junk
+	// empty-string entry may be written into the child's metadata.
+	ctx := parentContext("")
+
+	child := &capturingAgent{mockAgent: mockAgent{name: "search", response: "ok"}}
+	at := agenttool.New(child)
+
+	_, err := at.Execute(ctx, json.RawMessage(`{}`))
+	require.NoError(t, err)
+
+	assert.NotContains(t, child.gotMetadata, session.MetadataConversationID)
+}

--- a/tool/agenttool/session_grouping_test.go
+++ b/tool/agenttool/session_grouping_test.go
@@ -56,17 +56,17 @@ func (m *capturingAgent) Run(_ context.Context, inv *agent.InvocationMetadata) i
 	}
 }
 
-func parentContext(id string, messages ...llm.Message) (context.Context, *agent.InvocationMetadata) {
+func parentContext(id string, messages ...llm.Message) context.Context {
 	parentSess := &session.State{ID: id, Messages: messages}
 	parentInv := agent.NewInvocationMetadata(parentSess, agent.Info{Name: "root"})
 
-	return agent.ContextWithInvocation(context.Background(), parentInv), parentInv
+	return agent.ContextWithInvocation(context.Background(), parentInv)
 }
 
 func TestExecute_GroupsUnderParentConversation(t *testing.T) {
 	t.Parallel()
 
-	ctx, _ := parentContext("parent-sess-123",
+	ctx := parentContext("parent-sess-123",
 		llm.NewMessage(llm.RoleUser, llm.NewTextPart("parent secret")))
 
 	child := &capturingAgent{mockAgent: mockAgent{name: "search", response: "ok"}}
@@ -116,7 +116,7 @@ func TestExecute_PropagatesRootConversationID(t *testing.T) {
 func TestExecute_ContextIsolatedDespiteGrouping(t *testing.T) {
 	t.Parallel()
 
-	ctx, _ := parentContext("parent-sess-123",
+	ctx := parentContext("parent-sess-123",
 		llm.NewMessage(llm.RoleUser, llm.NewTextPart("parent secret")))
 
 	child := &capturingAgent{mockAgent: mockAgent{name: "search", response: "ok"}}

--- a/tool/agenttool/session_grouping_test.go
+++ b/tool/agenttool/session_grouping_test.go
@@ -63,10 +63,10 @@ func parentContext(id string, messages ...llm.Message) (context.Context, *agent.
 	return agent.ContextWithInvocation(context.Background(), parentInv), parentInv
 }
 
-func TestExecute_SharesParentSessionID(t *testing.T) {
+func TestExecute_GroupsUnderParentConversation(t *testing.T) {
 	t.Parallel()
 
-	ctx, parentInv := parentContext("parent-sess-123",
+	ctx, _ := parentContext("parent-sess-123",
 		llm.NewMessage(llm.RoleUser, llm.NewTextPart("parent secret")))
 
 	child := &capturingAgent{mockAgent: mockAgent{name: "search", response: "ok"}}
@@ -75,16 +75,45 @@ func TestExecute_SharesParentSessionID(t *testing.T) {
 	_, err := at.Execute(ctx, json.RawMessage(`{"query":"x"}`))
 	require.NoError(t, err)
 
-	// Shares the parent's session id for conversation grouping.
-	assert.Equal(t, "parent-sess-123", child.gotSessionID)
+	// The sub-agent keeps its OWN unique storage id — it never reuses the
+	// parent's, so it can never collide in a store.
+	assert.True(t, strings.HasPrefix(child.gotSessionID, "agent-tool-search-"),
+		"got %q", child.gotSessionID)
+	assert.NotEqual(t, "parent-sess-123", child.gotSessionID)
 
-	// Linkage metadata records the back-reference + sub-agent identity; its
-	// presence is the signal that this is a sub-agent run.
-	assert.Equal(t, parentInv.InvocationID(), child.gotMetadata[session.MetadataParentInvocationID])
-	assert.Equal(t, "search", child.gotMetadata[session.MetadataAgentPath])
+	// Conversation grouping is carried in metadata: the parent's conversation id,
+	// so observability groups the two under one conversation.
+	assert.Equal(t, "parent-sess-123", child.gotMetadata[session.MetadataConversationID])
+
+	// And ConversationID resolves the sub-agent's session to the parent's id.
+	assert.Equal(t, "parent-sess-123",
+		session.ConversationID(&session.State{ID: child.gotSessionID, Metadata: child.gotMetadata}))
 }
 
-func TestExecute_ContextIsolatedDespiteSharedID(t *testing.T) {
+func TestExecute_PropagatesRootConversationID(t *testing.T) {
+	t.Parallel()
+
+	// A parent that is itself a sub-agent already carries a conversation id in
+	// metadata (the root). A nested sub-agent must group under that ROOT, not
+	// under the immediate parent's unique storage id.
+	parentSess := &session.State{
+		ID:       "agent-tool-mid-999",
+		Metadata: map[string]any{session.MetadataConversationID: "root-sess-1"},
+	}
+	parentInv := agent.NewInvocationMetadata(parentSess, agent.Info{Name: "mid"})
+	ctx := agent.ContextWithInvocation(context.Background(), parentInv)
+
+	child := &capturingAgent{mockAgent: mockAgent{name: "leaf", response: "ok"}}
+	at := agenttool.New(child)
+
+	_, err := at.Execute(ctx, json.RawMessage(`{}`))
+	require.NoError(t, err)
+
+	assert.Equal(t, "root-sess-1", child.gotMetadata[session.MetadataConversationID])
+	assert.NotEqual(t, "agent-tool-mid-999", child.gotMetadata[session.MetadataConversationID])
+}
+
+func TestExecute_ContextIsolatedDespiteGrouping(t *testing.T) {
 	t.Parallel()
 
 	ctx, _ := parentContext("parent-sess-123",

--- a/tool/agenttool/session_grouping_test.go
+++ b/tool/agenttool/session_grouping_test.go
@@ -54,6 +54,7 @@ func (m *capturingAgent) Run(ctx context.Context, inv *agent.InvocationMetadata)
 		ctxInv, ok := agent.InvocationFromContext(ctx)
 		m.gotContextInvocationPresent = ok
 		m.gotContextInvocationSame = ctxInv == inv
+
 		if ok && ctxInv.Session() != nil {
 			m.gotContextSessionID = ctxInv.Session().ID
 		}

--- a/tool/agenttool/session_grouping_test.go
+++ b/tool/agenttool/session_grouping_test.go
@@ -38,14 +38,25 @@ type capturingAgent struct {
 	gotSessionID string
 	gotMessages  []llm.Message
 	gotMetadata  map[string]any
+
+	gotContextInvocationPresent bool
+	gotContextInvocationSame    bool
+	gotContextSessionID         string
 }
 
-func (m *capturingAgent) Run(_ context.Context, inv *agent.InvocationMetadata) iter.Seq2[agent.Event, error] {
+func (m *capturingAgent) Run(ctx context.Context, inv *agent.InvocationMetadata) iter.Seq2[agent.Event, error] {
 	return func(yield func(agent.Event, error) bool) {
 		s := inv.Session()
 		m.gotSessionID = s.ID
 		m.gotMessages = s.Messages
 		m.gotMetadata = s.Metadata
+
+		ctxInv, ok := agent.InvocationFromContext(ctx)
+		m.gotContextInvocationPresent = ok
+		m.gotContextInvocationSame = ctxInv == inv
+		if ok && ctxInv.Session() != nil {
+			m.gotContextSessionID = ctxInv.Session().ID
+		}
 
 		msg := llm.NewMessage(llm.RoleAssistant, llm.NewTextPart(m.response))
 		if !yield(agent.MessageEvent{Response: llm.Response{Message: msg}}, nil) {
@@ -88,6 +99,22 @@ func TestExecute_GroupsUnderParentConversation(t *testing.T) {
 	// And ConversationID resolves the sub-agent's session to the parent's id.
 	assert.Equal(t, "parent-sess-123",
 		session.ConversationID(&session.State{ID: child.gotSessionID, Metadata: child.gotMetadata}))
+}
+
+func TestExecute_ContextCarriesChildInvocation(t *testing.T) {
+	t.Parallel()
+
+	ctx := parentContext("parent-sess-123")
+	child := &capturingAgent{mockAgent: mockAgent{name: "search", response: "ok"}}
+	at := agenttool.New(child)
+
+	_, err := at.Execute(ctx, json.RawMessage(`{}`))
+	require.NoError(t, err)
+
+	assert.True(t, child.gotContextInvocationPresent)
+	assert.True(t, child.gotContextInvocationSame)
+	assert.Equal(t, child.gotSessionID, child.gotContextSessionID)
+	assert.NotEqual(t, "parent-sess-123", child.gotContextSessionID)
 }
 
 func TestExecute_PropagatesRootConversationID(t *testing.T) {

--- a/tool/agenttool/shared_session_test.go
+++ b/tool/agenttool/shared_session_test.go
@@ -78,8 +78,8 @@ func TestExecute_SharesParentSessionID(t *testing.T) {
 	// Shares the parent's session id for conversation grouping.
 	assert.Equal(t, "parent-sess-123", child.gotSessionID)
 
-	// Linkage metadata records the discriminator + back-reference.
-	assert.Equal(t, true, child.gotMetadata[session.MetadataIsSidechain])
+	// Linkage metadata records the back-reference + sub-agent identity; its
+	// presence is the signal that this is a sub-agent run.
 	assert.Equal(t, parentInv.InvocationID(), child.gotMetadata[session.MetadataParentInvocationID])
 	assert.Equal(t, "search", child.gotMetadata[session.MetadataAgentPath])
 }

--- a/tool/agenttool/shared_session_test.go
+++ b/tool/agenttool/shared_session_test.go
@@ -1,0 +1,137 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agenttool_test
+
+import (
+	"context"
+	"encoding/json"
+	"iter"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/redpanda-data/ai-sdk-go/agent"
+	"github.com/redpanda-data/ai-sdk-go/llm"
+	"github.com/redpanda-data/ai-sdk-go/store/session"
+	"github.com/redpanda-data/ai-sdk-go/tool/agenttool"
+)
+
+// capturingAgent records the session it is invoked with, so tests can assert on
+// the session id, messages, and metadata that agenttool builds for the child.
+type capturingAgent struct {
+	mockAgent
+
+	gotSessionID string
+	gotMessages  []llm.Message
+	gotMetadata  map[string]any
+}
+
+func (m *capturingAgent) Run(_ context.Context, inv *agent.InvocationMetadata) iter.Seq2[agent.Event, error] {
+	return func(yield func(agent.Event, error) bool) {
+		s := inv.Session()
+		m.gotSessionID = s.ID
+		m.gotMessages = s.Messages
+		m.gotMetadata = s.Metadata
+
+		msg := llm.NewMessage(llm.RoleAssistant, llm.NewTextPart(m.response))
+		if !yield(agent.MessageEvent{Response: llm.Response{Message: msg}}, nil) {
+			return
+		}
+
+		yield(agent.InvocationEndEvent{FinishReason: agent.FinishReasonStop}, nil)
+	}
+}
+
+func parentContext(id string, messages ...llm.Message) (context.Context, *agent.InvocationMetadata) {
+	parentSess := &session.State{ID: id, Messages: messages}
+	parentInv := agent.NewInvocationMetadata(parentSess, agent.Info{Name: "root"})
+
+	return agent.ContextWithInvocation(context.Background(), parentInv), parentInv
+}
+
+func TestExecute_SharesParentSessionID(t *testing.T) {
+	t.Parallel()
+
+	ctx, parentInv := parentContext("parent-sess-123",
+		llm.NewMessage(llm.RoleUser, llm.NewTextPart("parent secret")))
+
+	child := &capturingAgent{mockAgent: mockAgent{name: "search", response: "ok"}}
+	at := agenttool.New(child)
+
+	_, err := at.Execute(ctx, json.RawMessage(`{"query":"x"}`))
+	require.NoError(t, err)
+
+	// Shares the parent's session id for conversation grouping.
+	assert.Equal(t, "parent-sess-123", child.gotSessionID)
+
+	// Linkage metadata records the discriminator + back-reference.
+	assert.Equal(t, true, child.gotMetadata[session.MetadataIsSidechain])
+	assert.Equal(t, parentInv.InvocationID(), child.gotMetadata[session.MetadataParentInvocationID])
+	assert.Equal(t, "search", child.gotMetadata[session.MetadataAgentPath])
+}
+
+func TestExecute_ContextIsolatedDespiteSharedID(t *testing.T) {
+	t.Parallel()
+
+	ctx, _ := parentContext("parent-sess-123",
+		llm.NewMessage(llm.RoleUser, llm.NewTextPart("parent secret")))
+
+	child := &capturingAgent{mockAgent: mockAgent{name: "search", response: "ok"}}
+	at := agenttool.New(child)
+
+	_, err := at.Execute(ctx, json.RawMessage(`{"query":"x"}`))
+	require.NoError(t, err)
+
+	// The sub-agent must NOT observe the parent's history: exactly the args
+	// message and nothing from the parent.
+	require.Len(t, child.gotMessages, 1)
+	assert.JSONEq(t, `{"query":"x"}`, child.gotMessages[0].TextContent())
+}
+
+func TestExecute_NoParentInvocation_MintsUniqueID(t *testing.T) {
+	t.Parallel()
+
+	child := &capturingAgent{mockAgent: mockAgent{name: "search", response: "ok"}}
+	at := agenttool.New(child)
+
+	_, err := at.Execute(context.Background(), json.RawMessage(`{}`))
+	require.NoError(t, err)
+
+	// Falls back to the previous behavior: a freshly minted, unique id.
+	assert.True(t, strings.HasPrefix(child.gotSessionID, "agent-tool-search-"),
+		"got %q", child.gotSessionID)
+	// No linkage metadata when there is no parent.
+	assert.Empty(t, child.gotMetadata)
+}
+
+func TestExecute_ParentWithNilSession_MintsUniqueID(t *testing.T) {
+	t.Parallel()
+
+	// Invocation present in ctx, but it has no session.
+	parentInv := agent.NewInvocationMetadata(nil, agent.Info{Name: "root"})
+	ctx := agent.ContextWithInvocation(context.Background(), parentInv)
+
+	child := &capturingAgent{mockAgent: mockAgent{name: "search", response: "ok"}}
+	at := agenttool.New(child)
+
+	_, err := at.Execute(ctx, json.RawMessage(`{}`))
+	require.NoError(t, err)
+
+	assert.True(t, strings.HasPrefix(child.gotSessionID, "agent-tool-search-"),
+		"got %q", child.gotSessionID)
+	assert.Empty(t, child.gotMetadata)
+}


### PR DESCRIPTION
## What

Alternative to #153. Same goal — make an in-process `agenttool` sub-agent **group with its parent as one conversation** in session-oriented observability (Langfuse) — but **without overloading the storage `session.ID`**.

#153 made the sub-agent reuse the parent's `session.ID`. That conflates a *storage primary key* with a *telemetry grouping id*, and is safe only while the sub-agent session is never persisted — an invariant nothing enforces:

- Both `session.Store` impls (`InMemoryStore`, Kafka `KVStore`) key **solely** on `session.ID` with whole-record last-write-wins; there is no compound key or merge.
- `AgentTool.New` accepts **any** `agent.Agent`, so a persisting sub-agent (or future persistence on this path) would write under the shared id.
- Tools execute **concurrently** (default 3-way), so multiple sub-agents would adopt the *same* parent id at once → silent lost-update clobbering of sibling / parent sessions.

#153's own code comment concedes this ("safe ONLY because this session is never loaded or persisted"). This PR removes the hazard instead of documenting it.

## How

Decouple the conversation/grouping id from the storage id:

- **`agent` (+ `llmagent`)**: expose the calling agent's `InvocationMetadata` on the tool-execution `ctx` via new `ContextWithInvocation` / `InvocationFromContext` helpers. `llmagent` sets it before every tool call, so a tool can read the parent invocation (its session, conversation id) without a new tool interface; tools that ignore it are unaffected.
- **`agenttool`**: the sub-agent keeps its **own freshly minted, globally unique** `session.ID` (can never collide in a store). When a parent invocation is in `ctx`, it records the parent's **conversation id** in session metadata — propagated **transitively**, so nested sub-agents group under the *root* conversation.
- **`store/session`**: new `ConversationID(*State)` resolver (single source of truth) — returns the conversation id from metadata, else the session's own id. The metadata key is namespaced under `redpanda.agent.conversation_id` so it can't be confused with caller-supplied metadata (and matches the OTel attribute name).
- **`plugins/otel`**: emit `gen_ai.conversation.id` and the injector `SessionID` (→ `langfuse.session.id`) from `ConversationID` on **invocation, model and tool** spans, so the whole sub-agent subtree reports one consistent conversation id.

Within-trace parent/child nesting (the "sub-agent was spawned by this tool call" edge) is already free via `ctx` span propagation — the sub-agent's `invoke_agent` span is a child of the parent's `execute_tool` span. This PR only aligns the conversation-id *value* for cross-span / Langfuse session grouping.

Net: grouping is identical to #153 at the telemetry layer, but every storage `session.ID` stays unique — the "safe only while unpersisted" caveat is gone.

## Scope

Deliberately limited to sharing the conversation id — the one thing session grouping needs. Direct cross-trace parent linkage (a `parent_invocation_id` back-reference, or the spawning `gen_ai.tool.call.id`) is **not** included: within a trace it is redundant with span parentage, and the only consumer that would need it across traces is the downstream ADP transcript-assembly query path. It can be added there, when a query actually requires it.

## Tests

`tool/agenttool/session_grouping_test.go` covers: unique sub-agent id (never the parent's), grouping under the parent's conversation id, **transitive propagation of the root id through nesting**, context isolation, and no-parent / nil-session fallback. `agent/context_test.go` covers the ctx invocation round-trip. `go build`, `go vet`, and the `agent` / `agenttool` / `store/session` / `plugins/otel` suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
