### PR TITLE
fix: make prompt caching work (deterministic tool order + default-on Anthropic/Bedrock caching)

### DIFF
--- a/providers/anthropic/cache_default_test.go
+++ b/providers/anthropic/cache_default_test.go
@@ -1,0 +1,106 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package anthropic
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/anthropics/anthropic-sdk-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/redpanda-data/ai-sdk-go/llm"
+)
+
+// TestDefaultProviderEnablesCaching pins the default: a provider built the way
+// every consumer builds it (no caching option) must have caching ON. Prompt
+// caching being opt-in means everyone forgets to opt in, which is exactly the
+// regression this guards against.
+func TestDefaultProviderEnablesCaching(t *testing.T) {
+	t.Parallel()
+
+	p, err := NewProvider("test-key")
+	require.NoError(t, err)
+
+	assert.True(t, p.EnableCaching,
+		"caching must default to ON; the SDK's consumers never call WithCaching()")
+}
+
+// TestDefaultCachingEmitsCacheControlMarkers proves the default flows all the
+// way through: a model built from a default provider must emit cache_control
+// markers on the cacheable prefix (last system block) and on the last message,
+// without anyone calling WithCaching().
+func TestDefaultCachingEmitsCacheControlMarkers(t *testing.T) {
+	t.Parallel()
+
+	p, err := NewProvider("test-key")
+	require.NoError(t, err)
+
+	model, err := p.NewModel(ModelClaudeSonnet45)
+	require.NoError(t, err)
+
+	m, ok := model.(*Model)
+	require.True(t, ok, "NewModel must return *Model")
+
+	req := &llm.Request{
+		Messages: []llm.Message{
+			{
+				Role: llm.RoleSystem,
+				Content: []llm.Part{
+					// Realistic system prompt; size is irrelevant to marker
+					// emission (Anthropic ignores markers below its token
+					// minimum server-side, the SDK always writes them).
+					llm.NewTextPart("You are a helpful assistant. " + strings.Repeat("context ", 200)),
+				},
+			},
+			{
+				Role:    llm.RoleUser,
+				Content: []llm.Part{llm.NewTextPart("Hello")},
+			},
+		},
+	}
+
+	apiReq, err := m.requestMapper.ToProvider(req)
+	require.NoError(t, err)
+
+	require.NotEmpty(t, apiReq.System, "system blocks must be present")
+	lastSystem := apiReq.System[len(apiReq.System)-1]
+	assert.True(t, hasCacheMarker(lastSystem.CacheControl),
+		"last system block must carry a cache_control marker by default")
+
+	require.NotEmpty(t, apiReq.Messages, "messages must be present")
+	assert.True(t, lastMessageHasCacheMarker(apiReq.Messages[len(apiReq.Messages)-1]),
+		"last message must carry a cache_control marker by default")
+}
+
+// hasCacheMarker reports whether a cache_control value has been set. The zero
+// value leaves Type empty; NewBetaCacheControlEphemeralParam sets it to
+// "ephemeral".
+func hasCacheMarker(cc anthropic.BetaCacheControlEphemeralParam) bool {
+	return cc.Type != ""
+}
+
+// lastMessageHasCacheMarker reports whether any text block in the message
+// carries a cache_control marker.
+func lastMessageHasCacheMarker(msg anthropic.BetaMessageParam) bool {
+	for _, block := range msg.Content {
+		if block.OfText != nil && hasCacheMarker(block.OfText.CacheControl) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/providers/anthropic/cache_default_test.go
+++ b/providers/anthropic/cache_default_test.go
@@ -86,6 +86,59 @@ func TestDefaultCachingEmitsCacheControlMarkers(t *testing.T) {
 		"last message must carry a cache_control marker by default")
 }
 
+// TestWithCachingIsNoOp pins the backward-compatibility contract: WithCaching()
+// stays callable with no arguments and leaves caching on. The default is
+// already on, so it is a no-op, but consumers and existing tests call it and
+// must keep compiling.
+func TestWithCachingIsNoOp(t *testing.T) {
+	t.Parallel()
+
+	p, err := NewProvider("test-key", WithCaching())
+	require.NoError(t, err)
+
+	assert.True(t, p.EnableCaching, "WithCaching() must remain a valid no-op with caching on")
+}
+
+// TestWithCachingDisabledSuppressesMarkers proves the opt-out works end to end:
+// no cache_control markers on the system block or the last message.
+func TestWithCachingDisabledSuppressesMarkers(t *testing.T) {
+	t.Parallel()
+
+	p, err := NewProvider("test-key", WithCachingDisabled())
+	require.NoError(t, err)
+	require.False(t, p.EnableCaching, "WithCachingDisabled must turn caching off")
+
+	model, err := p.NewModel(ModelClaudeSonnet45)
+	require.NoError(t, err)
+
+	m, ok := model.(*Model)
+	require.True(t, ok, "NewModel must return *Model")
+
+	req := &llm.Request{
+		Messages: []llm.Message{
+			{
+				Role:    llm.RoleSystem,
+				Content: []llm.Part{llm.NewTextPart("You are a helpful assistant.")},
+			},
+			{
+				Role:    llm.RoleUser,
+				Content: []llm.Part{llm.NewTextPart("Hello")},
+			},
+		},
+	}
+
+	apiReq, err := m.requestMapper.ToProvider(req)
+	require.NoError(t, err)
+
+	require.NotEmpty(t, apiReq.System)
+	assert.False(t, hasCacheMarker(apiReq.System[len(apiReq.System)-1].CacheControl),
+		"WithCachingDisabled must suppress the system cache_control marker")
+
+	require.NotEmpty(t, apiReq.Messages)
+	assert.False(t, lastMessageHasCacheMarker(apiReq.Messages[len(apiReq.Messages)-1]),
+		"WithCachingDisabled must suppress the message cache_control marker")
+}
+
 // hasCacheMarker reports whether a cache_control value has been set. The zero
 // value leaves Type empty; NewBetaCacheControlEphemeralParam sets it to
 // "ephemeral".

--- a/providers/anthropic/provider.go
+++ b/providers/anthropic/provider.go
@@ -75,6 +75,9 @@ func NewProvider(apiKey string, opts ...ProviderOption) (*Provider, error) {
 			Timeout: timeout,
 		},
 		Timeout: timeout,
+		// Caching is on by default. Opt-in caching just means callers forget
+		// to enable it; use WithCachingDisabled to turn it off.
+		EnableCaching: true,
 	}
 
 	for _, opt := range opts {
@@ -123,12 +126,23 @@ func WithHTTPClient(client *http.Client) ProviderOption {
 	}
 }
 
-// WithCaching enables prompt caching by setting cache_control markers on requests.
-// When enabled, the SDK automatically marks the last message content block for caching,
-// allowing Anthropic to cache the conversation prefix for cost savings.
+// WithCaching is retained for backward compatibility and is now a no-op:
+// prompt caching is enabled by default. Use WithCachingDisabled to turn it off.
 func WithCaching() ProviderOption {
 	return func(p *Provider) error {
 		p.EnableCaching = true
+		return nil
+	}
+}
+
+// WithCachingDisabled turns off prompt caching, so no cache_control markers are
+// emitted. Caching is on by default because an agent re-sending a stable system
+// prompt and toolset every turn gets much cheaper cache reads for a one-time
+// write premium, and below the model's token minimum the marker is ignored
+// server-side. Use this only when you specifically do not want caching.
+func WithCachingDisabled() ProviderOption {
+	return func(p *Provider) error {
+		p.EnableCaching = false
 		return nil
 	}
 }

--- a/providers/anthropic/tool_order_wire_test.go
+++ b/providers/anthropic/tool_order_wire_test.go
@@ -1,0 +1,161 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package anthropic
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/redpanda-data/ai-sdk-go/llm"
+	"github.com/redpanda-data/ai-sdk-go/tool"
+)
+
+// TestToolOrderReachesTheWire proves the real-world impact behind the
+// registry/MCP sort: the order of req.Tools is serialized verbatim into the
+// actual Anthropic request, so a reordered tool list is a byte-different request
+// prefix — a guaranteed cache miss. Together with TestRegistryListSortedAndStable
+// (which shows List() returned a randomized order before the fix), this closes
+// the causal chain: randomized List() -> randomized wire -> cache never hits.
+func TestToolOrderReachesTheWire(t *testing.T) {
+	t.Parallel()
+
+	m := newWireTestModel(t)
+
+	orderA, bytesA := serializedRequest(t, m, toolDefs("alpha", "bravo", "charlie"))
+	orderB, bytesB := serializedRequest(t, m, toolDefs("charlie", "bravo", "alpha"))
+
+	// The mapper preserves req.Tools order verbatim — it does not re-sort. So
+	// whatever order the tool list arrives in is exactly what hits the wire.
+	assert.Equal(t, []string{"alpha", "bravo", "charlie"}, orderA)
+	assert.Equal(t, []string{"charlie", "bravo", "alpha"}, orderB)
+
+	// And that difference is real bytes on the wire: the two marshaled requests
+	// differ solely because the tools were ordered differently.
+	assert.NotEqual(t, bytesA, bytesB,
+		"reordering tools must change the serialized request — this is what busts the cache")
+}
+
+// TestRegistryToolOrderIsStableOnTheWire closes the loop end to end: tools
+// registered in arbitrary order produce a single deterministic wire order
+// (sorted), identical across independent List()->map cycles. Before the
+// registry sort this produced a different wire order on essentially every call.
+func TestRegistryToolOrderIsStableOnTheWire(t *testing.T) {
+	t.Parallel()
+
+	m := newWireTestModel(t)
+
+	build := func() string {
+		reg := tool.NewRegistry(tool.RegistryConfig{})
+		for _, n := range []string{"zeta", "mike", "alpha", "romeo", "bravo"} {
+			require.NoError(t, reg.Register(fakeTool{name: n}))
+		}
+
+		order, _ := serializedRequest(t, m, reg.List())
+
+		return strings.Join(order, ",")
+	}
+
+	const want = "alpha,bravo,mike,romeo,zeta"
+
+	assert.Equal(t, want, build(), "registry tool order must reach the wire sorted")
+
+	// Rebuild many times: the wire order must never vary.
+	for range 20 {
+		assert.Equal(t, want, build())
+	}
+}
+
+// serializedRequest maps a request carrying the given tools through the real
+// Anthropic request mapper and returns the tool names in wire order plus the
+// fully marshaled request body.
+func serializedRequest(t *testing.T, m *Model, tools []llm.ToolDefinition) ([]string, string) {
+	t.Helper()
+
+	req := &llm.Request{
+		Messages: []llm.Message{
+			{
+				Role:    llm.RoleSystem,
+				Content: []llm.Part{llm.NewTextPart("You are a helpful assistant.")},
+			},
+			{
+				Role:    llm.RoleUser,
+				Content: []llm.Part{llm.NewTextPart("hi")},
+			},
+		},
+		Tools: tools,
+	}
+
+	apiReq, err := m.requestMapper.ToProvider(req)
+	require.NoError(t, err)
+
+	names := make([]string, len(apiReq.Tools))
+
+	for i, tn := range apiReq.Tools {
+		require.NotNil(t, tn.OfTool, "expected a function tool")
+		names[i] = tn.OfTool.Name
+	}
+
+	raw, err := json.Marshal(apiReq)
+	require.NoError(t, err)
+
+	return names, string(raw)
+}
+
+func toolDefs(names ...string) []llm.ToolDefinition {
+	defs := make([]llm.ToolDefinition, len(names))
+	for i, n := range names {
+		defs[i] = llm.ToolDefinition{
+			Name:        n,
+			Description: n,
+			Parameters:  json.RawMessage(`{"type":"object","properties":{}}`),
+		}
+	}
+
+	return defs
+}
+
+func newWireTestModel(t *testing.T) *Model {
+	t.Helper()
+
+	p, err := NewProvider("test-key")
+	require.NoError(t, err)
+
+	model, err := p.NewModel(ModelClaudeSonnet45)
+	require.NoError(t, err)
+
+	m, ok := model.(*Model)
+	require.True(t, ok, "NewModel must return *Model")
+
+	return m
+}
+
+type fakeTool struct{ name string }
+
+func (f fakeTool) Definition() llm.ToolDefinition {
+	return llm.ToolDefinition{
+		Name:        f.name,
+		Description: f.name,
+		Parameters:  json.RawMessage(`{"type":"object","properties":{}}`),
+	}
+}
+
+func (fakeTool) Execute(context.Context, json.RawMessage) (json.RawMessage, error) {
+	return json.RawMessage(`{}`), nil
+}

--- a/providers/bedrock/cache_default_test.go
+++ b/providers/bedrock/cache_default_test.go
@@ -76,6 +76,54 @@ func TestDefaultCachingInsertsCachePoint(t *testing.T) {
 		"system blocks must carry a CachePoint by default")
 }
 
+// TestWithCachingIsNoOp pins the backward-compatibility contract: WithCaching()
+// stays callable with no arguments and leaves caching on.
+func TestWithCachingIsNoOp(t *testing.T) {
+	t.Parallel()
+
+	p, err := NewProvider(context.Background(),
+		WithAWSConfig(aws.Config{Region: "us-east-1"}), WithCaching())
+	require.NoError(t, err)
+
+	assert.True(t, p.enableCaching, "WithCaching() must remain a valid no-op with caching on")
+}
+
+// TestWithCachingDisabledSuppressesCachePoint proves the opt-out works end to
+// end: no CachePoint inserted into the system blocks.
+func TestWithCachingDisabledSuppressesCachePoint(t *testing.T) {
+	t.Parallel()
+
+	p, err := NewProvider(context.Background(),
+		WithAWSConfig(aws.Config{Region: "us-east-1"}), WithCachingDisabled())
+	require.NoError(t, err)
+	require.False(t, p.enableCaching, "WithCachingDisabled must turn caching off")
+
+	model, err := p.NewModel(ModelClaudeSonnet46)
+	require.NoError(t, err)
+
+	m, ok := model.(*Model)
+	require.True(t, ok, "NewModel must return *Model")
+
+	req := &llm.Request{
+		Messages: []llm.Message{
+			{
+				Role:    llm.RoleSystem,
+				Content: []llm.Part{llm.NewTextPart("You are a helpful assistant.")},
+			},
+			{
+				Role:    llm.RoleUser,
+				Content: []llm.Part{llm.NewTextPart("Hello")},
+			},
+		},
+	}
+
+	input, err := m.requestMapper.ToConverseInput(req)
+	require.NoError(t, err)
+
+	assert.False(t, hasSystemCachePoint(input.System),
+		"WithCachingDisabled must suppress the CachePoint")
+}
+
 // hasSystemCachePoint reports whether the system blocks contain a cache point.
 func hasSystemCachePoint(blocks []types.SystemContentBlock) bool {
 	for _, b := range blocks {

--- a/providers/bedrock/cache_default_test.go
+++ b/providers/bedrock/cache_default_test.go
@@ -1,0 +1,88 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bedrock
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/redpanda-data/ai-sdk-go/llm"
+)
+
+// TestDefaultProviderEnablesCaching pins the default: Bedrock runs Claude, and
+// prompt caching being opt-in means consumers forget to opt in. A provider
+// built the normal way (no caching option) must have caching ON.
+func TestDefaultProviderEnablesCaching(t *testing.T) {
+	t.Parallel()
+
+	// WithAWSConfig bypasses the AWS credential/config-file lookup so this runs
+	// fully offline.
+	p, err := NewProvider(context.Background(), WithAWSConfig(aws.Config{Region: "us-east-1"}))
+	require.NoError(t, err)
+
+	assert.True(t, p.enableCaching,
+		"Bedrock caching must default to ON; consumers never call WithCaching()")
+}
+
+// TestDefaultCachingInsertsCachePoint proves the default flows through to the
+// wire: a model built from a default provider must insert a CachePoint after
+// the system block without anyone calling WithCaching().
+func TestDefaultCachingInsertsCachePoint(t *testing.T) {
+	t.Parallel()
+
+	p, err := NewProvider(context.Background(), WithAWSConfig(aws.Config{Region: "us-east-1"}))
+	require.NoError(t, err)
+
+	model, err := p.NewModel(ModelClaudeSonnet46)
+	require.NoError(t, err)
+
+	m, ok := model.(*Model)
+	require.True(t, ok, "NewModel must return *Model")
+
+	req := &llm.Request{
+		Messages: []llm.Message{
+			{
+				Role:    llm.RoleSystem,
+				Content: []llm.Part{llm.NewTextPart("You are a helpful assistant.")},
+			},
+			{
+				Role:    llm.RoleUser,
+				Content: []llm.Part{llm.NewTextPart("Hello")},
+			},
+		},
+	}
+
+	input, err := m.requestMapper.ToConverseInput(req)
+	require.NoError(t, err)
+
+	assert.True(t, hasSystemCachePoint(input.System),
+		"system blocks must carry a CachePoint by default")
+}
+
+// hasSystemCachePoint reports whether the system blocks contain a cache point.
+func hasSystemCachePoint(blocks []types.SystemContentBlock) bool {
+	for _, b := range blocks {
+		if _, ok := b.(*types.SystemContentBlockMemberCachePoint); ok {
+			return true
+		}
+	}
+
+	return false
+}

--- a/providers/bedrock/provider.go
+++ b/providers/bedrock/provider.go
@@ -50,7 +50,10 @@ type providerConfig struct {
 // NewProvider creates a new Bedrock provider.
 // It uses the AWS SDK default credential chain (env vars, IAM roles, SSO, etc.).
 func NewProvider(ctx context.Context, opts ...ProviderOption) (*Provider, error) {
-	cfg := &providerConfig{}
+	// Caching is on by default. Bedrock does no automatic prefix caching, so
+	// these explicit markers are the only way to cache at all; opt-in just means
+	// callers forget. Use WithCachingDisabled to turn it off.
+	cfg := &providerConfig{caching: true}
 
 	for _, opt := range opts {
 		if err := opt(cfg); err != nil {
@@ -149,10 +152,23 @@ func WithNoAuth() ProviderOption {
 	}
 }
 
-// WithCaching enables prompt caching on Bedrock.
+// WithCaching is retained for backward compatibility and is now a no-op:
+// prompt caching is enabled by default. Use WithCachingDisabled to turn it off.
 func WithCaching() ProviderOption {
 	return func(cfg *providerConfig) error {
 		cfg.caching = true
+		return nil
+	}
+}
+
+// WithCachingDisabled turns off prompt caching, so no CachePoint markers are
+// emitted. Caching is on by default because Bedrock does no automatic prefix
+// caching: the explicit CachePoint markers are the only way to cache, and an
+// agent re-sending a stable prefix every turn benefits immediately. Use this
+// only when you specifically do not want caching.
+func WithCachingDisabled() ProviderOption {
+	return func(cfg *providerConfig) error {
+		cfg.caching = false
 		return nil
 	}
 }

--- a/tool/mcp/tools.go
+++ b/tool/mcp/tools.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -51,6 +52,15 @@ func (c *clientImpl) ListTools(context.Context) ([]llm.ToolDefinition, error) {
 	for _, wrapper := range c.tools {
 		tools = append(tools, wrapper.definition)
 	}
+
+	// Sort by name so the returned slice is byte-stable across calls. Ranging
+	// the map yields a randomized order every time, and callers pass this
+	// straight into llm.Request.Tools, so a stable order is required for
+	// upstream prompt caching to hit. Names are unique (namespaced by server
+	// ID), giving a total order.
+	sort.Slice(tools, func(i, j int) bool {
+		return tools[i].Name < tools[j].Name
+	})
 
 	return tools, nil
 }

--- a/tool/mcp/tools.go
+++ b/tool/mcp/tools.go
@@ -15,11 +15,12 @@
 package mcp
 
 import (
+	"cmp"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"sort"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -58,8 +59,8 @@ func (c *clientImpl) ListTools(context.Context) ([]llm.ToolDefinition, error) {
 	// straight into llm.Request.Tools, so a stable order is required for
 	// upstream prompt caching to hit. Names are unique (namespaced by server
 	// ID), giving a total order.
-	sort.Slice(tools, func(i, j int) bool {
-		return tools[i].Name < tools[j].Name
+	slices.SortFunc(tools, func(a, b llm.ToolDefinition) int {
+		return cmp.Compare(a.Name, b.Name)
 	})
 
 	return tools, nil

--- a/tool/mcp/tools_list_test.go
+++ b/tool/mcp/tools_list_test.go
@@ -1,0 +1,88 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mcp
+
+import (
+	"context"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/redpanda-data/ai-sdk-go/llm"
+)
+
+// TestListToolsSortedAndStable guards prompt caching on the direct MCP-client
+// path. ListTools() is documented as something callers "Pass to an LLM for tool
+// calling", so its order becomes part of the request prefix every provider
+// serializes. Ranging the internal tools map without sorting reorders the slice
+// on every call, busting the upstream cache. The agent path goes through the
+// registry (covered separately), but this public API must be deterministic on
+// its own.
+func TestListToolsSortedAndStable(t *testing.T) {
+	t.Parallel()
+
+	// Names deliberately NOT in sorted order, and enough that randomized map
+	// iteration is overwhelmingly unlikely to emit them sorted by chance.
+	names := []string{
+		"srv__zeta", "srv__yankee", "srv__xray", "srv__whiskey",
+		"srv__victor", "srv__uniform", "srv__tango", "srv__sierra",
+		"srv__romeo", "srv__quebec", "srv__papa", "srv__oscar",
+		"srv__november", "srv__mike", "srv__lima", "srv__kilo",
+	}
+
+	c := &clientImpl{
+		bgCtx: context.Background(),
+		tools: make(map[string]*toolWrapper, len(names)),
+	}
+	for _, n := range names {
+		c.tools[n] = &toolWrapper{definition: llm.ToolDefinition{Name: n}}
+	}
+
+	want := make([]string, len(names))
+	copy(want, names)
+	sort.Strings(want)
+
+	defs, err := c.ListTools(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, want, toolNames(defs), "ListTools() must return definitions sorted by name")
+
+	// Order must be identical across many calls.
+	const iterations = 50
+
+	orderings := make(map[string]struct{})
+
+	for range iterations {
+		got, err := c.ListTools(context.Background())
+		require.NoError(t, err)
+
+		orderings[strings.Join(toolNames(got), ",")] = struct{}{}
+	}
+
+	assert.Lenf(t, orderings, 1,
+		"ListTools() order must be stable across %d calls, got %d distinct orderings",
+		iterations, len(orderings))
+}
+
+func toolNames(defs []llm.ToolDefinition) []string {
+	names := make([]string, len(defs))
+	for i, d := range defs {
+		names[i] = d.Name
+	}
+
+	return names
+}

--- a/tool/registry.go
+++ b/tool/registry.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"sort"
 	"sync"
 
 	"golang.org/x/sync/errgroup"
@@ -156,6 +157,15 @@ func (r *registry) List() []llm.ToolDefinition {
 	for _, registered := range r.tools {
 		definitions = append(definitions, registered.tool.Definition())
 	}
+
+	// Sort by name so the tools array is byte-identical across calls. Ranging a
+	// map yields a randomized order every time, and providers serialize
+	// req.Tools verbatim into the request prefix; a stable order is required for
+	// upstream prompt caching to ever hit. Names are unique (Register rejects
+	// duplicates), so this is a total order.
+	sort.Slice(definitions, func(i, j int) bool {
+		return definitions[i].Name < definitions[j].Name
+	})
 
 	return definitions
 }

--- a/tool/registry.go
+++ b/tool/registry.go
@@ -15,11 +15,12 @@
 package tool
 
 import (
+	"cmp"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"sort"
+	"slices"
 	"sync"
 
 	"golang.org/x/sync/errgroup"
@@ -163,8 +164,8 @@ func (r *registry) List() []llm.ToolDefinition {
 	// req.Tools verbatim into the request prefix; a stable order is required for
 	// upstream prompt caching to ever hit. Names are unique (Register rejects
 	// duplicates), so this is a total order.
-	sort.Slice(definitions, func(i, j int) bool {
-		return definitions[i].Name < definitions[j].Name
+	slices.SortFunc(definitions, func(a, b llm.ToolDefinition) int {
+		return cmp.Compare(a.Name, b.Name)
 	})
 
 	return definitions

--- a/tool/registry_test.go
+++ b/tool/registry_test.go
@@ -1,0 +1,84 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tool_test
+
+import (
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/redpanda-data/ai-sdk-go/llm"
+	"github.com/redpanda-data/ai-sdk-go/tool"
+)
+
+// TestRegistryListSortedAndStable guards prompt caching: every provider
+// serializes req.Tools verbatim into the request prefix (the tools block
+// precedes system + messages for Anthropic, and is part of the cached prefix
+// everywhere). If List() returns tools in a different order on each call, the
+// prefix changes every turn and the upstream cache never hits.
+//
+// List() must therefore return a deterministic, name-sorted order regardless of
+// registration order, and that order must be identical across repeated calls.
+func TestRegistryListSortedAndStable(t *testing.T) {
+	t.Parallel()
+
+	// Names deliberately NOT in sorted order, and enough of them that Go's
+	// randomized map iteration is overwhelmingly unlikely to emit them sorted
+	// by chance (1/16! ~ 5e-14).
+	names := []string{
+		"zeta", "yankee", "x-ray", "whiskey", "victor", "uniform",
+		"tango", "sierra", "romeo", "quebec", "papa", "oscar",
+		"november", "mike", "lima", "kilo",
+	}
+
+	registry := tool.NewRegistry(tool.RegistryConfig{})
+	for _, n := range names {
+		require.NoError(t, registry.Register(&mockTool{name: n}))
+	}
+
+	want := make([]string, len(names))
+	copy(want, names)
+	sort.Strings(want)
+
+	// Order must equal the name-sorted expectation.
+	assert.Equal(t, want, definitionNames(registry.List()),
+		"List() must return tool definitions sorted by name")
+
+	// Order must be identical across many calls (no map-iteration randomization).
+	// Pre-fix this almost surely yields >= 2 distinct orderings; post-fix exactly 1.
+	const iterations = 50
+
+	orderings := make(map[string]struct{})
+	for range iterations {
+		orderings[strings.Join(definitionNames(registry.List()), ",")] = struct{}{}
+	}
+
+	assert.Lenf(t, orderings, 1,
+		"List() order must be stable across %d calls, got %d distinct orderings",
+		iterations, len(orderings))
+}
+
+// definitionNames extracts tool names from a slice of definitions, preserving order.
+func definitionNames(defs []llm.ToolDefinition) []string {
+	names := make([]string, len(defs))
+	for i, d := range defs {
+		names[i] = d.Name
+	}
+
+	return names
+}


### PR DESCRIPTION
## What

Make prompt caching actually work for agents built on this SDK. Two changes,
each fixing a class of bug that silently destroys the upstream cache:

1. **Deterministic tool ordering.** `tool.Registry.List()` and the MCP client's
   `ListTools()` now return tool definitions sorted by name instead of in Go's
   randomized map-iteration order.
2. **Caching on by default for the Anthropic-backed providers.** The Anthropic
   and Bedrock providers now enable prompt caching by default. A new
   `WithCachingDisabled()` option turns it off; the existing no-arg
   `WithCaching()` stays valid (now a no-op).

No public signatures change. The only behavioral change a caller can observe is
that requests are now deterministic and Anthropic/Bedrock requests carry
`cache_control` / `CachePoint` markers unless explicitly disabled.

## Why

Caching is effectively dead for managed agents today, for two independent
reasons.

**Nondeterministic tool order busts the cache prefix on every provider.**
`registry.List()` ranged the internal `map[string]*registeredTool` with no sort:

```go
for _, registered := range r.tools {        // map range: randomized every call
    definitions = append(definitions, registered.tool.Definition())
}
```

`llmagent` calls `List()` fresh on every turn (`agent/llmagent/llmagent.go:251`,
`:670`) and every provider's request mapper serializes `req.Tools` in slice
order (verified for anthropic, openai, openaicompat, google, bedrock — none
re-sort). Go randomizes map iteration per range, so the tools array goes to the
wire in a different order on every request. For Anthropic the tools block
precedes system + messages and the breakpoint sits on the last system block, so
the cached prefix is `[tools]+[system]`; reorder the tools and the prefix never
matches. The same byte-level change defeats OpenAI's and Google's automatic
prefix caching and busts the prefix that Bedrock's explicit CachePoint markers
cover. An agent with several MCP servers has many tools, so this reorders
constantly. A single test that calls `List()` 50 times on a 16-tool registry
observed 14 distinct orderings.

The MCP client's `ListTools()` (`tool/mcp/tools.go:50`) has the identical
map-range bug. The agent path doesn't hit it (MCP tools are registered into the
registry one by one, so the registry sort covers that path), but `ListTools()`
is a public API whose docstring explicitly says the result is "Passed to an LLM
for tool calling." Anyone building `llm.Request.Tools` from it directly gets the
same cache-busting nondeterminism, and the registry sort does not reach it.

**Caching is opt-in and nobody opts in.** Anthropic's `EnableCaching` defaulted
`false`; `cache_control` markers are written only when it is true; the only way
to flip it was `WithCaching()`. Managed-agent construction never calls it, so
zero markers were ever emitted. Bedrock (which runs Claude on AWS) has the exact
same shape: `enableCaching` defaults `false`, only `bedrock.WithCaching()` flips
it. Bedrock does **not** do automatic prefix caching — the explicit CachePoint
markers are the only way to cache there at all, so default-off meant Bedrock
agents never cached, full stop. For an agent hammering a stable system prompt +
toolset, cache reads are ~90% cheaper; the only cost is a one-time ~25% write
premium, and below the provider's token minimum the marker is simply ignored.
Opt-in just means everyone forgets — which is the bug.

OpenAI, OpenAICompat and Google need no flag change: they cache automatically
server-side with no markers. Their only exposure was the tool-ordering bug,
which the sort fixes.

## Implementation details

This change is gated by unit tests that are red before the fix and green after,
committed in that order so the regression is auditable. The tests are pure unit
tests (no network, no API key) so they gate CI — unlike the existing
integration-only cache tests.

**Tool ordering.** `registry.List()` sorts the assembled slice by
`Definition().Name` before returning; `mcp.clientImpl.ListTools()` does the
same. Tool names are unique (the registry rejects duplicates; MCP namespaces by
server ID), so the sort is a total order and fully deterministic. This is the
single source of truth — every provider consumes the now-sorted `req.Tools`
downstream, so one sort fixes every provider. The audit confirmed no provider
mapper re-sorts or re-randomizes, and that schema mappers build their `required`
arrays deterministically (`encoding/json` already marshals map keys sorted).

**Default-on caching.** `anthropic.NewProvider` and `bedrock.NewProvider` set
the caching flag to true before applying options. `WithCaching()` keeps setting
it true (harmless no-op, kept so existing callers and tests compile unchanged —
adding a bool parameter would be a breaking change). A new
`WithCachingDisabled()` option sets it false for callers who genuinely want to
opt out. The marker-writing logic is unchanged: Anthropic marks the last system
block and the last message; Bedrock inserts a `CachePoint` after the last system
block and the last message content.

**Backward compatibility.** No exported signature changes. `WithCaching()`
remains callable with no arguments. The behavioral delta is deterministic
request bodies and default-on Anthropic/Bedrock markers, both of which are
strictly cache-positive and free below the token minimum.

**What this does not fix.** Deterministic tool order is the SDK-controlled
cache-buster, but it is not the only way a prefix can change turn to turn, and
this PR should not be read as "caching can never miss":

- A **volatile system prompt** defeats everything. `llmagent` calls the
  caller-supplied system-prompt provider every turn; if it interpolates a
  timestamp, date, or session ID, the system breakpoint rewrites every turn and
  tool order is irrelevant. That is the caller's responsibility.
- The valuable breakpoint is the one on the last **system** block (it caches the
  stable tools+system prefix). The last-message marker is incidental — in a
  multi-turn loop it mostly pays write premiums — and is left unchanged here.
- Anthropic's cache lookback is the last 20 content blocks; a single turn with
  more than 20 tool_use/tool_result blocks can push the prior breakpoint out of
  the window and miss. Not introduced here, but default-on makes it relevant to
  tool-heavy agents. Tracked as a follow-up.

## References

- Follow-up (separate, out of scope here): `cloudv2` bumps its pin to pick this
  up. With default-on caching, `apps/ai-agent` needs no caching call-site change
  — `go get github.com/redpanda-data/ai-sdk-go@main && go mod tidy` is the whole
  diff.
