### PR TITLE
feat(tool): forward LLM tool-call id to MCP servers via _meta

### DIFF
--- a/tool/callid.go
+++ b/tool/callid.go
@@ -1,0 +1,38 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tool
+
+import "context"
+
+// toolCallIDKey keys the LLM-issued tool-call id in an execution context.
+type toolCallIDKey struct{}
+
+// WithCallID returns a child context carrying the LLM-issued tool-call id
+// (llm.ToolRequestPart.ID) for the tool execution about to run. The Registry
+// sets this immediately before invoking a tool so that transport-level tool
+// implementations — notably the MCP client — can forward the id to the server
+// for cross-layer correlation (e.g. so a gateway can stamp gen_ai.tool.call.id
+// on its tool-execution span and tie it back to the model turn that requested
+// it). Tools that don't care simply ignore it.
+func WithCallID(ctx context.Context, id string) context.Context {
+	return context.WithValue(ctx, toolCallIDKey{}, id)
+}
+
+// CallIDFromContext returns the tool-call id set by WithCallID, or
+// ("", false) when absent.
+func CallIDFromContext(ctx context.Context) (string, bool) {
+	id, ok := ctx.Value(toolCallIDKey{}).(string)
+	return id, ok
+}

--- a/tool/callid_test.go
+++ b/tool/callid_test.go
@@ -1,0 +1,71 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tool_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/redpanda-data/ai-sdk-go/llm"
+	"github.com/redpanda-data/ai-sdk-go/tool"
+)
+
+func TestWithCallIDRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	id, ok := tool.CallIDFromContext(context.Background())
+	assert.False(t, ok)
+	assert.Empty(t, id)
+
+	ctx := tool.WithCallID(context.Background(), "call_42")
+	id, ok = tool.CallIDFromContext(ctx)
+	assert.True(t, ok)
+	assert.Equal(t, "call_42", id)
+}
+
+// TestRegistryExecuteExposesToolCallID verifies the Registry makes the
+// originating LLM tool-call id (req.ID) visible to the tool's Execute via the
+// context, so transport tools can forward it downstream.
+func TestRegistryExecuteExposesToolCallID(t *testing.T) {
+	t.Parallel()
+
+	var seen string
+
+	var seenOK bool
+
+	registry := tool.NewRegistry(tool.RegistryConfig{})
+	require.NoError(t, registry.Register(&mockTool{
+		name: "probe",
+		execFunc: func(ctx context.Context, _ json.RawMessage) (json.RawMessage, error) {
+			seen, seenOK = tool.CallIDFromContext(ctx)
+
+			return json.RawMessage(`{"ok":true}`), nil
+		},
+	}))
+
+	_, err := registry.Execute(t.Context(), &llm.ToolRequestPart{
+		ID:        "call_xyz",
+		Name:      "probe",
+		Arguments: json.RawMessage(`{}`),
+	})
+	require.NoError(t, err)
+
+	assert.True(t, seenOK, "tool-call id should be present on the execution context")
+	assert.Equal(t, "call_xyz", seen)
+}

--- a/tool/mcp/testutil_test.go
+++ b/tool/mcp/testutil_test.go
@@ -33,6 +33,15 @@ type mockMCPServer struct {
 	mu              sync.Mutex
 	started         bool
 	serverSession   *sdkmcp.ServerSession
+	lastCallMeta    sdkmcp.Meta // _meta of the most recent tools/call, guarded by mu
+}
+
+// lastMeta returns the _meta of the most recent tools/call the server handled.
+func (ms *mockMCPServer) lastMeta() sdkmcp.Meta {
+	ms.mu.Lock()
+	defer ms.mu.Unlock()
+
+	return ms.lastCallMeta
 }
 
 // newMockMCPServer creates a mock MCP server with test tools.
@@ -79,6 +88,12 @@ func newMockMCPServer() *mockMCPServer {
 	// Register tools with handlers
 	for _, t := range ms.tools {
 		ms.server.AddTool(t, func(_ context.Context, req *sdkmcp.CallToolRequest) (*sdkmcp.CallToolResult, error) {
+			// Capture the request _meta so tests can assert what the client
+			// forwarded (e.g. the originating LLM tool-call id).
+			ms.mu.Lock()
+			ms.lastCallMeta = req.Params.Meta
+			ms.mu.Unlock()
+
 			// Parse arguments from raw JSON
 			var args map[string]any
 			if len(req.Params.Arguments) > 0 {

--- a/tool/mcp/toolcallid_test.go
+++ b/tool/mcp/toolcallid_test.go
@@ -1,0 +1,83 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mcp
+
+import (
+	"encoding/json"
+	"testing"
+
+	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/redpanda-data/ai-sdk-go/tool"
+)
+
+// TestExecuteToolForwardsLLMToolCallID verifies that when the execution context
+// carries an LLM tool-call id (as the Registry sets via tool.WithCallID),
+// ExecuteTool forwards it to the server in the tools/call request _meta under
+// MetaKeyLLMToolCallID. Without an id on the context, no such _meta key is sent.
+func TestExecuteToolForwardsLLMToolCallID(t *testing.T) {
+	t.Parallel()
+
+	t.Run("forwards id from context", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+
+		server := newMockMCPServer()
+		transport, err := server.start(ctx)
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = server.stop() })
+
+		client, err := NewClient("test-server", func() (sdkmcp.Transport, error) { return transport, nil })
+		require.NoError(t, err)
+		require.NoError(t, client.Start(ctx))
+		t.Cleanup(func() { _ = client.Close() })
+
+		callCtx := tool.WithCallID(ctx, "call_abc123")
+
+		_, err = client.ExecuteTool(callCtx, "test-server__echo", json.RawMessage(`{"message":"hi"}`))
+		require.NoError(t, err)
+
+		meta := server.lastMeta()
+		require.NotNil(t, meta, "server should have received _meta")
+		assert.Equal(t, "call_abc123", meta[MetaKeyLLMToolCallID],
+			"the originating LLM tool-call id must be forwarded under MetaKeyLLMToolCallID")
+	})
+
+	t.Run("no _meta key when context has no id", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+
+		server := newMockMCPServer()
+		transport, err := server.start(ctx)
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = server.stop() })
+
+		client, err := NewClient("test-server", func() (sdkmcp.Transport, error) { return transport, nil })
+		require.NoError(t, err)
+		require.NoError(t, client.Start(ctx))
+		t.Cleanup(func() { _ = client.Close() })
+
+		// No tool.WithCallID on the context.
+		_, err = client.ExecuteTool(ctx, "test-server__echo", json.RawMessage(`{"message":"hi"}`))
+		require.NoError(t, err)
+
+		_, present := server.lastMeta()[MetaKeyLLMToolCallID]
+		assert.False(t, present, "no tool-call id should be sent when the context carries none")
+	})
+}

--- a/tool/mcp/tools.go
+++ b/tool/mcp/tools.go
@@ -31,6 +31,15 @@ import (
 	"github.com/redpanda-data/ai-sdk-go/tool"
 )
 
+// MetaKeyLLMToolCallID is the MCP request `_meta` key under which the
+// originating LLM tool-call id (llm.ToolRequestPart.ID) is forwarded to the server
+// on a tools/call. A gateway or observability layer can read it to correlate
+// the tool execution back to the model turn that requested it (e.g. stamping
+// gen_ai.tool.call.id on its span). Domain-namespaced per the MCP `_meta`
+// convention so it never collides with the tool's own arguments or with
+// protocol-reserved keys.
+const MetaKeyLLMToolCallID = "redpanda.com/llm-tool-call-id"
+
 // ListTools returns tool definitions for all available MCP server tools.
 //
 // Tool names are namespaced with serverID (e.g., "github__create-issue").
@@ -130,11 +139,19 @@ func (c *clientImpl) ExecuteTool(ctx context.Context, toolName string, args json
 	opCtx, cancel := opContext(bgCtx, ctx)
 	defer cancel()
 
-	// Call MCP server with server tool name (prefix stripped)
-	result, err := session.CallTool(opCtx, &sdkmcp.CallToolParams{
+	// Call MCP server with server tool name (prefix stripped). Forward the
+	// originating LLM tool-call id (when the Registry put one on the context)
+	// in the request _meta so a gateway/observability layer can correlate this
+	// tool execution back to the model turn that requested it.
+	params := &sdkmcp.CallToolParams{
 		Name:      serverToolName,
 		Arguments: argsMap,
-	})
+	}
+	if id, ok := tool.CallIDFromContext(ctx); ok && id != "" {
+		params.Meta = sdkmcp.Meta{MetaKeyLLMToolCallID: id}
+	}
+
+	result, err := session.CallTool(opCtx, params)
 	if err != nil {
 		return nil, fmt.Errorf("tool %q execution failed: %w", toolName, err)
 	}

--- a/tool/registry.go
+++ b/tool/registry.go
@@ -209,6 +209,11 @@ func (r *registry) Execute(ctx context.Context, req *llm.ToolRequestPart) (*llm.
 		defer cancel()
 	}
 
+	// Carry the LLM-issued tool-call id on the execution context so transport
+	// tools (e.g. the MCP client) can forward it to the server for cross-layer
+	// correlation. Harmless for tools that ignore it.
+	executeCtx = WithCallID(executeCtx, req.ID)
+
 	// Execute the tool
 	result, err := registered.tool.Execute(executeCtx, req.Arguments)
 	// Handle execution errors


### PR DESCRIPTION
## What

Threads the originating **LLM tool-call id** (`llm.ToolRequestPart.ID`) from the agent loop down to the MCP server on every `tools/call`:

- `tool.WithCallID` / `tool.CallIDFromContext` — new context helpers (`tool/callid.go`).
- `Registry.Execute` stashes `req.ID` on the execution context immediately before invoking a tool (`tool/registry.go`). Harmless for tools that ignore it.
- The MCP client reads it and forwards it in the `tools/call` request `_meta` under the domain-namespaced key `redpanda.com/llm-tool-call-id`, exported as `mcp.MetaKeyLLMToolCallID` (`tool/mcp/tools.go`).

## Why

Today, when an agent runs LLM and MCP calls through a gateway (e.g. Redpanda's `aigw`), the gateway's MCP tool-execution span carries the tool *name* but not the *which-tool-call* id, so it can't be tied back to the specific model turn that requested it — only grouped by conversation. Forwarding the id lets the gateway stamp `gen_ai.tool.call.id` on its span, enabling a precise tool-use ↔ invocation join (and lets the transcripts consumer dedup the gateway span against the in-agent `execute_tool` span by `conversation + tool.call.id`).

`_meta` is the MCP protocol's sanctioned extensibility slot: servers that don't understand the key ignore it, and the tool's own `arguments` are never touched. When the context carries no id (e.g. a direct `ExecuteTool` call outside the registry), the `_meta` key is simply omitted — no behavior change.

## Tests

- `TestWithCallIDRoundTrip`, `TestRegistryExecuteExposesToolCallID` — context plumbing.
- `TestExecuteToolForwardsLLMToolCallID` — asserts the id reaches the server in `_meta` when present, and is absent when the context carries none.

## Consumer side (separate, in cloudv2)

The matching `aigw` change (read `params._meta` → stamp `gen_ai.tool.call.id` on the MCP span) is a follow-up in the cloudv2 repo; this PR is the producer half and is a no-op until that lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)