### PR TITLE
fix(bedrock): detect geo profiles by prefix, not dot count

### DIFF
--- a/providers/bedrock/cross_region_test.go
+++ b/providers/bedrock/cross_region_test.go
@@ -76,6 +76,17 @@ func TestIsModelAllowedFromRegion(t *testing.T) {
 		{"us from unknown region", ModelClaudeSonnet46US, "xx-fake-1", false},
 		{"global from unknown region", ModelClaudeSonnet46Global, "xx-fake-1", true},
 		{"bare from unknown region (allowed)", ModelClaudeSonnet45, "xx-fake-1", true},
+
+		// Vendor-namespaced IDs with a dotted version (e.g. "openai.gpt-5.5")
+		// are bare, not region-prefixed, and must be allowed from any region —
+		// regression for the dot-counting misclassification that blocked them
+		// everywhere.
+		{"openai dotted-version bare from us-east-2", "openai.gpt-5.5", "us-east-2", true},
+		{"openai dotted-version bare from eu-west-1", "openai.gpt-5.5", "eu-west-1", true},
+		{"openai dotted-version bare from unknown region", "openai.gpt-5.5", "xx-fake-1", true},
+		// A real geo prefix on such an ID is still enforced.
+		{"eu-prefixed openai from us-east-1 (cross-geo)", "eu.openai.gpt-5.5", "us-east-1", false},
+		{"us-prefixed openai from us-east-1", "us.openai.gpt-5.5", "us-east-1", true},
 	}
 
 	for _, tc := range tests {

--- a/providers/bedrock/models.go
+++ b/providers/bedrock/models.go
@@ -154,18 +154,36 @@ func InferenceProfileRegion(region string) string {
 	return prefix
 }
 
-// hasRegionPrefix reports whether a model ID already contains a region
-// inference-profile prefix (e.g. "us.anthropic.claude-sonnet-4-6").
-// It checks for the "{region}.{provider}." pattern by counting dot-separated
-// segments: bare model IDs like "anthropic.claude-sonnet-4-6" have one dot,
-// while prefixed IDs have two or more.
+// geoProfilePrefixes are the Bedrock cross-region and global inference-profile
+// prefixes that can lead a model ID — e.g. the "us" in
+// "us.anthropic.claude-sonnet-4-6" or the "global" in
+// "global.anthropic.claude-opus-4-6-v1".
+var geoProfilePrefixes = map[string]bool{
+	"us":     true,
+	"eu":     true,
+	"apac":   true,
+	"jp":     true,
+	"au":     true,
+	"global": true,
+}
+
+// hasRegionPrefix reports whether a model ID already begins with a Bedrock
+// region/global inference-profile prefix (e.g. "us.anthropic.claude-sonnet-4-6"
+// or "global.anthropic.claude-opus-4-6-v1").
+//
+// It matches the leading dot-separated segment against the known geo-profile
+// prefixes rather than counting dots. Dot-counting misclassifies
+// vendor-namespaced IDs whose model component itself contains a dot — notably
+// "openai.gpt-5.5" (the "5.5" version) — as region-prefixed. That mistake both
+// blocks such models from every region in IsModelAllowedFromRegion (no geo
+// matches the "openai" pseudo-prefix) and mis-prepends a profile in NewModel.
 func hasRegionPrefix(modelID string) bool {
-	_, after, ok := strings.Cut(modelID, ".")
+	prefix, _, ok := strings.Cut(modelID, ".")
 	if !ok {
 		return false
 	}
 
-	return strings.ContainsRune(after, '.')
+	return geoProfilePrefixes[prefix]
 }
 
 // lookupModel finds a ModelDefinition by exact model ID. Each inference

--- a/providers/bedrock/provider_test.go
+++ b/providers/bedrock/provider_test.go
@@ -71,6 +71,15 @@ func TestHasRegionPrefix(t *testing.T) {
 		{"apac.anthropic.claude-sonnet-4-6", true},
 		{"global.anthropic.claude-sonnet-4-6", true},
 		{"no-dots-here", false},
+		// Vendor-namespaced IDs whose version carries its own dot must not be
+		// mistaken for region-prefixed (the dot-counting bug). "openai" is not
+		// a geo prefix, so these are bare.
+		{"openai.gpt-5.5", false},
+		{"openai.gpt-5.4", false},
+		{"openai.gpt-oss-120b-1:0", false},
+		// A genuine geo prefix in front of such an ID is still detected.
+		{"us.openai.gpt-5.5", true},
+		{"eu.openai.gpt-5.5", true},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Problem

`hasRegionPrefix` (providers/bedrock/models.go) decided whether a model ID already carries a Bedrock inference-profile prefix by **counting dots** — one dot = bare, two or more = region-prefixed:

```go
_, after, _ := strings.Cut(modelID, ".")
return strings.ContainsRune(after, '.')
```

That misclassifies vendor-namespaced IDs whose **model component contains its own dot** — notably the OpenAI Mantle models `openai.gpt-5.5` and `openai.gpt-5.4`, where the `5.5` version adds a second dot. `hasRegionPrefix("openai.gpt-5.5")` returns `true`, with the leading segment read as a geo prefix of `openai`.

### Fallout

- **`IsModelAllowedFromRegion`** then compares `openai` against the source region's geography. It matches none, so the cross-region interceptor rejects `openai.gpt-5.5` **from every region** — there is no region you can invoke it from.
- **`NewModel`** mis-prepends a region profile (`InferenceProfileRegion(region) + "."`) only when `hasRegionPrefix` is false, so the misclassification also skews ID construction.

Net effect: an AI Gateway Bedrock provider cannot invoke `openai.gpt-5.5` at all (confirmed live against an AI-Gateway Bedrock provider — the gateway returns `cross_region_inference_profile` before the request ever reaches AWS).

## Fix

Match the leading dot-separated segment against the known Bedrock geo-profile prefixes (`us`/`eu`/`apac`/`jp`/`au`/`global`) instead of counting dots.

This is behavior-preserving for the catalog: every `supportedModels` key is either bare (`anthropic.claude-fable-5`) or genuinely geo-prefixed (`us.`/`eu.`/`au.`/`jp.`/`global.`), and both old and new logic agree on all of them. Only `vendor.<dotted-version>` IDs change classification — which is exactly the bug.

## Tests

- `TestHasRegionPrefix`: `openai.gpt-5.5`, `openai.gpt-5.4`, `openai.gpt-oss-120b-1:0` → false; `us.openai.gpt-5.5`, `eu.openai.gpt-5.5` → true.
- `TestIsModelAllowedFromRegion`: `openai.gpt-5.5` allowed from `us-east-2`/`eu-west-1`/unknown; `eu.openai.gpt-5.5` still rejected cross-geo from `us-east-1`.

`go test ./providers/bedrock/...` passes; `gofmt`/`go vet` clean.
