### PR TITLE
providers: add Claude Sonnet 5 (Anthropic + Bedrock)

### DIFF
--- a/.claude/skills/model-maintenance/SKILL.md
+++ b/.claude/skills/model-maintenance/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: model-maintenance
+description: >-
+  Guidance for adding or updating LLM models in this repo's provider catalogs
+  (providers/*/models.go). Use when registering a new model, a new model
+  snapshot, or new region/profile variants, especially on Bedrock. Pairs with
+  the "Adding New Models" pricing rules in CLAUDE.md.
+---
+
+# Model maintenance
+
+When you add a model to any provider's `supportedModels` map you **must** set
+`Pricing` (microcents per million tokens) — see the "Adding New Models" section
+in `CLAUDE.md` for the conversion and the per-provider `TestAllModelsHavePricing`
+requirement. Below is the extra process that is specific to Bedrock.
+
+## Adding a new Bedrock model
+
+Bedrock exposes each Claude model only through **cross-region inference
+profiles** (`us.`, `eu.`, `global.`, and so on), never the bare
+`anthropic.<model>` id — invoking the bare id returns a `ValidationException`
+("on-demand throughput isn't supported"), so register one entry per *published
+profile* in `providers/bedrock/models.go` and do **not** add a bare entry.
+Confirm which profiles actually exist by invoking each candidate with a one-token
+`Converse` request rather than guessing: a working profile returns output, an
+unpublished one returns `ValidationException` ("the provided model identifier is
+invalid") even from its home region, and a published-but-unsubscribed one returns
+`AccessDeniedException`. A newly released model is often US- and global-only at
+first, with other geos published later. Pricing is per-profile: the `global.`
+profile is the cheapest and each geo profile is exactly `1.10x` the global rate in
+every column (enforced by `TestGeoGlobalRatio`) — spell every rate out in place,
+and reuse the shared capability/constraint vars when the context window matches an
+existing generation. Add a lookup test (the new profiles present; the bare and any
+unpublished profile absent) plus a region-allow test; the integration conformance
+suite then picks the new entries up automatically through `Models()`.
+
+Separately, a catalog entry is not invokable until the **account** has accepted
+the model's Bedrock agreement (an AWS Marketplace subscription) in **every region
+the profile routes across** — a `us.` cross-region profile needs the agreement
+enabled in all of its member regions, not just the entry region. Enable it from
+the Bedrock "Model access" console page, or with
+`aws bedrock create-foundation-model-agreement` (after
+`list-foundation-model-agreement-offers` to get the offer token); newly released
+Anthropic models are usually already authorized at the account level, so this is a
+one-time acceptance with no use-case form. Until access is granted, invocation
+returns `AccessDeniedException` mentioning the required `aws-marketplace` actions.
+The conformance suite's `isModelAccessGate` treats that as "in the catalog but not
+subscribed by this account" and **skips** the model, so CI stays green for entries
+the test account hasn't enabled yet; once the account is subscribed, the same test
+exercises the model for real with no code change.

--- a/providers/anthropic/alias_test.go
+++ b/providers/anthropic/alias_test.go
@@ -40,6 +40,16 @@ func TestModelResolution(t *testing.T) {
 			expectedModel: "claude-fable-5-20260604",
 		},
 		{
+			name:          "claude-sonnet-5 family name resolves",
+			modelKey:      "claude-sonnet-5",
+			expectedModel: "claude-sonnet-5",
+		},
+		{
+			name:          "claude-sonnet-5 timestamped preserves original",
+			modelKey:      "claude-sonnet-5-20260601",
+			expectedModel: "claude-sonnet-5-20260601",
+		},
+		{
 			name:          "claude-sonnet-4-6 family name resolves",
 			modelKey:      "claude-sonnet-4-6",
 			expectedModel: "claude-sonnet-4-6",
@@ -257,6 +267,20 @@ func TestWithEffort(t *testing.T) {
 		require.True(t, ok)
 		require.NotNil(t, m.config.Effort)
 		assert.Equal(t, EffortMax, *m.config.Effort)
+	})
+
+	t.Run("all effort levels accepted on Sonnet 5", func(t *testing.T) {
+		t.Parallel()
+
+		for _, effort := range []Effort{EffortLow, EffortMedium, EffortHigh, EffortXHigh, EffortMax} {
+			model, err := provider.NewModel(ModelClaudeSonnet5, WithEffort(effort))
+			require.NoError(t, err)
+
+			m, ok := model.(*Model)
+			require.True(t, ok)
+			require.NotNil(t, m.config.Effort)
+			assert.Equal(t, effort, *m.config.Effort)
+		}
 	})
 
 	t.Run("all effort levels accepted on Fable 5", func(t *testing.T) {

--- a/providers/anthropic/models.go
+++ b/providers/anthropic/models.go
@@ -26,6 +26,7 @@ import (
 // accepts them directly and resolves to the latest snapshot.
 const (
 	ModelClaudeFable5   = "claude-fable-5"
+	ModelClaudeSonnet5  = "claude-sonnet-5"
 	ModelClaudeSonnet46 = "claude-sonnet-4-6"
 	ModelClaudeSonnet45 = "claude-sonnet-4-5"
 	ModelClaudeHaiku45  = "claude-haiku-4-5"
@@ -190,6 +191,39 @@ var supportedModels = map[string]ModelDefinition{
 		AdaptiveThinking: true,
 		Pricing: pricing.FlatInfoFromRates(
 			pricing.NewRates(5.00, 25.00, 0.50).WithCacheCreation(6.25, 10.00, 0),
+		),
+	},
+	ModelClaudeSonnet5: {
+		Name:  ModelClaudeSonnet5,
+		Label: "Claude Sonnet 5",
+		Capabilities: llm.ModelCapabilities{
+			Streaming:        true,
+			Tools:            true,
+			JSONMode:         false, // Anthropic doesn't have native JSON mode
+			StructuredOutput: false, // Use tool calling for structured output instead
+			Vision:           true,
+			MultiTurn:        true,
+			SystemPrompts:    true,
+			Reasoning:        true, // Adaptive thinking only; use effort to bias toward more/less thinking
+		},
+		Constraints: llm.ModelConstraints{
+			TemperatureRange: [2]float64{0.0, 1.0},
+			MaxInputTokens:   1000000, // 1M context window
+			MaxOutputTokens:  128000,  // 128K output tokens
+			// Sonnet 5 shares Opus 4.7's request surface: manual thinking budget
+			// is removed (adaptive thinking + effort instead), no fast mode.
+			SupportedParams:   []string{"temperature", "top_p", "top_k", "max_tokens", "effort"},
+			MutuallyExclusive: [][]string{},
+		},
+		// First Sonnet-tier model with xhigh; supports the full effort range.
+		SupportedEfforts: []Effort{EffortLow, EffortMedium, EffortHigh, EffortXHigh, EffortMax},
+		AdaptiveThinking: true,
+		Pricing: pricing.FlatInfoFromRates(
+			// List price $3/$15 per MTok (the introductory $2/$10 through
+			// 2026-08-31 is deliberately not tracked here). Cache rates from
+			// Anthropic's prompt-caching multipliers (5m-write 1.25x, 1h-write 2x,
+			// cache-read 0.10x of base input).
+			pricing.NewRates(3.00, 15.00, 0.30).WithCacheCreation(3.75, 6.00, 0),
 		),
 	},
 	ModelClaudeSonnet46: {

--- a/providers/bedrock/cross_region_test.go
+++ b/providers/bedrock/cross_region_test.go
@@ -32,6 +32,13 @@ func TestIsModelAllowedFromRegion(t *testing.T) {
 		{"bare from eu", ModelClaudeSonnet45, "eu-west-1", true},
 		{"bare from unknown region", ModelClaudeSonnet45, "xx-fake-1", true},
 
+		// Sonnet 5 — only us. and global. are published; us. honours geo rules.
+		{"sonnet5 bare from eu", ModelClaudeSonnet5, "eu-west-1", true},
+		{"sonnet5 us from us-east-1", ModelClaudeSonnet5US, "us-east-1", true},
+		{"sonnet5 us from ca-central-1 (Canada is US Geo)", ModelClaudeSonnet5US, "ca-central-1", true},
+		{"sonnet5 us from eu-west-1 (cross-geo)", ModelClaudeSonnet5US, "eu-west-1", false},
+		{"sonnet5 global from me-central-1", ModelClaudeSonnet5Global, "me-central-1", true},
+
 		// global.* is always allowed.
 		{"global from us", ModelClaudeSonnet46Global, "us-east-1", true},
 		{"global from eu", ModelClaudeSonnet46Global, "eu-west-1", true},

--- a/providers/bedrock/models.go
+++ b/providers/bedrock/models.go
@@ -50,6 +50,16 @@ const (
 	ModelClaudeFable5US     = "us." + ModelClaudeFable5
 	ModelClaudeFable5EU     = "eu." + ModelClaudeFable5
 
+	// ModelClaudeSonnet5 is the bare Bedrock ID for Claude Sonnet 5
+	// (inference-profile-only — invoke via one of the prefixed variants).
+	// Only us. and global. profiles are published so far (verified by
+	// invocation 2026-06: us. succeeds, global. is IAM-gated, and eu./au./jp.
+	// return ValidationException "model identifier is invalid" even from their
+	// home regions). Add geo profiles here once AWS publishes them.
+	ModelClaudeSonnet5       = "anthropic.claude-sonnet-5"
+	ModelClaudeSonnet5Global = "global." + ModelClaudeSonnet5
+	ModelClaudeSonnet5US     = "us." + ModelClaudeSonnet5
+
 	// ModelClaudeSonnet46 is the bare Bedrock ID for Claude Sonnet 4.6
 	// (inference-profile-only — invoke via one of the prefixed variants).
 	ModelClaudeSonnet46       = "anthropic.claude-sonnet-4-6"
@@ -432,6 +442,29 @@ var supportedModels = map[string]ModelDefinition{
 		Constraints:  claudeContext200kConstraints,
 		Pricing: pricing.FlatInfoFromRates(
 			pricing.NewRates(5.50, 27.50, 0.55).WithCacheCreation(6.875, 11.00, 0),
+		),
+	},
+
+	// ----------------------------------------------------------------
+	// Claude Sonnet 5 — inference-profile-only, no bare entry. Only us
+	// and global are published so far (see const block); 1M context.
+	// ----------------------------------------------------------------
+	ModelClaudeSonnet5Global: {
+		Name:         ModelClaudeSonnet5Global,
+		Label:        "Claude Sonnet 5 (Global)",
+		Capabilities: claudeStandardCaps,
+		Constraints:  claudeContext1MConstraints,
+		Pricing: pricing.FlatInfoFromRates(
+			pricing.NewRates(3.00, 15.00, 0.30).WithCacheCreation(3.75, 6.00, 0),
+		),
+	},
+	ModelClaudeSonnet5US: {
+		Name:         ModelClaudeSonnet5US,
+		Label:        "Claude Sonnet 5 (US)",
+		Capabilities: claudeStandardCaps,
+		Constraints:  claudeContext1MConstraints,
+		Pricing: pricing.FlatInfoFromRates(
+			pricing.NewRates(3.30, 16.50, 0.33).WithCacheCreation(4.125, 6.60, 0),
 		),
 	},
 

--- a/providers/bedrock/provider_test.go
+++ b/providers/bedrock/provider_test.go
@@ -117,6 +117,28 @@ func TestLookupModel(t *testing.T) {
 			wantOK: false,
 		},
 		{
+			name:   "Sonnet 5 bare ID is not in the catalog",
+			input:  ModelClaudeSonnet5,
+			wantOK: false,
+		},
+		{
+			name:    "Sonnet 5 US profile is its own entry",
+			input:   ModelClaudeSonnet5US,
+			wantOK:  true,
+			wantDef: ModelClaudeSonnet5US,
+		},
+		{
+			name:    "Sonnet 5 global profile is its own entry",
+			input:   ModelClaudeSonnet5Global,
+			wantOK:  true,
+			wantDef: ModelClaudeSonnet5Global,
+		},
+		{
+			name:   "Sonnet 5 eu profile is not published yet",
+			input:  "eu." + ModelClaudeSonnet5,
+			wantOK: false,
+		},
+		{
 			// The Bedrock catalog registers inference-profile variants so
 			// pricing and routing metadata stay explicit per profile.
 			name:   "Fable 5 bare ID is not in the catalog",

--- a/providers/conformance/suite.go
+++ b/providers/conformance/suite.go
@@ -1539,16 +1539,27 @@ func testAllSupportedModels(t *testing.T, fixture Fixture) { //nolint:thelper //
 }
 
 // isModelAccessGate reports whether err indicates the model exists in the
-// provider's catalog but is not accessible to the test account. For example,
-// Anthropic returns a 404 not_found_error with "<model> is not available" for
-// gated models such as Fable 5 (which requires Mythos access). Such models
-// should be skipped rather than failing conformance, while accounts that do
-// have access still exercise them.
+// provider's catalog but is not accessible to the test account. Two shapes:
+//
+//   - Anthropic returns a 404 not_found_error with "<model> is not available"
+//     for gated models such as Fable 5 (which requires Mythos access).
+//   - Bedrock returns an AccessDeniedException whose message points at the
+//     missing AWS Marketplace subscription ("Model access is denied ... not
+//     authorized to perform the required AWS Marketplace actions") for models
+//     the account hasn't subscribed to yet — newly released models like
+//     Sonnet 5 land here until the workspace enables them.
+//
+// Such models should be skipped rather than failing conformance, while
+// accounts that do have access still exercise them.
 func isModelAccessGate(err error) bool {
 	var perr *llm.ProviderError
 	if !errors.As(err, &perr) {
 		return false
 	}
 
-	return strings.Contains(perr.Message, "is not available")
+	msg := strings.ToLower(perr.Message)
+
+	return strings.Contains(msg, "is not available") ||
+		strings.Contains(msg, "model access is denied") ||
+		strings.Contains(msg, "aws-marketplace")
 }


### PR DESCRIPTION
## What

Add Claude Sonnet 5 (`claude-sonnet-5`) to the Anthropic provider and to Bedrock, with unit/conformance coverage on both. No existing model is changed.

## Why

Sonnet 5 is GA and is the new Sonnet-tier default — near-Opus quality on coding and agentic work at Sonnet pricing. The SDK should expose it on both the first-party Anthropic API and Bedrock.

## Implementation details

### Anthropic

Sonnet 5 shares Opus 4.7's request surface, so the catalog entry mirrors it: adaptive thinking only (no manual `thinking_budget`), effort `low..max` (first Sonnet tier to accept `xhigh`), no fast mode. 1M context, 128K output. List price $3/$15 per MTok with cache rates from the standard prompt-caching multipliers (5m-write 1.25x, 1h-write 2x, cache-read 0.10x). The introductory $2/$10 rate is intentionally not tracked — the catalog carries list price.

### Bedrock

Only the `us.` and `global.` inference profiles are registered. This was verified by invocation against the account, not guessed:

- `us.anthropic.claude-sonnet-5` invokes successfully.
- `global.anthropic.claude-sonnet-5` exists but is IAM-gated for the service user, same as every other `global.` profile.
- bare `anthropic.claude-sonnet-5` returns "on-demand throughput isn't supported" (inference-profile-only, so no bare catalog entry — matches every 4.5+ model).
- `eu.`/`au.`/`jp.` return ValidationException "model identifier is invalid" even from their home regions, so they are deliberately omitted until AWS publishes them.

Pricing follows the existing rule: the `us.` geo rate is exactly 1.10x the `global.` rate in every priced column, so `TestGeoGlobalRatio` holds. Uses the shared 1M-context constraints.

### Tests

- Anthropic: model-resolution (family + timestamped), full effort-range acceptance.
- Bedrock: region-allow rules (`us.`/`global.`/bare/cross-geo) and catalog lookup (`us.`/`global.` present, bare and `eu.` absent).
- The integration conformance suites pick the new models up automatically via `Models()` — exercised live in CI (Anthropic API + Bedrock `us-east-1`).

## References

Model card: https://www.anthropic.com/news/claude-sonnet-5
