### PR TITLE
llm: expose model constraints via provider.Models()

### DIFF
--- a/llm/api.go
+++ b/llm/api.go
@@ -25,6 +25,10 @@ import (
 // performing any generation. This is useful for model discovery, capability
 // checking, and routing decisions.
 //
+// To inspect a provider's model catalog without constructing models, use
+// Provider.Models(), which returns the same metadata as ModelDiscoveryInfo
+// values.
+//
 // Example:
 //
 //	model := provider.NewModel("gpt-4o")

--- a/llm/types.go
+++ b/llm/types.go
@@ -304,7 +304,10 @@ type ModelCapabilities struct {
 	Reasoning        bool // Supports reasoning controls and exposes reasoning traces
 }
 
-// ModelDiscoveryInfo provides metadata about a model that can be discovered at runtime.
+// ModelDiscoveryInfo provides metadata about a model that can be discovered at
+// runtime, without constructing the model. It is the static counterpart of the
+// ModelInfo interface: Name, Provider, Capabilities, and Constraints mirror the
+// ModelInfo accessors, plus discovery-only fields (Label, Metadata).
 // This is returned by provider.Models() for model discovery and capability checking.
 type ModelDiscoveryInfo struct {
 	// Name is the model identifier used in API calls
@@ -315,6 +318,11 @@ type ModelDiscoveryInfo struct {
 
 	// Capabilities describes what features this model supports
 	Capabilities ModelCapabilities
+
+	// Constraints carries the model's validation rules and token limits.
+	// MaxInputTokens is the context window size; MaxOutputTokens the
+	// per-response generation cap.
+	Constraints ModelConstraints
 
 	// Provider is the name of the provider that offers this model
 	Provider string

--- a/providers/anthropic/provider.go
+++ b/providers/anthropic/provider.go
@@ -231,6 +231,7 @@ func (*Provider) Models() []llm.ModelDiscoveryInfo {
 			Name:         def.Name,
 			Label:        def.Label,
 			Capabilities: def.Capabilities,
+			Constraints:  def.Constraints,
 			Provider:     "anthropic",
 		})
 	}

--- a/providers/anthropic/provider_test.go
+++ b/providers/anthropic/provider_test.go
@@ -101,3 +101,17 @@ func TestWithBaseURLNormalization(t *testing.T) {
 		})
 	}
 }
+
+func TestModelsDiscoveryConstraints(t *testing.T) {
+	t.Parallel()
+
+	models := (&Provider{}).Models()
+	assert.Len(t, models, len(supportedModels))
+
+	for _, m := range models {
+		assert.Positive(t, m.Constraints.MaxInputTokens,
+			"model %s missing MaxInputTokens — set Constraints in its ModelDefinition", m.Name)
+		assert.Positive(t, m.Constraints.MaxOutputTokens,
+			"model %s missing MaxOutputTokens — set Constraints in its ModelDefinition", m.Name)
+	}
+}

--- a/providers/bedrock/provider.go
+++ b/providers/bedrock/provider.go
@@ -228,6 +228,7 @@ func (p *Provider) Models() []llm.ModelDiscoveryInfo {
 			Name:         def.Name,
 			Label:        def.Label,
 			Capabilities: def.Capabilities,
+			Constraints:  def.Constraints,
 			Provider:     p.Name(),
 			Metadata:     def.discoveryMetadata(),
 		})

--- a/providers/bedrock/provider_test.go
+++ b/providers/bedrock/provider_test.go
@@ -1049,6 +1049,10 @@ func TestModelsDiscovery(t *testing.T) {
 		assert.Equal(t, "aws.bedrock", m.Provider)
 		assert.NotEmpty(t, m.Name)
 		assert.NotEmpty(t, m.Label)
+		assert.Positive(t, m.Constraints.MaxInputTokens,
+			"model %s missing MaxInputTokens — set Constraints in its ModelDefinition", m.Name)
+		assert.Positive(t, m.Constraints.MaxOutputTokens,
+			"model %s missing MaxOutputTokens — set Constraints in its ModelDefinition", m.Name)
 	}
 
 	// Verify sorted by name

--- a/providers/conformance/suite.go
+++ b/providers/conformance/suite.go
@@ -1493,6 +1493,23 @@ func testAllSupportedModels(t *testing.T, fixture Fixture) { //nolint:thelper //
 		t.Skip("No models available for testing")
 	}
 
+	t.Run("discovery info exposes constraints", func(t *testing.T) {
+		for _, m := range models {
+			assert.Positive(t, m.Constraints.MaxInputTokens,
+				"model %s missing MaxInputTokens in discovery info", m.Name)
+			assert.Positive(t, m.Constraints.MaxOutputTokens,
+				"model %s missing MaxOutputTokens in discovery info", m.Name)
+
+			model, err := fixture.NewModel(m.Name)
+			if err != nil {
+				continue
+			}
+
+			assert.Equal(t, model.Constraints(), m.Constraints,
+				"discovery constraints for %s should match the instantiated model's constraints", m.Name)
+		}
+	})
+
 	// Run sequentially (not parallel) to avoid rate limiting across providers.
 	// Each model is wrapped with retry to handle transient errors.
 	t.Run("basic generation works for all supported models", func(t *testing.T) {

--- a/providers/google/google_test.go
+++ b/providers/google/google_test.go
@@ -58,6 +58,10 @@ func TestProviderModels(t *testing.T) {
 		assert.NotEmpty(t, model.Name, "Model name should not be empty")
 		assert.NotEmpty(t, model.Label, "Model label should not be empty")
 		assert.Equal(t, "gcp.gemini", model.Provider, "Provider should be 'gcp.gemini'")
+		assert.Positive(t, model.Constraints.MaxInputTokens,
+			"model %s missing MaxInputTokens — set Constraints in its ModelDefinition", model.Name)
+		assert.Positive(t, model.Constraints.MaxOutputTokens,
+			"model %s missing MaxOutputTokens — set Constraints in its ModelDefinition", model.Name)
 	}
 
 	// Verify expected models are present

--- a/providers/google/provider.go
+++ b/providers/google/provider.go
@@ -197,6 +197,7 @@ func (p *Provider) Models() []llm.ModelDiscoveryInfo {
 			Name:         def.Name,
 			Label:        def.Label,
 			Capabilities: def.Capabilities,
+			Constraints:  def.Constraints,
 			Provider:     p.Name(),
 		})
 	}

--- a/providers/openai/openai_test.go
+++ b/providers/openai/openai_test.go
@@ -102,6 +102,10 @@ func TestProviderModels(t *testing.T) {
 		assert.NotEmpty(t, model.Name, "Model name should not be empty")
 		assert.NotEmpty(t, model.Label, "Model label should not be empty")
 		assert.Equal(t, "openai", model.Provider, "Provider should be 'openai'")
+		assert.Positive(t, model.Constraints.MaxInputTokens,
+			"model %s missing MaxInputTokens — set Constraints in its ModelDefinition", model.Name)
+		assert.Positive(t, model.Constraints.MaxOutputTokens,
+			"model %s missing MaxOutputTokens — set Constraints in its ModelDefinition", model.Name)
 	}
 
 	// Verify expected models are present
@@ -638,9 +642,10 @@ func TestMessageMappingWithToolParts(t *testing.T) {
 					Role: llm.RoleUser,
 					Content: []llm.Part{
 						&llm.ToolResponsePart{
-							ID:    "call_123",
-							Name:  "get_weather",
-							IsError: true, Result: json.RawMessage(`{"error":"API rate limit exceeded"}`),						},
+							ID:      "call_123",
+							Name:    "get_weather",
+							IsError: true, Result: json.RawMessage(`{"error":"API rate limit exceeded"}`),
+						},
 					},
 				},
 			},

--- a/providers/openai/provider.go
+++ b/providers/openai/provider.go
@@ -186,6 +186,7 @@ func (*Provider) Models() []llm.ModelDiscoveryInfo {
 			Name:         def.Name,
 			Label:        def.Label,
 			Capabilities: def.Capabilities,
+			Constraints:  def.Constraints,
 			Provider:     "openai",
 		})
 	}


### PR DESCRIPTION
## Why

An AI gateway consumer wants to list models with their metadata — notably max context size — without instantiating each model. Today `MaxInputTokens`/`MaxOutputTokens` are hardcoded in every provider's catalog but only reachable via `NewModel(name)` → `Constraints()`.

## What

- Add `Constraints llm.ModelConstraints` to `llm.ModelDiscoveryInfo` and populate it in `Models()` for anthropic, openai, google, and bedrock (openaicompat is dynamic and returns no catalog). Non-breaking: additive struct field, existing consumers unaffected.
- Discovery info now mirrors the `ModelInfo` interface (Name, Provider, Capabilities, Constraints) — doc comments cross-reference the two.
- Unit tests assert every cataloged model exposes positive token limits; the conformance suite checks discovery constraints match the instantiated model's constraints.

Pricing stays with the existing static `ModelPricing()` accessors (`pricing` imports `llm`, so `ModelDiscoveryInfo` can't reference `pricing.Info`); consumers can join by model name.

Usage:
```go
for _, m := range provider.Models() {
    ctx := m.Constraints.MaxInputTokens // context window, no instantiation
}
```