### PR TITLE
session: add List to the Store interface

### DIFF
--- a/runner/runner_test.go
+++ b/runner/runner_test.go
@@ -671,6 +671,7 @@ type mockSessionStore struct {
 	loadFunc   func(context.Context, string) (*session.State, error)
 	saveFunc   func(context.Context, *session.State) error
 	deleteFunc func(context.Context, string) error
+	listFunc   func(context.Context, *session.ListRequest) (*session.ListResponse, error)
 }
 
 func (m *mockSessionStore) Load(ctx context.Context, sessionID string) (*session.State, error) {
@@ -695,4 +696,12 @@ func (m *mockSessionStore) Delete(ctx context.Context, sessionID string) error {
 	}
 
 	return nil
+}
+
+func (m *mockSessionStore) List(ctx context.Context, req *session.ListRequest) (*session.ListResponse, error) {
+	if m.listFunc != nil {
+		return m.listFunc(ctx, req)
+	}
+
+	return &session.ListResponse{}, nil
 }

--- a/store/session/kvstore/kvstore.go
+++ b/store/session/kvstore/kvstore.go
@@ -169,6 +169,13 @@ func (s *KVStore) Delete(ctx context.Context, sessionID string) error {
 	return s.client.Delete(ctx, []byte(sessionID))
 }
 
+// List always returns session.ErrListNotSupported: the Kafka key-value
+// backend is keyed by session ID and cannot enumerate sessions. This store is
+// slated for deprecation, so enumeration is intentionally not implemented.
+func (*KVStore) List(_ context.Context, _ *session.ListRequest) (*session.ListResponse, error) {
+	return nil, session.ErrListNotSupported
+}
+
 // Close shuts down the kvstore client and releases resources.
 func (s *KVStore) Close() error {
 	return s.raw.Close()

--- a/store/session/kvstore/kvstore_test.go
+++ b/store/session/kvstore/kvstore_test.go
@@ -27,6 +27,18 @@ import (
 	"github.com/redpanda-data/ai-sdk-go/store/session/kvstore"
 )
 
+// TestKVStore_ListNotSupported needs no broker: List ignores the client and
+// always reports that the key-value backend cannot enumerate sessions.
+func TestKVStore_ListNotSupported(t *testing.T) {
+	t.Parallel()
+
+	store := &kvstore.KVStore{}
+
+	resp, err := store.List(t.Context(), &session.ListRequest{})
+	require.ErrorIs(t, err, session.ErrListNotSupported)
+	require.Nil(t, resp)
+}
+
 func TestKVStore_LoadSaveDelete(t *testing.T) { //nolint:paralleltest // Serial to reduce container memory pressure
 	if testing.Short() {
 		t.Skip("skipping integration test")

--- a/store/session/memory.go
+++ b/store/session/memory.go
@@ -16,6 +16,10 @@ package session
 
 import (
 	"context"
+	"fmt"
+	"maps"
+	"sort"
+	"strconv"
 	"time"
 
 	"github.com/twmb/go-cache/cache"
@@ -28,6 +32,10 @@ const (
 
 	// DefaultCleanupInterval is how often the cache automatically cleans up expired sessions.
 	DefaultCleanupInterval = 1 * time.Hour
+
+	// DefaultListPageSize is the number of summaries List returns when
+	// ListRequest.PageSize is non-positive.
+	DefaultListPageSize = 50
 )
 
 // InMemoryStore provides an in-memory session storage implementation with automatic expiration.
@@ -108,10 +116,15 @@ func (s *InMemoryStore) Load(_ context.Context, sessionID string) (*State, error
 // Save persists a session and resets its expiration timer.
 //
 // If a session with the same ID already exists, it is completely replaced.
-// The state is cloned before storing to prevent external modifications.
+// The state is cloned before storing to prevent external modifications, and
+// UpdatedAt is stamped with the current time (storage-managed; the caller's
+// value is ignored).
 func (s *InMemoryStore) Save(_ context.Context, state *State) error {
 	// Clone to prevent external modifications
-	s.cache.Set(state.ID, state.Clone())
+	clone := state.Clone()
+	clone.UpdatedAt = time.Now()
+	s.cache.Set(state.ID, clone)
+
 	return nil
 }
 
@@ -122,4 +135,65 @@ func (s *InMemoryStore) Delete(_ context.Context, sessionID string) error {
 	//nolint:dogsled // cache.Delete returns (value, existed, evicted); we don't need any of these
 	_, _, _ = s.cache.Delete(sessionID)
 	return nil
+}
+
+// List returns a page of session summaries ordered by UpdatedAt descending,
+// then ID ascending. The page token is a plain offset into that ordering:
+// adequate for an in-memory store, though durable stores should prefer keyset
+// pagination. Summaries omit the message payload.
+func (s *InMemoryStore) List(_ context.Context, req *ListRequest) (*ListResponse, error) {
+	if req == nil {
+		req = &ListRequest{}
+	}
+
+	summaries := make([]Summary, 0)
+
+	s.cache.Range(func(id string, state *State, err error) bool {
+		if err != nil || state == nil {
+			return true
+		}
+
+		summaries = append(summaries, Summary{
+			ID:        id,
+			Metadata:  maps.Clone(state.Metadata),
+			UpdatedAt: state.UpdatedAt,
+		})
+
+		return true
+	})
+
+	sort.Slice(summaries, func(i, j int) bool {
+		if !summaries[i].UpdatedAt.Equal(summaries[j].UpdatedAt) {
+			return summaries[i].UpdatedAt.After(summaries[j].UpdatedAt)
+		}
+
+		return summaries[i].ID < summaries[j].ID
+	})
+
+	offset := 0
+
+	if req.PageToken != "" {
+		n, err := strconv.Atoi(req.PageToken)
+		if err != nil || n < 0 {
+			return nil, fmt.Errorf("session: invalid page token %q", req.PageToken)
+		}
+
+		offset = n
+	}
+
+	offset = min(offset, len(summaries))
+
+	pageSize := int(req.PageSize)
+	if pageSize <= 0 {
+		pageSize = DefaultListPageSize
+	}
+
+	end := min(offset+pageSize, len(summaries))
+
+	resp := &ListResponse{Sessions: summaries[offset:end]}
+	if end < len(summaries) {
+		resp.NextPageToken = strconv.Itoa(end)
+	}
+
+	return resp, nil
 }

--- a/store/session/memory_test.go
+++ b/store/session/memory_test.go
@@ -1,0 +1,163 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package session_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/redpanda-data/ai-sdk-go/store/session"
+)
+
+// saveSpaced saves the given IDs in order, spacing the writes so each gets a
+// strictly greater UpdatedAt (the store stamps time.Now()). Returns the store.
+func saveSpaced(t *testing.T, ids ...string) *session.InMemoryStore {
+	t.Helper()
+
+	store := session.NewInMemoryStore()
+	for _, id := range ids {
+		require.NoError(t, store.Save(context.Background(), &session.State{ID: id}))
+		time.Sleep(2 * time.Millisecond)
+	}
+
+	return store
+}
+
+func TestInMemoryStore_SaveStampsUpdatedAt(t *testing.T) {
+	t.Parallel()
+
+	store := session.NewInMemoryStore()
+
+	before := time.Now()
+	// The caller's UpdatedAt is ignored; the store stamps the write time.
+	require.NoError(t, store.Save(context.Background(), &session.State{
+		ID:        "s1",
+		UpdatedAt: time.Unix(0, 0),
+	}))
+
+	after := time.Now()
+
+	loaded, err := store.Load(context.Background(), "s1")
+	require.NoError(t, err)
+	require.False(t, loaded.UpdatedAt.Before(before), "UpdatedAt should be >= before")
+	require.False(t, loaded.UpdatedAt.After(after), "UpdatedAt should be <= after")
+}
+
+func TestInMemoryStore_ListOrdersByUpdatedAtDescThenID(t *testing.T) {
+	t.Parallel()
+	store := saveSpaced(t, "alpha", "bravo", "charlie")
+
+	resp, err := store.List(context.Background(), &session.ListRequest{})
+	require.NoError(t, err)
+	require.Empty(t, resp.NextPageToken)
+
+	ids := summaryIDs(resp.Sessions)
+	// Newest write first.
+	require.Equal(t, []string{"charlie", "bravo", "alpha"}, ids)
+}
+
+func TestInMemoryStore_ListPaginates(t *testing.T) {
+	t.Parallel()
+	store := saveSpaced(t, "a", "b", "c", "d", "e")
+
+	var got []string
+
+	token := ""
+	for range 10 {
+		resp, err := store.List(context.Background(), &session.ListRequest{PageSize: 2, PageToken: token})
+		require.NoError(t, err)
+		require.LessOrEqual(t, len(resp.Sessions), 2)
+		got = append(got, summaryIDs(resp.Sessions)...)
+
+		token = resp.NextPageToken
+		if token == "" {
+			break
+		}
+	}
+
+	// Every session shows up exactly once, newest first, across pages.
+	require.Equal(t, []string{"e", "d", "c", "b", "a"}, got)
+}
+
+func TestInMemoryStore_ListEmpty(t *testing.T) {
+	t.Parallel()
+
+	store := session.NewInMemoryStore()
+
+	resp, err := store.List(context.Background(), &session.ListRequest{})
+	require.NoError(t, err)
+	require.Empty(t, resp.Sessions)
+	require.Empty(t, resp.NextPageToken)
+}
+
+func TestInMemoryStore_ListNilRequest(t *testing.T) {
+	t.Parallel()
+	store := saveSpaced(t, "only")
+
+	resp, err := store.List(context.Background(), nil)
+	require.NoError(t, err)
+	require.Equal(t, []string{"only"}, summaryIDs(resp.Sessions))
+}
+
+func TestInMemoryStore_ListRejectsBadPageToken(t *testing.T) {
+	t.Parallel()
+	store := saveSpaced(t, "a")
+
+	_, err := store.List(context.Background(), &session.ListRequest{PageToken: "not-a-number"})
+	require.Error(t, err)
+}
+
+func TestInMemoryStore_ListOmitsMessagesKeepsMetadata(t *testing.T) {
+	t.Parallel()
+
+	store := session.NewInMemoryStore()
+	require.NoError(t, store.Save(context.Background(), &session.State{
+		ID:       "s1",
+		Metadata: map[string]any{"title": "hello"},
+	}))
+
+	resp, err := store.List(context.Background(), &session.ListRequest{})
+	require.NoError(t, err)
+	require.Len(t, resp.Sessions, 1)
+	require.Equal(t, "hello", resp.Sessions[0].Metadata["title"])
+
+	// Mutating the returned metadata must not corrupt stored state.
+	resp.Sessions[0].Metadata["title"] = "mutated"
+	loaded, err := store.Load(context.Background(), "s1")
+	require.NoError(t, err)
+	require.Equal(t, "hello", loaded.Metadata["title"])
+}
+
+func TestState_CloneCopiesUpdatedAt(t *testing.T) {
+	t.Parallel()
+
+	ts := time.Date(2026, 7, 1, 10, 0, 0, 0, time.UTC)
+	original := &session.State{ID: "s1", UpdatedAt: ts}
+
+	clone := original.Clone()
+	require.Equal(t, ts, clone.UpdatedAt)
+}
+
+func summaryIDs(summaries []session.Summary) []string {
+	ids := make([]string, len(summaries))
+	for i, s := range summaries {
+		ids[i] = s.ID
+	}
+
+	return ids
+}

--- a/store/session/store.go
+++ b/store/session/store.go
@@ -26,6 +26,7 @@
 //	    Load(ctx context.Context, sessionID string) (*State, error)
 //	    Save(ctx context.Context, state *State) error
 //	    Delete(ctx context.Context, sessionID string) error
+//	    List(ctx context.Context, req *ListRequest) (*ListResponse, error)
 //	}
 //
 // # Concurrency
@@ -47,6 +48,7 @@ import (
 	"context"
 	"errors"
 	"maps"
+	"time"
 
 	"github.com/redpanda-data/ai-sdk-go/llm"
 )
@@ -70,6 +72,16 @@ type Store interface {
 	// Delete removes a session by its ID.
 	// Returns nil if the session doesn't exist (idempotent).
 	Delete(ctx context.Context, sessionID string) error
+
+	// List returns a page of session summaries ordered by UpdatedAt
+	// descending, then ID ascending (a stable total order for keyset
+	// pagination). Summaries omit the message payload — use Load to fetch a
+	// full session. PageToken is opaque and implementation-defined; callers
+	// pass back the NextPageToken from the previous response.
+	//
+	// Stores whose backend cannot enumerate sessions (e.g. a plain key-value
+	// backend keyed by session ID) return ErrListNotSupported.
+	List(ctx context.Context, req *ListRequest) (*ListResponse, error)
 }
 
 // State represents the persistent state of a conversation session.
@@ -88,6 +100,12 @@ type State struct {
 	// Metadata contains arbitrary key-value pairs associated with the session.
 	// Common uses include user settings, locale, feature flags, and analytics data.
 	Metadata map[string]any `json:"metadata,omitempty"`
+
+	// UpdatedAt is the time the session was last persisted. It is
+	// storage-managed and output-only: Save ignores whatever value it holds
+	// (the store stamps the write time), while Load and List populate it.
+	// Stores without a clock may leave it zero.
+	UpdatedAt time.Time `json:"updated_at,omitzero"`
 }
 
 // Clone creates a deep copy of the session state.
@@ -101,9 +119,10 @@ func (s *State) Clone() *State {
 	}
 
 	clone := &State{
-		ID:       s.ID,
-		Messages: make([]llm.Message, len(s.Messages)),
-		Metadata: make(map[string]any, len(s.Metadata)),
+		ID:        s.ID,
+		Messages:  make([]llm.Message, len(s.Messages)),
+		Metadata:  make(map[string]any, len(s.Metadata)),
+		UpdatedAt: s.UpdatedAt,
 	}
 
 	for i, msg := range s.Messages {
@@ -117,3 +136,44 @@ func (s *State) Clone() *State {
 
 // ErrNotFound indicates that the requested session does not exist.
 var ErrNotFound = errors.New("session: not found")
+
+// ErrListNotSupported indicates that a Store's backend cannot enumerate
+// sessions (e.g. a plain key-value backend keyed by session ID). Such stores
+// return it from List.
+var ErrListNotSupported = errors.New("session: listing not supported by this store")
+
+// Summary is the list view of a session: its identity and metadata without
+// the message payload. It is what List returns per session, keeping list
+// queries cheap regardless of conversation size — fetch the messages with
+// Load only when a specific session is opened.
+type Summary struct {
+	// ID is the unique identifier for the session.
+	ID string
+
+	// Metadata is the session's metadata, as in State.
+	Metadata map[string]any
+
+	// UpdatedAt is the time the session was last persisted.
+	UpdatedAt time.Time
+}
+
+// ListRequest selects a page of session summaries.
+type ListRequest struct {
+	// PageSize is the maximum number of summaries to return. A non-positive
+	// value lets the store apply its own default; stores may cap it.
+	PageSize int32
+
+	// PageToken continues a previous List; empty starts from the first page.
+	// The token is opaque and must come from a prior ListResponse.
+	PageToken string
+}
+
+// ListResponse is one page of session summaries.
+type ListResponse struct {
+	// Sessions is the page, ordered by UpdatedAt descending, ID ascending.
+	Sessions []Summary
+
+	// NextPageToken is the token for the following page, or empty when this
+	// is the last page.
+	NextPageToken string
+}


### PR DESCRIPTION
## What

Add `List` to the `session.Store` interface, plus the `Summary` / `ListRequest` / `ListResponse` types, an `ErrListNotSupported` sentinel, and an `UpdatedAt` field on `session.State`.

## Why

The interface only exposed `Load` / `Save` / `Delete` keyed by ID, so any consumer that needs to enumerate an agent's sessions has to reach around it. Listing is a normal session-store capability - adk-go's `session.Service` has it - and it belongs on the interface. The immediate consumer is cloudv2's ai-agent `SessionService`, which backs an inspector session picker.

## Implementation details

`List` returns lightweight `Summary` values (id, metadata, updated_at) with no message payload, ordered by `updated_at` descending then `id` ascending. The page token is opaque, so a durable backend can use keyset paging and the in-memory one an offset - neither leaks into the contract.

`State` gains `UpdatedAt`: storage-managed and output-only. `Save` ignores whatever the caller put there and the store stamps the write time; `Load` and `List` populate it; `Clone` copies it.

`InMemoryStore` implements `List` over its cache (`Range` + sort) and stamps `UpdatedAt` on `Save`. The kvstore returns `ErrListNotSupported` - it is keyed by session ID and cannot enumerate, and it is slated for deprecation.

Adding a method to `Store` is breaking for every implementer; the only other one in-tree is a runner test mock, which gains `List`.

## References

Consumer: cloudv2 ai-agent `redpanda.adp.managedagent.v1.SessionService`.