### PR TITLE
Add Amazon Nova 2 Lite to the Bedrock catalog

### DIFF
--- a/providers/bedrock/cross_region_test.go
+++ b/providers/bedrock/cross_region_test.go
@@ -59,6 +59,17 @@ func TestIsModelAllowedFromRegion(t *testing.T) {
 		{"au from ap-southeast-4 (Melbourne)", ModelClaudeHaiku45AU, "ap-southeast-4", true},
 		{"au from ap-southeast-6 (New Zealand)", ModelClaudeOpus46AU, "ap-southeast-6", true},
 
+		// Amazon Nova 2 Lite — same prefix-based routing as Claude (us/eu/jp
+		// geo profiles + global). Confirms the amazon. namespace routes like
+		// anthropic.
+		{"nova2 bare from us", ModelNova2Lite, "us-east-1", true},
+		{"nova2 us from us-east-1", ModelNova2LiteUS, "us-east-1", true},
+		{"nova2 eu from eu-west-1", ModelNova2LiteEU, "eu-west-1", true},
+		{"nova2 jp from ap-northeast-1 (Tokyo)", ModelNova2LiteJP, "ap-northeast-1", true},
+		{"nova2 global from me-central-1", ModelNova2LiteGlobal, "me-central-1", true},
+		{"nova2 us from eu-west-1 (cross-geo)", ModelNova2LiteUS, "eu-west-1", false},
+		{"nova2 eu from us-east-1 (cross-geo)", ModelNova2LiteEU, "us-east-1", false},
+
 		// Cross-geography — rejected.
 		{"eu from us-east-1", ModelClaudeSonnet46EU, "us-east-1", false},
 		{"us from eu-west-1", ModelClaudeSonnet46US, "eu-west-1", false},

--- a/providers/bedrock/models.go
+++ b/providers/bedrock/models.go
@@ -652,7 +652,7 @@ var supportedModels = map[string]ModelDefinition{
 	// profile is exactly 1.10x it (enforced by TestGeoGlobalRatio):
 	//   global (…-cross-region-global): $0.30 in / $2.50 out / $0.075 cache-read
 	//   geo/in-region:                  $0.33 in / $2.75 out / $0.0825 cache-read
-	// cache-read is exactly 25% of input (75% discount).
+	// Cache reads are billed at 25% of the input rate (75% discount).
 	//
 	// Cache WRITE is FREE: the AWS price list carries an explicit
 	// USE1-Nova2.0Lite-cache-write-input-token-count usagetype priced at

--- a/providers/bedrock/models.go
+++ b/providers/bedrock/models.go
@@ -117,6 +117,24 @@ const (
 	ModelClaudeOpus45EU     = "eu." + ModelClaudeOpus45
 )
 
+// Model ID constants for Amazon Nova models on Bedrock.
+//
+// Like the Claude 4.5+ models, Nova 2 Lite is inference-profile-only: its
+// regional-availability table lists In-Region = No in every region, so the bare
+// "amazon.nova-2-lite-v1:0" ID is not on-demand invocable and is registered only
+// as a building block for the prefixed variants. AWS publishes us./eu./jp. geo
+// profiles and a global. profile (no apac./au.). See
+// https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-amazon-nova-2-lite.html
+const (
+	// ModelNova2Lite is the bare Bedrock ID for Amazon Nova 2 Lite
+	// (inference-profile-only — invoke via one of the prefixed variants).
+	ModelNova2Lite       = "amazon.nova-2-lite-v1:0"
+	ModelNova2LiteGlobal = "global." + ModelNova2Lite
+	ModelNova2LiteUS     = "us." + ModelNova2Lite
+	ModelNova2LiteEU     = "eu." + ModelNova2Lite
+	ModelNova2LiteJP     = "jp." + ModelNova2Lite
+)
+
 // ModelDefinition defines a model with its capabilities and constraints.
 type ModelDefinition struct {
 	Name                        string // Real Bedrock model ID (e.g. "us.anthropic.claude-sonnet-4-6")
@@ -242,6 +260,31 @@ var (
 		MaxInputTokens:   200000,
 		MaxOutputTokens:  64000,
 		SupportedParams:  []string{"temperature", "top_p", "max_tokens", "stop"},
+	}
+
+	// Capability/constraint shapes for Amazon Nova 2 Lite. Unlike the Claude
+	// entries, JSONMode and StructuredOutput are set: Nova supports Bedrock
+	// constrained-decoding structured outputs (response_format / Converse
+	// outputConfig.textFormat), which is the primary reason to reach for it on
+	// extraction workloads. Multimodal (image + video input), text output;
+	// reasoning via extended thinking. Nova also accepts top_k.
+	nova2LiteCaps = llm.ModelCapabilities{
+		Streaming:        true,
+		Tools:            true,
+		JSONMode:         true,
+		StructuredOutput: true,
+		Vision:           true,
+		Audio:            false,
+		MultiTurn:        true,
+		SystemPrompts:    true,
+		Reasoning:        true,
+	}
+
+	nova2LiteConstraints = llm.ModelConstraints{
+		TemperatureRange: [2]float64{0.0, 1.0},
+		MaxInputTokens:   1000000,
+		MaxOutputTokens:  64000,
+		SupportedParams:  []string{"temperature", "top_p", "top_k", "max_tokens", "stop"},
 	}
 )
 
@@ -594,6 +637,64 @@ var supportedModels = map[string]ModelDefinition{
 		Constraints:  claudeContext200kConstraints,
 		Pricing: pricing.FlatInfoFromRates(
 			pricing.NewRates(1.10, 5.50, 0.11).WithCacheCreation(1.375, 2.20, 0),
+		),
+	},
+
+	// ----------------------------------------------------------------
+	// Amazon Nova 2 Lite — inference-profile-only, no bare entry. Geo
+	// profiles cover us, eu, jp; global. is also published.
+	//
+	// All rates verified against the AWS Price List bulk API (authoritative,
+	// machine-readable — the pricing web page is JS-rendered and unusable):
+	// offers/v1.0/aws/AmazonBedrock/<ts>/us-east-1/index.json, published
+	// 2026-07-07. Pricing follows the same geo/global split as the Claude
+	// entries above — the global. tier is the round base rate and each geo
+	// profile is exactly 1.10x it (enforced by TestGeoGlobalRatio):
+	//   global (…-cross-region-global): $0.30 in / $2.50 out / $0.075 cache-read
+	//   geo/in-region:                  $0.33 in / $2.75 out / $0.0825 cache-read
+	// cache-read is exactly 25% of input (75% discount).
+	//
+	// Cache WRITE is FREE: the AWS price list carries an explicit
+	// USE1-Nova2.0Lite-cache-write-input-token-count usagetype priced at
+	// $0.00 in both tiers (Nova charges nothing to populate the cache; only
+	// cache reads are billed, at the discounted rate above). So no
+	// WithCacheCreation is set — the cache-write buckets stay at zero, which
+	// TestAllModelsHavePricing explicitly allows for free-cache-write models.
+	// ----------------------------------------------------------------
+	ModelNova2LiteGlobal: {
+		Name:         ModelNova2LiteGlobal,
+		Label:        "Amazon Nova 2 Lite (Global)",
+		Capabilities: nova2LiteCaps,
+		Constraints:  nova2LiteConstraints,
+		Pricing: pricing.FlatInfoFromRates(
+			pricing.NewRates(0.30, 2.50, 0.075),
+		),
+	},
+	ModelNova2LiteUS: {
+		Name:         ModelNova2LiteUS,
+		Label:        "Amazon Nova 2 Lite (US)",
+		Capabilities: nova2LiteCaps,
+		Constraints:  nova2LiteConstraints,
+		Pricing: pricing.FlatInfoFromRates(
+			pricing.NewRates(0.33, 2.75, 0.0825),
+		),
+	},
+	ModelNova2LiteEU: {
+		Name:         ModelNova2LiteEU,
+		Label:        "Amazon Nova 2 Lite (EU)",
+		Capabilities: nova2LiteCaps,
+		Constraints:  nova2LiteConstraints,
+		Pricing: pricing.FlatInfoFromRates(
+			pricing.NewRates(0.33, 2.75, 0.0825),
+		),
+	},
+	ModelNova2LiteJP: {
+		Name:         ModelNova2LiteJP,
+		Label:        "Amazon Nova 2 Lite (JP)",
+		Capabilities: nova2LiteCaps,
+		Constraints:  nova2LiteConstraints,
+		Pricing: pricing.FlatInfoFromRates(
+			pricing.NewRates(0.33, 2.75, 0.0825),
 		),
 	},
 }

--- a/providers/bedrock/models.go
+++ b/providers/bedrock/models.go
@@ -266,8 +266,16 @@ var (
 	// entries, JSONMode and StructuredOutput are set: Nova supports Bedrock
 	// constrained-decoding structured outputs (response_format / Converse
 	// outputConfig.textFormat), which is the primary reason to reach for it on
-	// extraction workloads. Multimodal (image + video input), text output;
-	// reasoning via extended thinking. Nova also accepts top_k.
+	// extraction workloads. Multimodal image + video input, text output.
+	//
+	// Reasoning is left false even though Nova 2 Lite supports extended
+	// thinking at the model level: the only lever in this SDK — WithThinking —
+	// emits the Anthropic-shaped {"thinking":{"type":"enabled",...}} document
+	// via AdditionalModelRequestFields (request_mapper.go), which Nova does not
+	// accept, so reasoning is not reachable for Nova through the current API.
+	// Flip to true once Nova's reasoning schema is wired through a Bedrock
+	// option. top_k is omitted from SupportedParams for the same reason: the
+	// Converse request mapper only emits temperature/top_p/max_tokens/stop.
 	nova2LiteCaps = llm.ModelCapabilities{
 		Streaming:        true,
 		Tools:            true,
@@ -277,14 +285,14 @@ var (
 		Audio:            false,
 		MultiTurn:        true,
 		SystemPrompts:    true,
-		Reasoning:        true,
+		Reasoning:        false,
 	}
 
 	nova2LiteConstraints = llm.ModelConstraints{
 		TemperatureRange: [2]float64{0.0, 1.0},
 		MaxInputTokens:   1000000,
 		MaxOutputTokens:  64000,
-		SupportedParams:  []string{"temperature", "top_p", "top_k", "max_tokens", "stop"},
+		SupportedParams:  []string{"temperature", "top_p", "max_tokens", "stop"},
 	}
 )
 

--- a/providers/bedrock/pricing_test.go
+++ b/providers/bedrock/pricing_test.go
@@ -22,6 +22,17 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// freeCacheWriteModels lists Bedrock models AWS documents as charging nothing
+// to populate the cache (their cache-write usagetype is priced at $0.00). For
+// these, cache-write is expected to be exactly zero; every other model must
+// carry a positive cache-write rate.
+var freeCacheWriteModels = map[string]bool{
+	ModelNova2LiteGlobal: true,
+	ModelNova2LiteUS:     true,
+	ModelNova2LiteEU:     true,
+	ModelNova2LiteJP:     true,
+}
+
 func TestAllModelsHavePricing(t *testing.T) {
 	t.Parallel()
 
@@ -35,15 +46,23 @@ func TestAllModelsHavePricing(t *testing.T) {
 				"model %s missing output pricing — add Pricing to its ModelDefinition", id)
 			assert.Positive(t, def.Pricing.Default.Base.CachedInputPerMillion,
 				"model %s missing cached pricing — add CachedInputPerMillion to its ModelDefinition", id)
-			// Cache-write may legitimately be zero: some models (e.g. Amazon
-			// Nova 2 Lite) do not charge to populate the cache — AWS lists the
-			// cache-write usagetype at $0.00 and bills only cache reads. So we
-			// require non-negative rather than strictly positive here; input,
-			// output, and cache-read above are always billed and stay positive.
-			assert.GreaterOrEqual(t, def.Pricing.Default.Base.CacheCreation5mPerMillion, int64(0),
-				"model %s has negative 5m cache write pricing", id)
-			assert.GreaterOrEqual(t, def.Pricing.Default.Base.CacheCreation1hPerMillion, int64(0),
-				"model %s has negative 1h cache write pricing", id)
+			// Cache-write: every model must carry a positive rate, EXCEPT models
+			// AWS documents as charging nothing to populate the cache (their
+			// cache-write usagetype is $0.00) — Amazon Nova 2 Lite. Those must be
+			// exactly zero. Guarding both directions keeps the "forgot
+			// WithCacheCreation" check intact for Claude while allowing the
+			// documented free-cache-write models.
+			if freeCacheWriteModels[id] {
+				assert.Zero(t, def.Pricing.Default.Base.CacheCreation5mPerMillion,
+					"model %s is documented free-cache-write but has a 5m rate", id)
+				assert.Zero(t, def.Pricing.Default.Base.CacheCreation1hPerMillion,
+					"model %s is documented free-cache-write but has a 1h rate", id)
+			} else {
+				assert.Positive(t, def.Pricing.Default.Base.CacheCreation5mPerMillion,
+					"model %s missing 5m cache write pricing", id)
+				assert.Positive(t, def.Pricing.Default.Base.CacheCreation1hPerMillion,
+					"model %s missing 1h cache write pricing", id)
+			}
 		})
 	}
 }

--- a/providers/bedrock/pricing_test.go
+++ b/providers/bedrock/pricing_test.go
@@ -35,10 +35,15 @@ func TestAllModelsHavePricing(t *testing.T) {
 				"model %s missing output pricing — add Pricing to its ModelDefinition", id)
 			assert.Positive(t, def.Pricing.Default.Base.CachedInputPerMillion,
 				"model %s missing cached pricing — add CachedInputPerMillion to its ModelDefinition", id)
-			assert.Positive(t, def.Pricing.Default.Base.CacheCreation5mPerMillion,
-				"model %s missing 5m cache write pricing", id)
-			assert.Positive(t, def.Pricing.Default.Base.CacheCreation1hPerMillion,
-				"model %s missing 1h cache write pricing", id)
+			// Cache-write may legitimately be zero: some models (e.g. Amazon
+			// Nova 2 Lite) do not charge to populate the cache — AWS lists the
+			// cache-write usagetype at $0.00 and bills only cache reads. So we
+			// require non-negative rather than strictly positive here; input,
+			// output, and cache-read above are always billed and stay positive.
+			assert.GreaterOrEqual(t, def.Pricing.Default.Base.CacheCreation5mPerMillion, int64(0),
+				"model %s has negative 5m cache write pricing", id)
+			assert.GreaterOrEqual(t, def.Pricing.Default.Base.CacheCreation1hPerMillion, int64(0),
+				"model %s has negative 1h cache write pricing", id)
 		})
 	}
 }

--- a/providers/bedrock/provider_test.go
+++ b/providers/bedrock/provider_test.go
@@ -196,6 +196,44 @@ func TestLookupModel(t *testing.T) {
 			input:  "au." + ModelClaudeOpus45,
 			wantOK: false,
 		},
+
+		// Amazon Nova 2 Lite — inference-profile-only, like the Claude
+		// entries. global/us/eu/jp are registered; the bare ID and the
+		// unpublished au. profile are not.
+		{
+			name:    "Nova 2 Lite global profile is its own entry",
+			input:   ModelNova2LiteGlobal,
+			wantOK:  true,
+			wantDef: ModelNova2LiteGlobal,
+		},
+		{
+			name:    "Nova 2 Lite us profile is its own entry",
+			input:   ModelNova2LiteUS,
+			wantOK:  true,
+			wantDef: ModelNova2LiteUS,
+		},
+		{
+			name:    "Nova 2 Lite eu profile is its own entry",
+			input:   ModelNova2LiteEU,
+			wantOK:  true,
+			wantDef: ModelNova2LiteEU,
+		},
+		{
+			name:    "Nova 2 Lite jp profile is its own entry",
+			input:   ModelNova2LiteJP,
+			wantOK:  true,
+			wantDef: ModelNova2LiteJP,
+		},
+		{
+			name:   "Nova 2 Lite bare ID is not in the catalog",
+			input:  ModelNova2Lite,
+			wantOK: false,
+		},
+		{
+			name:   "Nova 2 Lite au profile is not published",
+			input:  "au." + ModelNova2Lite,
+			wantOK: false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Adds Amazon Nova 2 Lite so it surfaces in model discovery, pricing, and enforcement alongside the Claude entries.

- Registers the four inference-profile variants (global/us/eu/jp), inference-profile-only like the Claude models.
- Rates verified against the AWS Price List API — $0.30/$2.50 global, geo exactly 1.10×, cache-read 75% off, cache-write free.
- Relaxes the pricing test's cache-write assertion so free-cache-write models are allowed.