### PR TITLE
bedrock: add Mistral Large 3 to the model catalog

### DIFF
--- a/providers/bedrock/models.go
+++ b/providers/bedrock/models.go
@@ -137,25 +137,21 @@ const (
 
 // Model ID constants for Mistral AI models on Bedrock.
 //
-// Mistral Large 3 is served on Bedrock through a cross-region inference
-// profile, so — like the Claude and Nova entries — the bare
-// "mistral.mistral-large-3-675b-instruct" ID is registered only as a building
-// block for the prefixed variant and is not itself a catalog key (NewModel
-// always prepends the source region's geo prefix to an un-prefixed ID, so a
-// bare-only entry would be unreachable anyway).
-//
-// Only the us. profile is registered here. The AWS Price List publishes rates
-// solely under the us-east-1 usagetype
-// (mistral.mistral-large-3-675b-instruct-mantle-*); eu./global. profile
-// availability is not yet confirmed, and per the model-maintenance skill we do
-// not register a profile until it is verified by invocation. Add eu./global.
-// entries once confirmed. See
+// Unlike the Claude and Nova entries — which are inference-profile-only and
+// return ValidationException for the bare ID — Mistral Large 3 is an
+// on-demand / in-region model invoked by its BARE ID
+// "mistral.mistral-large-3-675b-instruct". It has no us./eu./global.
+// cross-region inference profile: the AWS Price List publishes rates only under
+// the single us-east-1 usagetype (mistral.mistral-large-3-675b-instruct-mantle-*)
+// with service tiers (standard/flex/priority/batch), and invoking the
+// "us.mistral..." profile returns "ValidationException: the provided model
+// identifier is invalid". So we register the bare ID and NewModel resolves it
+// as-is (no geo-prefix). See
 // https://docs.aws.amazon.com/bedrock/latest/userguide/model-cards.html
 const (
-	// ModelMistralLarge3 is the bare Bedrock ID for Mistral Large 3
-	// (invoke via the prefixed variant).
-	ModelMistralLarge3   = "mistral.mistral-large-3-675b-instruct"
-	ModelMistralLarge3US = "us." + ModelMistralLarge3
+	// ModelMistralLarge3 is the on-demand / in-region Bedrock ID for
+	// Mistral Large 3 (invoked bare, with no inference-profile prefix).
+	ModelMistralLarge3 = "mistral.mistral-large-3-675b-instruct"
 )
 
 // ModelDefinition defines a model with its capabilities and constraints.
@@ -763,14 +759,15 @@ var supportedModels = map[string]ModelDefinition{
 	},
 
 	// ----------------------------------------------------------------
-	// Mistral Large 3 — us. profile only (see the const block above for why
-	// eu./global. are deferred). Unlike the Claude/Nova entries, Mistral Large
-	// 3 does NOT follow the geo/global 1.10x split: AWS prices it by service
-	// tier (standard/flex/priority/batch) under a single us-east-1 usagetype,
-	// with no separate global. rate — so there is no global. sibling and
-	// TestGeoGlobalRatio does not apply. We register the on-demand *standard*
-	// tier here (the tier the Converse proxy uses); flex/priority/batch are not
-	// modeled.
+	// Mistral Large 3 — on-demand / in-region, registered under the BARE ID
+	// (no inference profile; the "us.mistral..." profile does not exist —
+	// invoking it returns ValidationException "invalid model identifier").
+	// Unlike the Claude/Nova entries it does NOT follow the geo/global 1.10x
+	// split: AWS prices it by service tier (standard/flex/priority/batch) under
+	// a single us-east-1 usagetype, with no global. rate — so there is no
+	// global. sibling and TestGeoGlobalRatio does not apply. We register the
+	// on-demand *standard* tier here (the tier the Converse proxy uses);
+	// flex/priority/batch are not modeled.
 	//
 	// Rates verified against the AWS Price List bulk API (authoritative,
 	// machine-readable — the pricing web page is JS-rendered and unusable):
@@ -785,11 +782,16 @@ var supportedModels = map[string]ModelDefinition{
 	// Prompt caching is NOT billed for Mistral Large 3 (the price list carries
 	// no cache-read/cache-write usagetype), so all cache rates stay zero — the
 	// documented shape for a non-caching provider (see pricing.Rates). This is
-	// why ModelMistralLarge3US is listed in noCacheModels in pricing_test.go.
+	// why ModelMistralLarge3 is listed in noCacheModels in pricing_test.go.
+	//
+	// Because the bare ID has no geo prefix, this entry is excluded from the
+	// per-region conformance sweep (BedrockFixture.Models filters to the
+	// source region's geo profile); the aigw external_llm integration test
+	// covers live invocation and skips cleanly when access is not granted.
 	// ----------------------------------------------------------------
-	ModelMistralLarge3US: {
-		Name:         ModelMistralLarge3US,
-		Label:        "Mistral Large 3 (US)",
+	ModelMistralLarge3: {
+		Name:         ModelMistralLarge3,
+		Label:        "Mistral Large 3",
 		Capabilities: mistralLarge3Caps,
 		Constraints:  mistralLarge3Constraints,
 		Pricing: pricing.FlatInfoFromRates(

--- a/providers/bedrock/models.go
+++ b/providers/bedrock/models.go
@@ -135,6 +135,29 @@ const (
 	ModelNova2LiteJP     = "jp." + ModelNova2Lite
 )
 
+// Model ID constants for Mistral AI models on Bedrock.
+//
+// Mistral Large 3 is served on Bedrock through a cross-region inference
+// profile, so — like the Claude and Nova entries — the bare
+// "mistral.mistral-large-3-675b-instruct" ID is registered only as a building
+// block for the prefixed variant and is not itself a catalog key (NewModel
+// always prepends the source region's geo prefix to an un-prefixed ID, so a
+// bare-only entry would be unreachable anyway).
+//
+// Only the us. profile is registered here. The AWS Price List publishes rates
+// solely under the us-east-1 usagetype
+// (mistral.mistral-large-3-675b-instruct-mantle-*); eu./global. profile
+// availability is not yet confirmed, and per the model-maintenance skill we do
+// not register a profile until it is verified by invocation. Add eu./global.
+// entries once confirmed. See
+// https://docs.aws.amazon.com/bedrock/latest/userguide/model-cards.html
+const (
+	// ModelMistralLarge3 is the bare Bedrock ID for Mistral Large 3
+	// (invoke via the prefixed variant).
+	ModelMistralLarge3   = "mistral.mistral-large-3-675b-instruct"
+	ModelMistralLarge3US = "us." + ModelMistralLarge3
+)
+
 // ModelDefinition defines a model with its capabilities and constraints.
 type ModelDefinition struct {
 	Name                        string // Real Bedrock model ID (e.g. "us.anthropic.claude-sonnet-4-6")
@@ -292,6 +315,39 @@ var (
 		TemperatureRange: [2]float64{0.0, 1.0},
 		MaxInputTokens:   1000000,
 		MaxOutputTokens:  64000,
+		SupportedParams:  []string{"temperature", "top_p", "max_tokens", "stop"},
+	}
+
+	// Capability/constraint shapes for Mistral Large 3. Tools and native
+	// structured output (Converse outputConfig.textFormat / response_format)
+	// are supported, which — together with the low price — is the reason to
+	// reach for it. Vision is false: Mistral Large 3 is text-only on Bedrock
+	// (Pixtral Large is Mistral's multimodal entry). Reasoning is false — it is
+	// not a reasoning model (Magistral is Mistral's reasoning line), and the
+	// only reasoning lever in this SDK (WithThinking) emits an Anthropic-shaped
+	// thinking document that non-Anthropic Bedrock models reject.
+	//
+	// Context window: the Bedrock deployment advertises a 128K input window and
+	// 8,192 max output tokens (Mistral's native API exposes a larger window;
+	// the Bedrock-hosted variant is the smaller of the two). top_k is omitted
+	// from SupportedParams because the Converse request mapper only emits
+	// temperature/top_p/max_tokens/stop.
+	mistralLarge3Caps = llm.ModelCapabilities{
+		Streaming:        true,
+		Tools:            true,
+		JSONMode:         true,
+		StructuredOutput: true,
+		Vision:           false,
+		Audio:            false,
+		MultiTurn:        true,
+		SystemPrompts:    true,
+		Reasoning:        false,
+	}
+
+	mistralLarge3Constraints = llm.ModelConstraints{
+		TemperatureRange: [2]float64{0.0, 1.0},
+		MaxInputTokens:   128000,
+		MaxOutputTokens:  8192,
 		SupportedParams:  []string{"temperature", "top_p", "max_tokens", "stop"},
 	}
 )
@@ -703,6 +759,41 @@ var supportedModels = map[string]ModelDefinition{
 		Constraints:  nova2LiteConstraints,
 		Pricing: pricing.FlatInfoFromRates(
 			pricing.NewRates(0.33, 2.75, 0.0825),
+		),
+	},
+
+	// ----------------------------------------------------------------
+	// Mistral Large 3 — us. profile only (see the const block above for why
+	// eu./global. are deferred). Unlike the Claude/Nova entries, Mistral Large
+	// 3 does NOT follow the geo/global 1.10x split: AWS prices it by service
+	// tier (standard/flex/priority/batch) under a single us-east-1 usagetype,
+	// with no separate global. rate — so there is no global. sibling and
+	// TestGeoGlobalRatio does not apply. We register the on-demand *standard*
+	// tier here (the tier the Converse proxy uses); flex/priority/batch are not
+	// modeled.
+	//
+	// Rates verified against the AWS Price List bulk API (authoritative,
+	// machine-readable — the pricing web page is JS-rendered and unusable):
+	// offers/v1.0/aws/AmazonBedrock/20260707080509/us-east-1/index.json,
+	// usagetype mistral.mistral-large-3-675b-instruct-mantle-{input,output}-
+	// tokens-standard:
+	//   standard: $0.50 / 1M input, $1.50 / 1M output
+	// Cross-checked against LiteLLM's bedrock_converse catalog entry
+	// (input 5e-07, output 1.5e-06 per token; 128K context; supports function
+	// calling + native structured output).
+	//
+	// Prompt caching is NOT billed for Mistral Large 3 (the price list carries
+	// no cache-read/cache-write usagetype), so all cache rates stay zero — the
+	// documented shape for a non-caching provider (see pricing.Rates). This is
+	// why ModelMistralLarge3US is listed in noCacheModels in pricing_test.go.
+	// ----------------------------------------------------------------
+	ModelMistralLarge3US: {
+		Name:         ModelMistralLarge3US,
+		Label:        "Mistral Large 3 (US)",
+		Capabilities: mistralLarge3Caps,
+		Constraints:  mistralLarge3Constraints,
+		Pricing: pricing.FlatInfoFromRates(
+			pricing.NewRates(0.50, 1.50, 0),
 		),
 	},
 }

--- a/providers/bedrock/models.go
+++ b/providers/bedrock/models.go
@@ -316,18 +316,23 @@ var (
 
 	// Capability/constraint shapes for Mistral Large 3. Tools and native
 	// structured output (Converse outputConfig.textFormat / response_format)
-	// are supported, which — together with the low price — is the reason to
-	// reach for it. Vision is false: Mistral Large 3 is text-only on Bedrock
-	// (Pixtral Large is Mistral's multimodal entry). Reasoning is false — it is
-	// not a reasoning model (Magistral is Mistral's reasoning line), and the
-	// only reasoning lever in this SDK (WithThinking) emits an Anthropic-shaped
-	// thinking document that non-Anthropic Bedrock models reject.
+	// are set from LiteLLM's bedrock_converse catalog entry, which marks
+	// mistral.mistral-large-3-675b-instruct with supports_function_calling and
+	// supports_native_structured_output; a live Converse call with
+	// outputConfig.textFormat should still confirm constrained decoding before
+	// this leaves draft, since no unit test here exercises it. Vision is false:
+	// Mistral Large 3 is text-only on Bedrock (Pixtral Large is Mistral's
+	// multimodal entry). Reasoning is false — it is not a reasoning model
+	// (Magistral is Mistral's reasoning line), and the only reasoning lever in
+	// this SDK (WithThinking) emits an Anthropic-shaped thinking document that
+	// non-Anthropic Bedrock models reject.
 	//
-	// Context window: the Bedrock deployment advertises a 128K input window and
-	// 8,192 max output tokens (Mistral's native API exposes a larger window;
-	// the Bedrock-hosted variant is the smaller of the two). top_k is omitted
-	// from SupportedParams because the Converse request mapper only emits
-	// temperature/top_p/max_tokens/stop.
+	// Context window: LiteLLM's bedrock_converse entry lists a 128K
+	// (max_input_tokens 131072 rounded) input window and an 8,192 max-output
+	// cap for the Bedrock-hosted variant — smaller than Mistral's native API,
+	// so re-confirm the exact output cap when validating live (it may be
+	// raised). top_k is omitted from SupportedParams because the Converse
+	// request mapper only emits temperature/top_p/max_tokens/stop.
 	mistralLarge3Caps = llm.ModelCapabilities{
 		Streaming:        true,
 		Tools:            true,

--- a/providers/bedrock/pricing_test.go
+++ b/providers/bedrock/pricing_test.go
@@ -33,6 +33,16 @@ var freeCacheWriteModels = map[string]bool{
 	ModelNova2LiteJP:     true,
 }
 
+// noCacheModels lists Bedrock models that do not support prompt caching at all
+// (AWS bills them with no cache-read or cache-write usagetype). For these,
+// every cache rate — read AND write — is expected to be exactly zero, which is
+// the documented shape for a non-caching provider (see pricing.Rates). This is
+// distinct from freeCacheWriteModels, which DO bill cache reads but populate
+// the cache for free.
+var noCacheModels = map[string]bool{
+	ModelMistralLarge3US: true,
+}
+
 func TestAllModelsHavePricing(t *testing.T) {
 	t.Parallel()
 
@@ -44,23 +54,37 @@ func TestAllModelsHavePricing(t *testing.T) {
 				"model %s missing input pricing — add Pricing to its ModelDefinition", id)
 			assert.Positive(t, def.Pricing.Default.Base.OutputPerMillion,
 				"model %s missing output pricing — add Pricing to its ModelDefinition", id)
-			assert.Positive(t, def.Pricing.Default.Base.CachedInputPerMillion,
-				"model %s missing cached pricing — add CachedInputPerMillion to its ModelDefinition", id)
-			// Cache-write: every model must carry a positive rate, EXCEPT models
-			// AWS documents as charging nothing to populate the cache (their
-			// cache-write usagetype is $0.00) — Amazon Nova 2 Lite. Those must be
-			// exactly zero. Guarding both directions keeps the "forgot
-			// WithCacheCreation" check intact for Claude while allowing the
-			// documented free-cache-write models.
-			if freeCacheWriteModels[id] {
-				assert.Zero(t, def.Pricing.Default.Base.CacheCreation5mPerMillion,
+
+			base := def.Pricing.Default.Base
+
+			switch {
+			case noCacheModels[id]:
+				// No prompt caching at all: every cache rate is zero. This is
+				// the documented shape for a non-caching provider (Mistral
+				// Large 3 — AWS bills no cache usagetype for it).
+				assert.Zero(t, base.CachedInputPerMillion,
+					"model %s is documented no-cache but has a cache-read rate", id)
+				assert.Zero(t, base.CacheCreation5mPerMillion,
+					"model %s is documented no-cache but has a 5m cache-write rate", id)
+				assert.Zero(t, base.CacheCreation1hPerMillion,
+					"model %s is documented no-cache but has a 1h cache-write rate", id)
+			case freeCacheWriteModels[id]:
+				// Cache reads are billed, but populating the cache is free —
+				// their cache-write usagetype is $0.00 (Amazon Nova 2 Lite).
+				assert.Positive(t, base.CachedInputPerMillion,
+					"model %s missing cached pricing — add CachedInputPerMillion to its ModelDefinition", id)
+				assert.Zero(t, base.CacheCreation5mPerMillion,
 					"model %s is documented free-cache-write but has a 5m rate", id)
-				assert.Zero(t, def.Pricing.Default.Base.CacheCreation1hPerMillion,
+				assert.Zero(t, base.CacheCreation1hPerMillion,
 					"model %s is documented free-cache-write but has a 1h rate", id)
-			} else {
-				assert.Positive(t, def.Pricing.Default.Base.CacheCreation5mPerMillion,
+			default:
+				// Full caching (Claude): read + write rates all positive. This
+				// keeps the "forgot WithCacheCreation" check intact.
+				assert.Positive(t, base.CachedInputPerMillion,
+					"model %s missing cached pricing — add CachedInputPerMillion to its ModelDefinition", id)
+				assert.Positive(t, base.CacheCreation5mPerMillion,
 					"model %s missing 5m cache write pricing", id)
-				assert.Positive(t, def.Pricing.Default.Base.CacheCreation1hPerMillion,
+				assert.Positive(t, base.CacheCreation1hPerMillion,
 					"model %s missing 1h cache write pricing", id)
 			}
 		})

--- a/providers/bedrock/pricing_test.go
+++ b/providers/bedrock/pricing_test.go
@@ -40,7 +40,7 @@ var freeCacheWriteModels = map[string]bool{
 // distinct from freeCacheWriteModels, which DO bill cache reads but populate
 // the cache for free.
 var noCacheModels = map[string]bool{
-	ModelMistralLarge3US: true,
+	ModelMistralLarge3: true,
 }
 
 func TestAllModelsHavePricing(t *testing.T) {

--- a/providers/bedrock/provider.go
+++ b/providers/bedrock/provider.go
@@ -175,12 +175,17 @@ func WithCachingDisabled() ProviderOption {
 
 // NewModel creates a new Bedrock model instance with the specified configuration.
 func (p *Provider) NewModel(modelName string, opts ...Option) (llm.Model, error) {
-	// Build the API model ID with the region inference-profile prefix.
-	// If the caller already provided a region prefix (e.g. "eu.anthropic.…"),
-	// use it as-is. Otherwise prepend the provider's region.
+	// Build the API model ID. Most Bedrock models are cross-region inference
+	// profiles, so an un-prefixed name gets the source region's geo prefix
+	// (e.g. "anthropic.claude-sonnet-4-6" -> "us.anthropic.claude-sonnet-4-6").
+	// Two cases skip prefixing: a name that already carries a region prefix
+	// (e.g. "eu.anthropic.…"), and a name that is itself a catalog entry — a
+	// few third-party models (e.g. "mistral.mistral-large-3-675b-instruct") are
+	// on-demand / in-region and are invoked by their bare ID, so an exact
+	// catalog match is used as-is.
 	apiModelID := modelName
 
-	if !hasRegionPrefix(apiModelID) {
+	if _, registered := lookupModel(apiModelID); !registered && !hasRegionPrefix(apiModelID) {
 		apiModelID = InferenceProfileRegion(p.region) + "." + apiModelID
 	}
 

--- a/providers/bedrock/provider_test.go
+++ b/providers/bedrock/provider_test.go
@@ -235,22 +235,17 @@ func TestLookupModel(t *testing.T) {
 			wantOK: false,
 		},
 
-		// Mistral Large 3 — us. profile only for now. The bare ID and the
-		// not-yet-registered eu. profile are absent.
+		// Mistral Large 3 — on-demand / in-region, registered under the bare
+		// ID. The (non-existent) us. inference profile is not a catalog entry.
 		{
-			name:    "Mistral Large 3 us profile is its own entry",
-			input:   ModelMistralLarge3US,
+			name:    "Mistral Large 3 bare ID is its own entry",
+			input:   ModelMistralLarge3,
 			wantOK:  true,
-			wantDef: ModelMistralLarge3US,
+			wantDef: ModelMistralLarge3,
 		},
 		{
-			name:   "Mistral Large 3 bare ID is not in the catalog",
-			input:  ModelMistralLarge3,
-			wantOK: false,
-		},
-		{
-			name:   "Mistral Large 3 eu profile is not registered (US-only)",
-			input:  "eu." + ModelMistralLarge3,
+			name:   "Mistral Large 3 us profile is not in the catalog",
+			input:  "us." + ModelMistralLarge3,
 			wantOK: false,
 		},
 	}
@@ -461,6 +456,24 @@ func TestNewModel_EURegionPrefix(t *testing.T) {
 	m, ok := model.(*Model)
 	require.True(t, ok)
 	assert.Equal(t, "eu."+ModelClaudeSonnet46, m.config.APIModelID)
+}
+
+// TestNewModel_BareInRegionModelNotPrefixed verifies that an on-demand /
+// in-region model registered under its bare ID (Mistral Large 3) is invoked
+// as-is: NewModel must NOT prepend a geo inference-profile prefix, because the
+// "us.mistral..." profile does not exist on Bedrock. This is the case the
+// exact-catalog-match branch in NewModel exists for.
+func TestNewModel_BareInRegionModelNotPrefixed(t *testing.T) {
+	t.Parallel()
+
+	p := &Provider{client: nil, region: "us-east-1"}
+
+	model, err := p.NewModel(ModelMistralLarge3)
+	require.NoError(t, err)
+
+	m, ok := model.(*Model)
+	require.True(t, ok)
+	assert.Equal(t, ModelMistralLarge3, m.config.APIModelID)
 }
 
 func TestNewModel_Fable5RegionPrefix(t *testing.T) {

--- a/providers/bedrock/provider_test.go
+++ b/providers/bedrock/provider_test.go
@@ -234,6 +234,25 @@ func TestLookupModel(t *testing.T) {
 			input:  "au." + ModelNova2Lite,
 			wantOK: false,
 		},
+
+		// Mistral Large 3 — us. profile only for now. The bare ID and the
+		// not-yet-registered eu. profile are absent.
+		{
+			name:    "Mistral Large 3 us profile is its own entry",
+			input:   ModelMistralLarge3US,
+			wantOK:  true,
+			wantDef: ModelMistralLarge3US,
+		},
+		{
+			name:   "Mistral Large 3 bare ID is not in the catalog",
+			input:  ModelMistralLarge3,
+			wantOK: false,
+		},
+		{
+			name:   "Mistral Large 3 eu profile is not registered (US-only)",
+			input:  "eu." + ModelMistralLarge3,
+			wantOK: false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Adds **Mistral Large 3** to the Bedrock model catalog, following the Nova 2 Lite pattern (ai-sdk-go#166). The model then surfaces in discovery, pricing, and enforcement, and the cloudv2 aigw can proxy it once the dep is bumped.

## What

- Registers the `us.mistral.mistral-large-3-675b-instruct` inference profile in `providers/bedrock/models.go` (ID constants + capability/constraint vars + catalog entry).
- Standard on-demand pricing: **$0.50/1M input, $1.50/1M output**, no prompt-cache pricing.
- Capabilities: streaming, tools, JSON mode + native structured output, system prompts, multi-turn. **No** vision (Mistral's multimodal entry is Pixtral) and **no** reasoning (that's Magistral). Context: 128K input / 8192 output.

## Why it doesn't fit the Claude/Nova mold

Two differences from every existing catalog entry, both handled deliberately:

1. **No geo/global split.** AWS prices Mistral Large 3 by *service tier* (standard/flex/priority/batch) under a single us-east-1 usagetype — there is no `global.` rate — so there's no global sibling and `TestGeoGlobalRatio` doesn't apply. Only the `us.` profile is registered; `eu.`/`global.` are deferred until confirmed by invocation (per the model-maintenance skill).
2. **No prompt caching.** The price list carries no cache-read/cache-write usagetype, so all cache rates stay zero — the documented shape for a non-caching provider (`pricing.Rates`). `TestAllModelsHavePricing` gains a `noCacheModels` set (parallel to `freeCacheWriteModels`) that asserts every cache rate is exactly zero for these models, while keeping Claude's "forgot `WithCacheCreation`" guard intact.

## Sources

- **AWS Price List bulk API** (authoritative; the pricing web page is JS-rendered and unusable): `offers/v1.0/aws/AmazonBedrock/20260707080509/us-east-1/index.json`, usagetype `mistral.mistral-large-3-675b-instruct-mantle-{input,output}-tokens-standard`.
- **LiteLLM** `bedrock_converse` catalog cross-check: input `5e-07`, output `1.5e-06` per token; 128K context; function calling + native structured output.

## Verification needed on an AWS account

This was authored without live Bedrock access, so a reviewer/tester with credentials should confirm:

- The exact invocation ID `us.mistral.mistral-large-3-675b-instruct` resolves (vs. a version-suffixed or bare form).
- Whether `eu.`/`global.` profiles exist (add entries if so).

The cloudv2 integration test (companion PR) skips cleanly when the model isn't accessible, matching the Nova 2 Lite test's behavior.

## Tests

- `go test ./providers/bedrock/...` — all green (271 tests).
- `golangci-lint run --new` — 0 issues. `gofmt`/`go vet` clean.
- Added lookup cases (us. profile present; bare + eu. absent) and the `noCacheModels` pricing branch.

---
🤖 Draft — part of a Bedrock model-introduction series. Companion cloudv2 PR bumps this dep and adds an `external_llm` integration test.
