### PR TITLE
Revert #168: remove xAI Grok 4.3 from the Bedrock catalog

### DIFF
--- a/providers/bedrock/models.go
+++ b/providers/bedrock/models.go
@@ -154,30 +154,6 @@ const (
 	ModelMistralLarge3 = "mistral.mistral-large-3-675b-instruct"
 )
 
-// Model ID constants for xAI (Grok) models on Bedrock.
-//
-// Like Mistral Large 3 (and unlike the inference-profile-only Claude/Nova
-// entries), Grok 4.3 is an on-demand / in-region model invoked by its BARE ID
-// "xai.grok-4.3": it has no us./eu./global. cross-region inference profile (the
-// AWS Price List publishes rates only under the single us-east-1 usagetype
-// xai.grok-4.3-mantle-* with service tiers standard/flex/priority/batch, and
-// invoking a "us.xai..." profile returns "ValidationException: the provided
-// model identifier is invalid"). So we register the bare ID and NewModel
-// resolves it as-is.
-//
-// Unlike Mistral, Grok 4.3 DOES bill prompt-cache reads with free cache writes —
-// the same pricing shape as Amazon Nova (so it belongs in freeCacheWriteModels,
-// not noCacheModels).
-//
-// Note: xAI's latest published model is 4.3 (the version line runs
-// 4 -> 4.1 -> 4.20 -> 4.3); there is no "4.5". See
-// https://docs.aws.amazon.com/bedrock/latest/userguide/model-cards.html
-const (
-	// ModelGrok43 is the on-demand / in-region Bedrock ID for xAI Grok 4.3
-	// (invoked bare, with no inference-profile prefix).
-	ModelGrok43 = "xai.grok-4.3"
-)
-
 // ModelDefinition defines a model with its capabilities and constraints.
 type ModelDefinition struct {
 	Name                        string // Real Bedrock model ID (e.g. "us.anthropic.claude-sonnet-4-6")
@@ -373,43 +349,6 @@ var (
 		TemperatureRange: [2]float64{0.0, 1.0},
 		MaxInputTokens:   128000,
 		MaxOutputTokens:  8192,
-		SupportedParams:  []string{"temperature", "top_p", "max_tokens", "stop"},
-	}
-
-	// Capability/constraint shapes for xAI Grok 4.3. Tools, native structured
-	// output, and vision are set from LiteLLM's bedrock_mantle/xai.grok-4.3
-	// entry (supports_function_calling, supports_native_structured_output,
-	// supports_vision); these are asserted from the catalog, not observed, so a
-	// live Converse round-trip (image block + outputConfig.textFormat) should
-	// confirm them before this leaves draft.
-	//
-	// Reasoning is descriptive metadata only, set false. Grok 4.3 is a
-	// reasoning model, but nothing in request_mapper.go gates WithThinking on
-	// this flag: a caller who passes WithThinking to Grok would still emit the
-	// Anthropic-shaped thinking document and get a Bedrock rejection. Leaving it
-	// false documents "no reachable reasoning lever here" (matching the Nova
-	// entries); it does not itself prevent that emission.
-	//
-	// Context window: LiteLLM's bedrock_mantle entry lists a 128K (131072)
-	// input window and a 16,384 max-output cap for the Bedrock-hosted variant.
-	// top_k is omitted from SupportedParams because the Converse request mapper
-	// only emits temperature/top_p/max_tokens/stop.
-	grok43Caps = llm.ModelCapabilities{
-		Streaming:        true,
-		Tools:            true,
-		JSONMode:         true,
-		StructuredOutput: true,
-		Vision:           true,
-		Audio:            false,
-		MultiTurn:        true,
-		SystemPrompts:    true,
-		Reasoning:        false,
-	}
-
-	grok43Constraints = llm.ModelConstraints{
-		TemperatureRange: [2]float64{0.0, 1.0},
-		MaxInputTokens:   131072,
-		MaxOutputTokens:  16384,
 		SupportedParams:  []string{"temperature", "top_p", "max_tokens", "stop"},
 	}
 )
@@ -862,43 +801,6 @@ var supportedModels = map[string]ModelDefinition{
 		Constraints:  mistralLarge3Constraints,
 		Pricing: pricing.FlatInfoFromRates(
 			pricing.NewRates(0.50, 1.50, 0),
-		),
-	},
-
-	// ----------------------------------------------------------------
-	// xAI Grok 4.3 — on-demand / in-region, registered under the BARE ID (no
-	// inference profile; the "us.xai..." profile does not exist — invoking it
-	// returns ValidationException "invalid model identifier"). Like Mistral
-	// Large 3 it does NOT follow the geo/global 1.10x split (AWS prices it by
-	// service tier under a single us-east-1 usagetype, no global. rate), so
-	// there is no global. sibling and TestGeoGlobalRatio does not apply. We
-	// register the on-demand *standard* tier (the tier the Converse proxy
-	// uses); flex/priority/batch are not modeled.
-	//
-	// Rates verified against the AWS Price List bulk API
-	// (offers/v1.0/aws/AmazonBedrock/20260707080509/us-east-1/index.json),
-	// usagetype xai.grok-4.3-mantle-{input,output,cache-read}-tokens-standard:
-	//   standard: $1.25 / 1M input, $2.50 / 1M output, $0.20 / 1M cache-read
-	// Cross-checked against LiteLLM's bedrock_mantle/xai.grok-4.3 entry
-	// (input 1.25e-06, output 2.5e-06, cache-read 2e-07 per token; 128K
-	// context; function calling + native structured output + vision).
-	//
-	// Cache WRITE is free (the price list carries no cache-write usagetype),
-	// same as Amazon Nova, so no WithCacheCreation is set and ModelGrok43 is
-	// listed in freeCacheWriteModels in pricing_test.go.
-	//
-	// Because the bare ID has no geo prefix, this entry is excluded from the
-	// per-region conformance sweep (BedrockFixture.Models filters to the
-	// source region's geo profile); the aigw external_llm integration test
-	// covers live invocation and skips cleanly when access is not granted.
-	// ----------------------------------------------------------------
-	ModelGrok43: {
-		Name:         ModelGrok43,
-		Label:        "Grok 4.3",
-		Capabilities: grok43Caps,
-		Constraints:  grok43Constraints,
-		Pricing: pricing.FlatInfoFromRates(
-			pricing.NewRates(1.25, 2.50, 0.20),
 		),
 	},
 }

--- a/providers/bedrock/pricing_test.go
+++ b/providers/bedrock/pricing_test.go
@@ -23,18 +23,14 @@ import (
 )
 
 // freeCacheWriteModels lists Bedrock models AWS documents as charging nothing
-// to populate the cache (their cache-write usagetype is priced at $0.00) —
-// currently Amazon Nova 2 Lite and xAI Grok 4.3. For these, cache-write is
-// expected to be exactly zero; every other caching model must carry a positive
-// cache-write rate.
+// to populate the cache (their cache-write usagetype is priced at $0.00). For
+// these, cache-write is expected to be exactly zero; every other model must
+// carry a positive cache-write rate.
 var freeCacheWriteModels = map[string]bool{
 	ModelNova2LiteGlobal: true,
 	ModelNova2LiteUS:     true,
 	ModelNova2LiteEU:     true,
 	ModelNova2LiteJP:     true,
-	// Grok 4.3 bills prompt-cache reads but populates the cache for free (no
-	// cache-write usagetype in the Price List) — same shape as Nova.
-	ModelGrok43: true,
 }
 
 // noCacheModels lists Bedrock models that do not support prompt caching at all
@@ -74,8 +70,7 @@ func TestAllModelsHavePricing(t *testing.T) {
 					"model %s is documented no-cache but has a 1h cache-write rate", id)
 			case freeCacheWriteModels[id]:
 				// Cache reads are billed, but populating the cache is free —
-				// their cache-write usagetype is $0.00 (Amazon Nova 2 Lite,
-				// xAI Grok 4.3).
+				// their cache-write usagetype is $0.00 (Amazon Nova 2 Lite).
 				assert.Positive(t, base.CachedInputPerMillion,
 					"model %s missing cached pricing — add CachedInputPerMillion to its ModelDefinition", id)
 				assert.Zero(t, base.CacheCreation5mPerMillion,

--- a/providers/bedrock/provider_test.go
+++ b/providers/bedrock/provider_test.go
@@ -248,20 +248,6 @@ func TestLookupModel(t *testing.T) {
 			input:  "us." + ModelMistralLarge3,
 			wantOK: false,
 		},
-
-		// Grok 4.3 — on-demand / in-region, registered under the bare ID.
-		// The (non-existent) us. inference profile is not a catalog entry.
-		{
-			name:    "Grok 4.3 bare ID is its own entry",
-			input:   ModelGrok43,
-			wantOK:  true,
-			wantDef: ModelGrok43,
-		},
-		{
-			name:   "Grok 4.3 us profile is not in the catalog",
-			input:  "us." + ModelGrok43,
-			wantOK: false,
-		},
 	}
 
 	for _, tt := range tests {
@@ -488,23 +474,6 @@ func TestNewModel_BareInRegionModelNotPrefixed(t *testing.T) {
 	m, ok := model.(*Model)
 	require.True(t, ok)
 	assert.Equal(t, ModelMistralLarge3, m.config.APIModelID)
-}
-
-// TestNewModel_Grok43BareNotPrefixed is the Grok analogue of
-// TestNewModel_BareInRegionModelNotPrefixed: the bare "xai.grok-4.3" ID must be
-// invoked as-is, with no "us." inference-profile prefix (that profile does not
-// exist on Bedrock).
-func TestNewModel_Grok43BareNotPrefixed(t *testing.T) {
-	t.Parallel()
-
-	p := &Provider{client: nil, region: "us-east-1"}
-
-	model, err := p.NewModel(ModelGrok43)
-	require.NoError(t, err)
-
-	m, ok := model.(*Model)
-	require.True(t, ok)
-	assert.Equal(t, ModelGrok43, m.config.APIModelID)
 }
 
 func TestNewModel_Fable5RegionPrefix(t *testing.T) {


### PR DESCRIPTION
Reverts **#168** (xAI Grok 4.3 on Bedrock), merge commit `666cb2a`, via `git revert -m 1`.

## What this removes
- The `xai.grok-4.3` catalog entry, its `ModelGrok43` const, and `grok43Caps`/`grok43Constraints`.
- Its `freeCacheWriteModels` membership + the `freeCacheWriteModels` comment mentions of Grok.
- The Grok lookup cases and `TestNewModel_Grok43BareNotPrefixed`.

## What this keeps
- **Mistral Large 3 (#167) is untouched.** Reverting `-m 1` only undoes the delta the #168 branch added on top of mainline.
- The shared exact-catalog-match branch in `NewModel` stays — Mistral Large 3 relies on it for bare in-region invocation.

Net: `3 files changed, +4 −138`; `go test ./providers/bedrock/...` green (271). The companion cloudv2 twin (#28006) was closed unmerged.
