### PR TITLE
feat(bedrock): add Google Gemma 4 models on the mantle endpoint

### DIFF
--- a/providers/bedrock/mantle.go
+++ b/providers/bedrock/mantle.go
@@ -1,0 +1,243 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bedrock
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	signerv4 "github.com/aws/aws-sdk-go-v2/aws/signer/v4"
+
+	"github.com/redpanda-data/ai-sdk-go/llm"
+	"github.com/redpanda-data/ai-sdk-go/providers/openai"
+)
+
+// mantleService is the AWS SigV4 signing name for the bedrock-mantle endpoint.
+// It is deliberately distinct from the standard "bedrock" service that
+// bedrock-runtime (Converse / InvokeModel) signs with — a request to
+// bedrock-mantle signed as "bedrock" fails with a signature mismatch. See
+// https://docs.aws.amazon.com/bedrock/latest/userguide/bedrock-mantle.html
+const mantleService = "bedrock-mantle"
+
+// mantlePlaceholderAPIKey is a non-empty stand-in required by the OpenAI SDK
+// client. Authentication on the mantle endpoint is AWS SigV4, not a bearer
+// token, so mantleTransport strips the Authorization header the SDK sets from
+// this value before signing.
+const mantlePlaceholderAPIKey = "bedrock-mantle-sigv4"
+
+// IsMantleModel reports whether modelID is served on the bedrock-mantle
+// endpoint (the OpenAI-compatible Responses / Chat Completions API) rather than
+// the standard bedrock-runtime Converse API. It consults the catalog, so it is
+// true only for registered mantle models — the Google Gemma 4 family today, and
+// OpenAI's gpt-5.x frontier models once added.
+//
+// The Redpanda AI Gateway's Bedrock reverse proxy reuses this predicate to
+// decide, per request, when to sign with the bedrock-mantle signing name and
+// route to the mantle host instead of bedrock-runtime.
+func IsMantleModel(modelID string) bool {
+	def, ok := lookupModel(modelID)
+	return ok && def.Mantle
+}
+
+// mantleBaseURL returns the OpenAI-compatible base URL for the bedrock-mantle
+// endpoint. With no baseEndpoint it targets the real mantle host in the given
+// region, e.g. "https://bedrock-mantle.us-east-1.api.aws/openai/v1". When a
+// baseEndpoint is set (proxy/gateway mode, via WithAWSConfig) it routes through
+// that host instead. Either way the OpenAI SDK appends "/responses" (or
+// "/chat/completions"), producing the paths the Gemma 4 model cards document.
+func mantleBaseURL(region, baseEndpoint string) string {
+	if baseEndpoint != "" {
+		return strings.TrimRight(baseEndpoint, "/") + "/openai/v1"
+	}
+
+	return fmt.Sprintf("https://bedrock-mantle.%s.api.aws/openai/v1", region)
+}
+
+// newMantleModel builds an llm.Model for a mantle-only model (Mantle: true in
+// the catalog). It reuses the OpenAI provider's Responses transport, pointed at
+// the mantle base URL with a SigV4-signing HTTP client, and wraps the result so
+// it reports the Bedrock provider identity.
+func newMantleModel(p *Provider, cfg *Config, def ModelDefinition) (llm.Model, error) {
+	// WithThinking emits an Anthropic-shaped thinking document (Converse-only)
+	// that the mantle Responses API does not accept, and there is no mantle
+	// reasoning-budget lever to translate it to. Reject it rather than silently
+	// dropping the caller's budget — Gemma's built-in reasoning runs in its
+	// default mode when no thinking option is set.
+	if cfg.EnableThinking {
+		return nil, fmt.Errorf("bedrock-mantle: WithThinking is not supported for mantle model %s", cfg.ModelName)
+	}
+
+	baseURL := mantleBaseURL(p.region, p.baseEndpoint)
+
+	transport := &mantleTransport{
+		base:         baseTransport(p.httpClient),
+		credProvider: p.credentials,
+		signer:       p.signer,
+		region:       p.region,
+	}
+
+	// Preserve the caller's client (Timeout, Jar, CheckRedirect, ...) and only
+	// swap in the SigV4-signing transport, so mantle requests behave like the
+	// Converse client rather than a bare default.
+	httpClient := &http.Client{Transport: transport}
+	if p.httpClient != nil {
+		clone := *p.httpClient
+		clone.Transport = transport
+		httpClient = &clone
+	}
+
+	oaiProvider, err := openai.NewProvider(
+		mantlePlaceholderAPIKey,
+		openai.WithBaseURL(baseURL),
+		openai.WithHTTPClient(httpClient),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("bedrock-mantle: build OpenAI transport: %w", err)
+	}
+
+	oaiDef := openai.ModelDefinition{
+		Name:         def.Name,
+		Label:        def.Label,
+		Capabilities: def.Capabilities,
+		Constraints:  def.Constraints,
+		Pricing:      def.Pricing,
+	}
+
+	// cfg was already validated against the Bedrock constraints in NewModel;
+	// forward the concrete parameters as OpenAI options (which re-validate
+	// against the same constraints). WithThinking was rejected above.
+	inner, err := oaiProvider.NewCompatModel(cfg.APIModelID, oaiDef, translateMantleOptions(cfg)...)
+	if err != nil {
+		return nil, fmt.Errorf("bedrock-mantle: build model %s: %w", cfg.ModelName, err)
+	}
+
+	return &mantleModel{Model: inner, name: cfg.ModelName, def: def}, nil
+}
+
+// translateMantleOptions maps the concrete parameters resolved on a Bedrock
+// Config into the equivalent OpenAI options for the mantle transport. Only
+// temperature and max_tokens are forwarded — those are the sampling controls
+// the Responses request mapper serializes, and the only ones the Gemma
+// constraints advertise (see gemma4 SupportedParams).
+func translateMantleOptions(cfg *Config) []openai.Option {
+	var opts []openai.Option
+
+	if cfg.Temperature != nil {
+		opts = append(opts, openai.WithTemperature(*cfg.Temperature))
+	}
+
+	if cfg.MaxTokens != nil {
+		opts = append(opts, openai.WithMaxTokens(int(*cfg.MaxTokens)))
+	}
+
+	return opts
+}
+
+// mantleModel wraps the OpenAI-transport model so it reports the Bedrock
+// provider identity ("aws.bedrock") and the user-facing model name, while
+// delegating Generate/GenerateEvents to the embedded model.
+type mantleModel struct {
+	llm.Model // embedded OpenAI Responses model (Generate/GenerateEvents)
+
+	name string
+	def  ModelDefinition
+}
+
+func (m *mantleModel) Name() string                        { return m.name }
+func (*mantleModel) Provider() string                      { return "aws.bedrock" }
+func (m *mantleModel) Capabilities() llm.ModelCapabilities { return m.def.Capabilities }
+func (m *mantleModel) Constraints() llm.ModelConstraints   { return m.def.Constraints }
+
+// mantleTransport is an http.RoundTripper that SigV4-signs OpenAI-shaped
+// requests for the bedrock-mantle endpoint. The OpenAI SDK has no notion of AWS
+// signing, so this transport removes the placeholder bearer token, computes the
+// payload hash, and signs with the bedrock-mantle service name before
+// forwarding.
+type mantleTransport struct {
+	base         http.RoundTripper
+	credProvider aws.CredentialsProvider
+	signer       *signerv4.Signer
+	region       string
+}
+
+func (t *mantleTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	// SigV4 owns the Authorization header on the mantle endpoint; strip the
+	// bearer placeholder the OpenAI SDK sets before signing (or before
+	// forwarding unsigned in proxy mode).
+	req.Header.Del("Authorization")
+
+	// No credential provider or anonymous credentials (WithNoAuth / proxy
+	// mode): forward unsigned and let the downstream proxy authenticate.
+	// AnonymousCredentials.Retrieve errors rather than returning empty creds,
+	// so this must be checked before Retrieve; IsCredentialsProvider also
+	// unwraps the CredentialsCache the SDK wraps providers in.
+	if t.credProvider == nil || aws.IsCredentialsProvider(t.credProvider, aws.AnonymousCredentials{}) {
+		return t.base.RoundTrip(req)
+	}
+
+	creds, err := t.credProvider.Retrieve(req.Context())
+	if err != nil {
+		return nil, fmt.Errorf("bedrock-mantle: retrieve AWS credentials: %w", err)
+	}
+
+	// Anonymous is already handled above, so an empty access key here is a
+	// misconfigured credential provider. Fail loudly rather than sending an
+	// unsigned request the mantle endpoint rejects with an opaque 403.
+	if creds.AccessKeyID == "" {
+		return nil, errors.New("bedrock-mantle: resolved AWS credentials have an empty access key ID")
+	}
+
+	// Buffer the body to compute the exact SHA-256 SigV4 requires and to keep
+	// it readable for the actual send.
+	var body []byte
+	if req.Body != nil {
+		body, err = io.ReadAll(req.Body)
+		if err != nil {
+			return nil, fmt.Errorf("bedrock-mantle: read request body: %w", err)
+		}
+
+		_ = req.Body.Close()
+		req.Body = io.NopCloser(bytes.NewReader(body))
+		req.ContentLength = int64(len(body))
+	}
+
+	sum := sha256.Sum256(body)
+	payloadHash := hex.EncodeToString(sum[:])
+
+	if err := t.signer.SignHTTP(req.Context(), creds, req, payloadHash, mantleService, t.region, time.Now()); err != nil {
+		return nil, fmt.Errorf("bedrock-mantle: sign request: %w", err)
+	}
+
+	return t.base.RoundTrip(req)
+}
+
+// baseTransport returns the RoundTripper to forward signed requests with,
+// preferring a caller-supplied client's Transport and falling back to the
+// default.
+func baseTransport(c *http.Client) http.RoundTripper {
+	if c != nil && c.Transport != nil {
+		return c.Transport
+	}
+
+	return http.DefaultTransport
+}

--- a/providers/bedrock/mantle_test.go
+++ b/providers/bedrock/mantle_test.go
@@ -1,0 +1,252 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bedrock
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	signerv4 "github.com/aws/aws-sdk-go-v2/aws/signer/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsMantleModel(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		modelID string
+		want    bool
+	}{
+		{ModelGemma431B, true},
+		{ModelGemma426BA4B, true},
+		{ModelGemma4E2B, true},
+		// Converse-API models are not mantle.
+		{ModelClaudeSonnet45US, false},
+		{ModelNova2LiteUS, false},
+		{ModelMistralLarge3, false},
+		// Unknown IDs are not mantle.
+		{"google.gemma-4-31b-nonexistent", false},
+		{"openai.gpt-5.5", false},
+		{"", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.modelID, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, IsMantleModel(tt.modelID))
+		})
+	}
+}
+
+func TestMantleModelsAreFlaggedAndBareID(t *testing.T) {
+	t.Parallel()
+
+	for id, def := range supportedModels {
+		if !def.Mantle {
+			continue
+		}
+
+		t.Run(id, func(t *testing.T) {
+			t.Parallel()
+			// Mantle models are invoked by their bare ID — they must not carry a
+			// geo/global inference-profile prefix (NewModel resolves them as-is).
+			assert.False(t, hasRegionPrefix(id),
+				"mantle model %s should be a bare ID with no geo prefix", id)
+			// The catalog Name must equal the map key.
+			assert.Equal(t, id, def.Name)
+		})
+	}
+}
+
+func TestMantleBaseURL(t *testing.T) {
+	t.Parallel()
+
+	// Direct: real mantle host per region.
+	assert.Equal(t, "https://bedrock-mantle.us-east-1.api.aws/openai/v1", mantleBaseURL("us-east-1", ""))
+	assert.Equal(t, "https://bedrock-mantle.eu-central-1.api.aws/openai/v1", mantleBaseURL("eu-central-1", ""))
+	// Proxy/gateway mode: route through the supplied base endpoint (trailing slash trimmed).
+	assert.Equal(t, "https://proxy.example/openai/v1", mantleBaseURL("us-east-1", "https://proxy.example/"))
+}
+
+func TestNewModel_MantleRoutesToBedrockProvider(t *testing.T) {
+	t.Parallel()
+
+	// WithNoAuth uses anonymous credentials, so no real AWS credentials are
+	// needed to construct the model (it is not invoked here).
+	p, err := NewProvider(context.Background(), WithRegion("us-east-1"), WithNoAuth())
+	require.NoError(t, err)
+
+	m, err := p.NewModel(ModelGemma431B, WithTemperature(0.5), WithMaxTokens(1024))
+	require.NoError(t, err)
+
+	// It reports the Bedrock identity, not "openai".
+	assert.Equal(t, "aws.bedrock", m.Provider())
+	assert.Equal(t, ModelGemma431B, m.Name())
+	// Capabilities/constraints come from the Bedrock catalog entry.
+	assert.True(t, m.Capabilities().Reasoning)
+	assert.Equal(t, 256000, m.Constraints().MaxInputTokens)
+}
+
+func TestNewModel_MantleRejectsUnserializedOptions(t *testing.T) {
+	t.Parallel()
+
+	p, err := NewProvider(context.Background(), WithRegion("us-east-1"), WithNoAuth())
+	require.NoError(t, err)
+
+	// top_p and stop are NOT serialized by the Responses request mapper, so
+	// Gemma does not advertise them — setting either must error rather than
+	// silently do nothing.
+	_, err = p.NewModel(ModelGemma431B, WithTopP(0.5))
+	require.Error(t, err)
+
+	_, err = p.NewModel(ModelGemma431B, WithStop("STOP"))
+	require.Error(t, err)
+}
+
+func TestNewModel_MantleRejectsThinking(t *testing.T) {
+	t.Parallel()
+
+	p, err := NewProvider(context.Background(), WithRegion("us-east-1"), WithNoAuth())
+	require.NoError(t, err)
+
+	// WithThinking is Anthropic/Converse-shaped and has no mantle equivalent, so
+	// it must error rather than being silently dropped.
+	_, err = p.NewModel(ModelGemma431B, WithThinking(1024))
+	require.Error(t, err)
+}
+
+func TestMantleTransport_EmptyAccessKeyErrors(t *testing.T) {
+	t.Parallel()
+
+	capture := &captureRoundTripper{}
+	tr := &mantleTransport{
+		base: capture,
+		credProvider: aws.CredentialsProviderFunc(func(context.Context) (aws.Credentials, error) {
+			return aws.Credentials{}, nil // resolves, but with an empty access key
+		}),
+		signer: signerv4.NewSigner(),
+		region: "us-east-1",
+	}
+
+	resp, err := tr.RoundTrip(newSignedRequest(t))
+	require.Error(t, err)
+
+	if resp != nil {
+		_ = resp.Body.Close()
+	}
+	// It fails loudly instead of forwarding an unsigned request downstream.
+	assert.Nil(t, capture.req)
+}
+
+func TestNewProvider_MantleHonorsAWSConfigHTTPClient(t *testing.T) {
+	t.Parallel()
+
+	// A client supplied via WithAWSConfig (not WithHTTPClient) must still be the
+	// one the mantle transport wraps, matching the Converse client's behavior.
+	custom := &http.Client{}
+
+	p, err := NewProvider(context.Background(), WithAWSConfig(aws.Config{
+		Region:      "us-east-1",
+		HTTPClient:  custom,
+		Credentials: aws.AnonymousCredentials{},
+	}))
+	require.NoError(t, err)
+	assert.Same(t, custom, p.httpClient)
+}
+
+// captureRoundTripper records the request it receives and returns a canned 200.
+type captureRoundTripper struct {
+	req *http.Request
+}
+
+func (c *captureRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
+	c.req = r
+
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader("{}")),
+		Header:     make(http.Header),
+	}, nil
+}
+
+func newSignedRequest(t *testing.T) *http.Request {
+	t.Helper()
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost,
+		"https://bedrock-mantle.us-east-1.api.aws/openai/v1/responses",
+		strings.NewReader(`{"model":"google.gemma-4-31b","input":"hi"}`))
+	require.NoError(t, err)
+	// The OpenAI SDK sets a bearer token; the transport must strip it.
+	req.Header.Set("Authorization", "Bearer bedrock-mantle-sigv4")
+	req.Header.Set("Content-Type", "application/json")
+
+	return req
+}
+
+func TestMantleTransport_SignsWithMantleService(t *testing.T) {
+	t.Parallel()
+
+	capture := &captureRoundTripper{}
+	tr := &mantleTransport{
+		base: capture,
+		credProvider: aws.CredentialsProviderFunc(func(context.Context) (aws.Credentials, error) {
+			return aws.Credentials{AccessKeyID: "AKIDEXAMPLE", SecretAccessKey: "secret"}, nil
+		}),
+		signer: signerv4.NewSigner(),
+		region: "us-east-1",
+	}
+
+	resp, err := tr.RoundTrip(newSignedRequest(t))
+	require.NoError(t, err)
+
+	_ = resp.Body.Close()
+
+	auth := capture.req.Header.Get("Authorization")
+	assert.True(t, strings.HasPrefix(auth, "AWS4-HMAC-SHA256"),
+		"expected a SigV4 Authorization header, got %q", auth)
+	assert.Contains(t, auth, "/us-east-1/bedrock-mantle/aws4_request",
+		"SigV4 credential scope should name the bedrock-mantle service")
+	assert.NotContains(t, auth, "Bearer", "the placeholder bearer token must be stripped")
+
+	// The body is preserved for the downstream send.
+	body, err := io.ReadAll(capture.req.Body)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"model":"google.gemma-4-31b","input":"hi"}`, string(body))
+}
+
+func TestMantleTransport_AnonymousForwardsUnsigned(t *testing.T) {
+	t.Parallel()
+
+	capture := &captureRoundTripper{}
+	tr := &mantleTransport{
+		base:         capture,
+		credProvider: aws.AnonymousCredentials{},
+		signer:       signerv4.NewSigner(),
+		region:       "us-east-1",
+	}
+
+	resp, err := tr.RoundTrip(newSignedRequest(t))
+	require.NoError(t, err)
+
+	_ = resp.Body.Close()
+
+	// No signing, and the placeholder bearer is still stripped.
+	assert.Empty(t, capture.req.Header.Get("Authorization"))
+}

--- a/providers/bedrock/models.go
+++ b/providers/bedrock/models.go
@@ -154,6 +154,36 @@ const (
 	ModelMistralLarge3 = "mistral.mistral-large-3-675b-instruct"
 )
 
+// Model ID constants for Google Gemma 4 models on Bedrock.
+//
+// The Gemma 4 family is served ONLY on the bedrock-mantle endpoint (the
+// OpenAI-compatible Responses / Chat Completions API), NOT the standard
+// bedrock-runtime Converse API — so every entry sets Mantle: true and NewModel
+// routes it through the SigV4-signed Responses transport in mantle.go.
+//
+// Like Mistral Large 3, these are invoked by their BARE ID with no us./eu./
+// global. cross-region inference profile: the model cards list Geo = Not
+// supported and Global = Not supported, with only In-Region availability
+// (us-east-1, us-east-2, us-west-2, eu-central-1). So the bare ID is registered
+// and NewModel resolves it as-is (no geo-prefix). See
+// https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-google-gemma-4-31b.html
+const (
+	// ModelGemma431B is Google Gemma 4 31B — a 30.7B dense model with
+	// built-in reasoning, native function calling, and text+image+video input
+	// (text output), 256K context. mantle-only.
+	ModelGemma431B = "google.gemma-4-31b"
+
+	// ModelGemma426BA4B is Google Gemma 4 26B-A4B — a 25.2B-total /
+	// 3.8B-active mixture-of-experts model tuned for cost/latency-sensitive
+	// workloads, 256K context. mantle-only.
+	ModelGemma426BA4B = "google.gemma-4-26b-a4b"
+
+	// ModelGemma4E2B is Google Gemma 4 E2B — the smallest variant (5.1B
+	// total / 2.3B effective) for low-latency interactive use, 128K context.
+	// mantle-only.
+	ModelGemma4E2B = "google.gemma-4-e2b"
+)
+
 // ModelDefinition defines a model with its capabilities and constraints.
 type ModelDefinition struct {
 	Name                        string // Real Bedrock model ID (e.g. "us.anthropic.claude-sonnet-4-6")
@@ -162,6 +192,16 @@ type ModelDefinition struct {
 	Constraints                 llm.ModelConstraints
 	Pricing                     pricing.Info
 	RequiresProviderDataSharing bool
+
+	// Mantle marks a model that is served ONLY on the bedrock-mantle
+	// endpoint (the OpenAI-compatible Responses / Chat Completions API at
+	// bedrock-mantle.{region}.api.aws), not the standard bedrock-runtime
+	// Converse API. NewModel routes these models through a SigV4-signed
+	// OpenAI Responses transport (see mantle.go) instead of Converse. The
+	// Google Gemma 4 family and OpenAI's gpt-5.x frontier models on Bedrock
+	// are mantle-only. See
+	// https://docs.aws.amazon.com/bedrock/latest/userguide/bedrock-mantle.html
+	Mantle bool
 }
 
 // ModelMetadataRequiresProviderDataSharing is set to "true" on discovery
@@ -350,6 +390,52 @@ var (
 		MaxInputTokens:   128000,
 		MaxOutputTokens:  8192,
 		SupportedParams:  []string{"temperature", "top_p", "max_tokens", "stop"},
+	}
+
+	// Capability/constraint shapes for the Google Gemma 4 family on the
+	// bedrock-mantle endpoint. All variants share the same capability surface:
+	// streaming, native function calling (Tools), built-in Reasoning, and text
+	// output. Audio is false, and although Gemma accepts image/video input at
+	// the model level, Vision is left FALSE: the SDK has no image Part and the
+	// reused OpenAI Responses request mapper only serializes text/tool/reasoning
+	// parts, so there is no wired path to send an image today — advertising
+	// Vision would promise input the mapper silently drops. Flip to true once
+	// image input is threaded through the Responses request mapping. JSONMode /
+	// StructuredOutput are false for the same reason: unverified on this path.
+	//
+	// The context windows differ by variant (256K for 31B / 26B-A4B, 128K for
+	// E2B), so each gets its own constraints var. AWS publishes no separate
+	// max-output cap for Gemma on Bedrock — output is bounded only by the
+	// context window (other hosts report the full context as the output
+	// ceiling) — so MaxOutputTokens mirrors MaxInputTokens rather than a guessed
+	// smaller cap that would make WithMaxTokens spuriously reject large but
+	// valid requests. TemperatureRange is the OpenAI API's 0..2 (the mantle
+	// Responses endpoint honors OpenAI sampling semantics). SupportedParams
+	// lists only temperature and max_tokens: those are the only sampling
+	// controls the request mapper serializes, so advertising top_p / stop /
+	// penalties would let callers set knobs that silently do nothing.
+	gemma4Caps = llm.ModelCapabilities{
+		Streaming:     true,
+		Tools:         true,
+		Vision:        false,
+		Audio:         false,
+		MultiTurn:     true,
+		SystemPrompts: true,
+		Reasoning:     true,
+	}
+
+	gemma4Context256kConstraints = llm.ModelConstraints{
+		TemperatureRange: [2]float64{0.0, 2.0},
+		MaxInputTokens:   256000,
+		MaxOutputTokens:  256000,
+		SupportedParams:  []string{"temperature", "max_tokens"},
+	}
+
+	gemma4Context128kConstraints = llm.ModelConstraints{
+		TemperatureRange: [2]float64{0.0, 2.0},
+		MaxInputTokens:   128000,
+		MaxOutputTokens:  128000,
+		SupportedParams:  []string{"temperature", "max_tokens"},
 	}
 )
 
@@ -801,6 +887,57 @@ var supportedModels = map[string]ModelDefinition{
 		Constraints:  mistralLarge3Constraints,
 		Pricing: pricing.FlatInfoFromRates(
 			pricing.NewRates(0.50, 1.50, 0),
+		),
+	},
+
+	// ----------------------------------------------------------------
+	// Google Gemma 4 family — mantle-only (Mantle: true), invoked by the
+	// bare ID via the bedrock-mantle Responses endpoint (no inference
+	// profile; the model cards list Geo/Global = Not supported). Because the
+	// bare IDs have no geo prefix, these are excluded from the per-region
+	// geo-profile conformance sweep and from TestGeoGlobalRatio (no global.
+	// sibling), and they are listed in noCacheModels in pricing_test.go.
+	//
+	// Pricing is the on-demand STANDARD-tier rate for the US regions
+	// (us-east-1/2, us-west-2), taken from https://aws.amazon.com/bedrock/pricing/
+	// (Google section, 2026-06). AWS also publishes a ~15-20% higher
+	// eu-central-1 (Frankfurt) rate that is NOT separately modeled here (the
+	// catalog keys on model ID, not region, and no existing Bedrock entry
+	// carries a region override): 31B EU $0.17/$0.48, 26B-A4B EU $0.16/$0.48,
+	// E2B EU $0.05/$0.10 per 1M in/out. Revisit with a pricing.Info region
+	// Override if EU-accurate billing is required. The mantle Responses
+	// endpoint bills only input/output (no cache-read/cache-write usagetype
+	// is published for Gemma), so all cache rates stay zero — the documented
+	// shape for a non-caching model (see pricing.Rates / noCacheModels).
+	// ----------------------------------------------------------------
+	ModelGemma431B: {
+		Name:         ModelGemma431B,
+		Label:        "Google Gemma 4 31B",
+		Capabilities: gemma4Caps,
+		Constraints:  gemma4Context256kConstraints,
+		Mantle:       true,
+		Pricing: pricing.FlatInfoFromRates(
+			pricing.NewRates(0.14, 0.40, 0),
+		),
+	},
+	ModelGemma426BA4B: {
+		Name:         ModelGemma426BA4B,
+		Label:        "Google Gemma 4 26B-A4B",
+		Capabilities: gemma4Caps,
+		Constraints:  gemma4Context256kConstraints,
+		Mantle:       true,
+		Pricing: pricing.FlatInfoFromRates(
+			pricing.NewRates(0.13, 0.40, 0),
+		),
+	},
+	ModelGemma4E2B: {
+		Name:         ModelGemma4E2B,
+		Label:        "Google Gemma 4 E2B",
+		Capabilities: gemma4Caps,
+		Constraints:  gemma4Context128kConstraints,
+		Mantle:       true,
+		Pricing: pricing.FlatInfoFromRates(
+			pricing.NewRates(0.04, 0.08, 0),
 		),
 	},
 }

--- a/providers/bedrock/pricing_test.go
+++ b/providers/bedrock/pricing_test.go
@@ -41,6 +41,9 @@ var freeCacheWriteModels = map[string]bool{
 // the cache for free.
 var noCacheModels = map[string]bool{
 	ModelMistralLarge3: true,
+	ModelGemma431B:     true,
+	ModelGemma426BA4B:  true,
+	ModelGemma4E2B:     true,
 }
 
 func TestAllModelsHavePricing(t *testing.T) {

--- a/providers/bedrock/provider.go
+++ b/providers/bedrock/provider.go
@@ -22,17 +22,28 @@ import (
 	"sort"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	signerv4 "github.com/aws/aws-sdk-go-v2/aws/signer/v4"
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime"
 
 	"github.com/redpanda-data/ai-sdk-go/llm"
 )
 
-// Provider implements the Bedrock model provider using the Converse API.
+// Provider implements the Bedrock model provider. Standard models use the
+// bedrock-runtime Converse API; mantle-only models (Mantle: true in the
+// catalog) use the OpenAI-compatible Responses API on bedrock-mantle, signed by
+// the SigV4 transport in mantle.go — which is why the provider also retains the
+// credentials, region, and a shared signer.
 type Provider struct {
 	client        *bedrockruntime.Client
 	region        string
 	enableCaching bool
+
+	// Retained for the mantle Responses transport (see mantle.go).
+	credentials  aws.CredentialsProvider
+	signer       *signerv4.Signer
+	httpClient   *http.Client // caller-supplied client, if any (base transport)
+	baseEndpoint string       // custom base endpoint (proxy/gateway mode), if any
 }
 
 // ProviderOption configures a Provider instance using functional options.
@@ -96,10 +107,31 @@ func NewProvider(ctx context.Context, opts ...ProviderOption) (*Provider, error)
 
 	client := bedrockruntime.NewFromConfig(awsCfg, clientOpts...)
 
+	var baseEndpoint string
+	if awsCfg.BaseEndpoint != nil {
+		baseEndpoint = *awsCfg.BaseEndpoint
+	}
+
+	// Resolve the HTTP client the mantle transport wraps. WithHTTPClient wins;
+	// otherwise honor a client supplied via WithAWSConfig (awsCfg.HTTPClient) so
+	// mantle requests use the same transport as the Converse client does, rather
+	// than silently falling back to the default. Anything else leaves it nil and
+	// mantle.go uses http.DefaultTransport.
+	httpClient := cfg.httpClient
+	if httpClient == nil {
+		if hc, ok := awsCfg.HTTPClient.(*http.Client); ok {
+			httpClient = hc
+		}
+	}
+
 	return &Provider{
 		client:        client,
 		region:        awsCfg.Region,
 		enableCaching: cfg.caching,
+		credentials:   awsCfg.Credentials,
+		signer:        signerv4.NewSigner(),
+		httpClient:    httpClient,
+		baseEndpoint:  baseEndpoint,
 	}, nil
 }
 
@@ -213,6 +245,12 @@ func (p *Provider) NewModel(modelName string, opts ...Option) (llm.Model, error)
 
 	if err := cfg.Validate(); err != nil {
 		return nil, fmt.Errorf("configuration validation failed for %s: %w", modelName, err)
+	}
+
+	// Mantle-only models (Gemma 4, gpt-5.x) are not served by the Converse API;
+	// route them through the SigV4-signed OpenAI Responses transport instead.
+	if modelDef.Mantle {
+		return newMantleModel(p, cfg, modelDef)
 	}
 
 	return &Model{

--- a/providers/openai/provider.go
+++ b/providers/openai/provider.go
@@ -141,29 +141,39 @@ func (p *Provider) NewModel(modelName string, opts ...Option) (llm.Model, error)
 		return nil, fmt.Errorf("unsupported OpenAI model: %s", modelName)
 	}
 
+	return p.NewCompatModel(modelName, modelDef, opts...)
+}
+
+// NewCompatModel creates a model for an OpenAI-compatible endpoint using an
+// explicit ModelDefinition, bypassing the built-in supportedModels catalog and
+// the family-name resolver. It is the constructor for OpenAI-shaped models that
+// are not OpenAI's own — e.g. the Google Gemma 4 and OpenAI gpt-5.x models on
+// the AWS bedrock-mantle Responses endpoint, which the Bedrock provider reaches
+// by pointing this provider at a mantle base URL with a SigV4-signing HTTP
+// client (see providers/bedrock/mantle.go).
+//
+// modelName is sent verbatim as the API model ID. def supplies capabilities,
+// constraints, reasoning efforts, and pricing. All request/response/streaming
+// behaviour is identical to NewModel — only catalog lookup differs.
+func (p *Provider) NewCompatModel(modelName string, def ModelDefinition, opts ...Option) (llm.Model, error) {
 	cfg := &Config{
 		ModelName:   modelName,
-		Constraints: modelDef.Constraints,
+		Constraints: def.Constraints,
 		setOptions:  make(map[string]bool),
 	}
 
-	// Apply all options with validation
 	for _, opt := range opts {
-		err := opt(cfg)
-		if err != nil {
+		if err := opt(cfg); err != nil {
 			return nil, fmt.Errorf("invalid option for %s: %w", modelName, err)
 		}
 	}
 
-	// Validate configuration
-	err := cfg.Validate()
-	if err != nil {
+	if err := cfg.Validate(); err != nil {
 		return nil, fmt.Errorf("configuration validation failed for %s: %w", modelName, err)
 	}
 
-	// Validate reasoning effort against model's supported efforts
-	if cfg.ReasoningEffort != nil && len(modelDef.SupportedReasoningEfforts) > 0 {
-		if !slices.Contains(modelDef.SupportedReasoningEfforts, *cfg.ReasoningEffort) {
+	if cfg.ReasoningEffort != nil && len(def.SupportedReasoningEfforts) > 0 {
+		if !slices.Contains(def.SupportedReasoningEfforts, *cfg.ReasoningEffort) {
 			return nil, fmt.Errorf("model %s does not support reasoning effort '%s'", modelName, *cfg.ReasoningEffort)
 		}
 	}
@@ -171,10 +181,10 @@ func (p *Provider) NewModel(modelName string, opts ...Option) (llm.Model, error)
 	return &Model{
 		provider:       p,
 		config:         cfg,
-		definition:     modelDef,
+		definition:     def,
 		client:         p.client,
 		requestMapper:  NewRequestMapper(cfg),
-		responseMapper: NewResponseMapper(modelDef),
+		responseMapper: NewResponseMapper(def),
 	}, nil
 }
 


### PR DESCRIPTION
Adds the Google Gemma 4 family (31B, 26B-A4B and E2B) to the Bedrock catalog. Because these models only run on Bedrock's mantle endpoint over the OpenAI Responses API, the provider now routes them through a small SigV4 transport signed with the bedrock-mantle service name that reuses our existing OpenAI model instead of Converse. It's unit tested and I also verified it end to end against a real Gemma 4 model in us-east-2.