### PR TITLE
feat(openai): add gpt-5.6 terra support

### DIFF
--- a/providers/openai/constants.go
+++ b/providers/openai/constants.go
@@ -45,6 +45,8 @@ const (
 
 	// ModelGPT5_6Luna is the cost-optimized GPT-5.6 model.
 	ModelGPT5_6Luna = shared.ChatModelGPT5_6Luna
+	// ModelGPT5_6Terra balances capability and cost in the GPT-5.6 family.
+	ModelGPT5_6Terra = shared.ChatModelGPT5_6Terra
 
 	// ModelGPT5_5 is the GPT-5.5 flagship model (1M context, coding/professional work).
 	// Raw string until the OpenAI SDK adds the constant.

--- a/providers/openai/models.go
+++ b/providers/openai/models.go
@@ -291,6 +291,37 @@ var supportedModels = map[string]ModelDefinition{
 			},
 		),
 	},
+	ModelGPT5_6Terra: {
+		Name:  ModelGPT5_6Terra,
+		Label: "OpenAI GPT-5.6 Terra",
+		Capabilities: llm.ModelCapabilities{
+			Streaming:        true,
+			Tools:            true,
+			JSONMode:         true,
+			StructuredOutput: true,
+			Vision:           true,
+			MultiTurn:        true,
+			SystemPrompts:    true,
+			Reasoning:        true,
+		},
+		Constraints: llm.ModelConstraints{
+			TemperatureRange:  [2]float64{0.0, 2.0},
+			MaxInputTokens:    1_050_000,
+			MaxOutputTokens:   128_000,
+			SupportedParams:   []string{"temperature", "top_p", "max_tokens", "frequency_penalty", "presence_penalty", "seed", "reasoning_effort", "reasoning_summary"},
+			MutuallyExclusive: [][]string{{"temperature", "top_p"}},
+		},
+		SupportedReasoningEfforts: []ReasoningEffort{ReasoningEffortNone, ReasoningEffortLow, ReasoningEffortMedium, ReasoningEffortHigh, ReasoningEffortXHigh, ReasoningEffortMax},
+		// Per M tokens: $2.50 input, $15.00 output, $0.25 cached input, $3.125 cache write.
+		// Above 272K: $5.00 input, $22.50 output, $0.50 cached input, $6.25 cache write.
+		Pricing: pricing.TieredInfo(
+			pricing.NewRates(2.50, 15.00, 0.25).WithCacheCreation(0, 0, 3.125),
+			pricing.Bracket{
+				MinContextTokens: 272_001,
+				Rates:            pricing.NewRates(5.00, 22.50, 0.50).WithCacheCreation(0, 0, 6.25),
+			},
+		),
+	},
 
 	// GPT-5.5 (May 2026 Flagship)
 	ModelGPT5_5: {

--- a/providers/openai/openai_test.go
+++ b/providers/openai/openai_test.go
@@ -174,6 +174,7 @@ func TestGPT56Models(t *testing.T) {
 		label string
 	}{
 		{name: "Luna", model: ModelGPT5_6Luna, label: "OpenAI GPT-5.6 Luna"},
+		{name: "Terra", model: ModelGPT5_6Terra, label: "OpenAI GPT-5.6 Terra"},
 	}
 
 	for _, tt := range tests {

--- a/providers/openai/pricing_test.go
+++ b/providers/openai/pricing_test.go
@@ -65,6 +65,25 @@ func TestGPT56Pricing(t *testing.T) {
 			wantWrite:   250_000_000,
 			wantOutput:  900_000_000,
 		},
+		{
+			name:       "Terra at 272K uses base rates",
+			model:      ModelGPT5_6Terra,
+			context:    272_000,
+			wantInput:  250_000_000,
+			wantCached: 25_000_000,
+			wantWrite:  312_500_000,
+			wantOutput: 1_500_000_000,
+		},
+		{
+			name:        "Terra above 272K uses long-context rates",
+			model:       ModelGPT5_6Terra,
+			context:     272_001,
+			wantBracket: 272_001,
+			wantInput:   500_000_000,
+			wantCached:  50_000_000,
+			wantWrite:   625_000_000,
+			wantOutput:  2_250_000_000,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

- add `gpt-5.6-terra` to OpenAI model discovery and construction
- expose the shared GPT-5.6 capability set, 1.05M context, 128K output, and `max` reasoning
- model standard and >272K context pricing, including cached reads and cache writes

## Stack

1. [GPT-5.6 Luna #171](https://github.com/redpanda-data/ai-sdk-go/pull/171) — shared SDK, reasoning, and cache-write groundwork
2. **GPT-5.6 Terra** — this PR, based on the Luna branch
3. GPT-5.6 Sol — follows on this branch

This PR's diff adds exactly one model.

## Model data

| Field | Value |
|---|---|
| Model ID | `gpt-5.6-terra` |
| Context | 1,050,000 tokens |
| Max output | 128,000 tokens |
| Reasoning | `none`, `low`, `medium`, `high`, `xhigh`, `max` |
| Standard pricing | $2.50 input / $0.25 cached / $3.125 cache write / $15 output per MTok |
| >272K pricing | $5 input / $0.50 cached / $6.25 cache write / $22.50 output per MTok |

## Verification

- `go test ./providers/openai`
- `task test:unit` — 1,326 passed, 51 skipped
- `task license:check`
- `task lint:new` — 0 issues
- `go vet ./...`

OpenAI integration tests were skipped because `OPENAI_API_KEY` is not set.

## Reference

- https://developers.openai.com/api/docs/models/gpt-5.6-terra

Visual recap omitted: small provider catalog addition with no visual surface.
