### PR TITLE
feat(openai): add gpt-5.6 sol support

### DIFF
--- a/providers/openai/constants.go
+++ b/providers/openai/constants.go
@@ -47,6 +47,10 @@ const (
 	ModelGPT5_6Luna = shared.ChatModelGPT5_6Luna
 	// ModelGPT5_6Terra balances capability and cost in the GPT-5.6 family.
 	ModelGPT5_6Terra = shared.ChatModelGPT5_6Terra
+	// ModelGPT5_6Sol is the flagship GPT-5.6 model.
+	ModelGPT5_6Sol = shared.ChatModelGPT5_6Sol
+	// ModelGPT5_6 is the official alias for GPT-5.6 Sol.
+	ModelGPT5_6 = "gpt-5.6"
 
 	// ModelGPT5_5 is the GPT-5.5 flagship model (1M context, coding/professional work).
 	// Raw string until the OpenAI SDK adds the constant.

--- a/providers/openai/models.go
+++ b/providers/openai/models.go
@@ -31,6 +31,10 @@ type ModelDefinition struct {
 	Pricing                   pricing.Info      // Cost per million tokens (microcents)
 }
 
+var modelAliases = map[string]string{
+	ModelGPT5_6: ModelGPT5_6Sol,
+}
+
 // resolveModelFamily returns the model family key for a given model string.
 // If the model string has a known family as a prefix, that family is returned
 // (longest match wins). Otherwise the original string is returned unchanged.
@@ -43,6 +47,10 @@ type ModelDefinition struct {
 //	"gpt-4o-2024-11-20" -> "gpt-4o"
 //	"gpt-4o"            -> "gpt-4o" (unchanged, exact match)
 func resolveModelFamily(model string) string {
+	if family, ok := modelAliases[model]; ok {
+		return family
+	}
+
 	best := ""
 
 	for family := range supportedModels {
@@ -52,6 +60,12 @@ func resolveModelFamily(model string) string {
 	}
 
 	if best != "" {
+		for alias := range modelAliases {
+			if strings.HasPrefix(model, alias+"-") && !strings.HasPrefix(best, alias+"-") {
+				return model
+			}
+		}
+
 		return best
 	}
 
@@ -319,6 +333,37 @@ var supportedModels = map[string]ModelDefinition{
 			pricing.Bracket{
 				MinContextTokens: 272_001,
 				Rates:            pricing.NewRates(5.00, 22.50, 0.50).WithCacheCreation(0, 0, 6.25),
+			},
+		),
+	},
+	ModelGPT5_6Sol: {
+		Name:  ModelGPT5_6Sol,
+		Label: "OpenAI GPT-5.6 Sol",
+		Capabilities: llm.ModelCapabilities{
+			Streaming:        true,
+			Tools:            true,
+			JSONMode:         true,
+			StructuredOutput: true,
+			Vision:           true,
+			MultiTurn:        true,
+			SystemPrompts:    true,
+			Reasoning:        true,
+		},
+		Constraints: llm.ModelConstraints{
+			TemperatureRange:  [2]float64{0.0, 2.0},
+			MaxInputTokens:    1_050_000,
+			MaxOutputTokens:   128_000,
+			SupportedParams:   []string{"temperature", "top_p", "max_tokens", "frequency_penalty", "presence_penalty", "seed", "reasoning_effort", "reasoning_summary"},
+			MutuallyExclusive: [][]string{{"temperature", "top_p"}},
+		},
+		SupportedReasoningEfforts: []ReasoningEffort{ReasoningEffortNone, ReasoningEffortLow, ReasoningEffortMedium, ReasoningEffortHigh, ReasoningEffortXHigh, ReasoningEffortMax},
+		// Per M tokens: $5.00 input, $30.00 output, $0.50 cached input, $6.25 cache write.
+		// Above 272K: $10.00 input, $45.00 output, $1.00 cached input, $12.50 cache write.
+		Pricing: pricing.TieredInfo(
+			pricing.NewRates(5.00, 30.00, 0.50).WithCacheCreation(0, 0, 6.25),
+			pricing.Bracket{
+				MinContextTokens: 272_001,
+				Rates:            pricing.NewRates(10.00, 45.00, 1.00).WithCacheCreation(0, 0, 12.50),
 			},
 		),
 	},

--- a/providers/openai/openai_test.go
+++ b/providers/openai/openai_test.go
@@ -175,6 +175,7 @@ func TestGPT56Models(t *testing.T) {
 	}{
 		{name: "Luna", model: ModelGPT5_6Luna, label: "OpenAI GPT-5.6 Luna"},
 		{name: "Terra", model: ModelGPT5_6Terra, label: "OpenAI GPT-5.6 Terra"},
+		{name: "Sol", model: ModelGPT5_6Sol, label: "OpenAI GPT-5.6 Sol"},
 	}
 
 	for _, tt := range tests {
@@ -212,6 +213,38 @@ func TestGPT56Models(t *testing.T) {
 
 			t.Fatalf("model %q was not discoverable", tt.model)
 		})
+	}
+}
+
+func TestGPT56AliasResolvesToSolWithoutDuplicateDiscovery(t *testing.T) {
+	t.Parallel()
+
+	provider, err := NewProvider("sk-test-key")
+	require.NoError(t, err)
+
+	aliasModel, err := provider.NewModel(ModelGPT5_6, WithReasoningEffort(ReasoningEffortMax))
+	require.NoError(t, err)
+	assert.Equal(t, ModelGPT5_6, aliasModel.Name())
+
+	solModel, err := provider.NewModel(ModelGPT5_6Sol)
+	require.NoError(t, err)
+	assert.Equal(t, solModel.Capabilities(), aliasModel.Capabilities())
+	assert.Equal(t, solModel.Constraints(), aliasModel.Constraints())
+
+	openAIModel, ok := aliasModel.(*Model)
+	require.True(t, ok)
+
+	apiReq, err := openAIModel.requestMapper.ToProvider(&llm.Request{})
+	require.NoError(t, err)
+	assert.Equal(t, ModelGPT5_6, apiReq.Model)
+
+	for _, discovered := range provider.Models() {
+		assert.NotEqual(t, ModelGPT5_6, discovered.Name)
+	}
+
+	for _, unsupported := range []string{"gpt-5.6-2026-07-09", "gpt-5.6-preview"} {
+		_, err := provider.NewModel(unsupported)
+		require.ErrorContains(t, err, "unsupported OpenAI model")
 	}
 }
 

--- a/providers/openai/pricing.go
+++ b/providers/openai/pricing.go
@@ -19,9 +19,13 @@ import "github.com/redpanda-data/ai-sdk-go/pricing"
 // ModelPricing returns a model ID → pricing map for all supported OpenAI models.
 // Source: https://openai.com/api/pricing/ (as of 2026-07).
 func ModelPricing() map[string]pricing.Info {
-	m := make(map[string]pricing.Info, len(supportedModels))
+	m := make(map[string]pricing.Info, len(supportedModels)+len(modelAliases))
 	for id, def := range supportedModels {
 		m[id] = def.Pricing
+	}
+
+	for alias, family := range modelAliases {
+		m[alias] = supportedModels[family].Pricing
 	}
 
 	return m

--- a/providers/openai/pricing_test.go
+++ b/providers/openai/pricing_test.go
@@ -84,6 +84,25 @@ func TestGPT56Pricing(t *testing.T) {
 			wantWrite:   625_000_000,
 			wantOutput:  2_250_000_000,
 		},
+		{
+			name:       "Sol at 272K uses base rates",
+			model:      ModelGPT5_6Sol,
+			context:    272_000,
+			wantInput:  500_000_000,
+			wantCached: 50_000_000,
+			wantWrite:  625_000_000,
+			wantOutput: 3_000_000_000,
+		},
+		{
+			name:        "Sol above 272K uses long-context rates",
+			model:       ModelGPT5_6Sol,
+			context:     272_001,
+			wantBracket: 272_001,
+			wantInput:   1_000_000_000,
+			wantCached:  100_000_000,
+			wantWrite:   1_250_000_000,
+			wantOutput:  4_500_000_000,
+		},
 	}
 
 	for _, tt := range tests {
@@ -130,10 +149,19 @@ func TestAllModelsHavePricing(t *testing.T) {
 	}
 }
 
+func TestGPT56AliasHasSolPricing(t *testing.T) {
+	t.Parallel()
+
+	pricingMap := ModelPricing()
+	aliasPricing, ok := pricingMap[ModelGPT5_6]
+	require.True(t, ok)
+	assert.Equal(t, supportedModels[ModelGPT5_6Sol].Pricing, aliasPricing)
+}
+
 func TestModelPricingMatchesModels(t *testing.T) {
 	t.Parallel()
 
 	pricingMap := ModelPricing()
-	assert.Len(t, pricingMap, len(supportedModels),
-		"ModelPricing should return exactly one entry per supported model")
+	assert.Len(t, pricingMap, len(supportedModels)+len(modelAliases),
+		"ModelPricing should return one entry per supported model and alias")
 }


### PR DESCRIPTION
## Summary

- add `gpt-5.6-sol` to OpenAI model discovery and construction
- accept the official `gpt-5.6` alias as Sol while preserving the alias in API requests
- keep the alias out of discovery and reject unsupported alias-like IDs
- model standard and >272K context pricing for both canonical and alias IDs

## Stack

1. [GPT-5.6 Luna #171](https://github.com/redpanda-data/ai-sdk-go/pull/171) — shared SDK, reasoning, and cache-write groundwork
2. [GPT-5.6 Terra #172](https://github.com/redpanda-data/ai-sdk-go/pull/172) — Terra model
3. **GPT-5.6 Sol** — this PR, based on the Terra branch

This PR's diff adds exactly one model plus its official alias.

## Model data

| Field | Value |
|---|---|
| Model IDs | `gpt-5.6-sol`, alias `gpt-5.6` |
| Context | 1,050,000 tokens |
| Max output | 128,000 tokens |
| Reasoning | `none`, `low`, `medium`, `high`, `xhigh`, `max` |
| Standard pricing | $5 input / $0.50 cached / $6.25 cache write / $30 output per MTok |
| >272K pricing | $10 input / $1 cached / $12.50 cache write / $45 output per MTok |

## Verification

- `go test ./providers/openai`
- `go test -race ./providers/openai ./pricing`
- `task test:unit` — 1,332 passed, 51 skipped
- `task license:check`
- `task lint:new` — 0 issues
- `go vet ./...`

OpenAI integration tests were skipped because `OPENAI_API_KEY` is not set.

## Reference

- https://developers.openai.com/api/docs/models/gpt-5.6-sol

Visual recap omitted: provider catalog and alias addition with no visual surface.
