### PR TITLE
a2a: report server-computed cost and itemized buckets in usage metadata

### DIFF
--- a/adapter/a2a/executor.go
+++ b/adapter/a2a/executor.go
@@ -28,14 +28,32 @@ import (
 
 	"github.com/redpanda-data/ai-sdk-go/agent"
 	"github.com/redpanda-data/ai-sdk-go/llm"
+	"github.com/redpanda-data/ai-sdk-go/pricing"
 	"github.com/redpanda-data/ai-sdk-go/runner"
 )
 
 // Executor implements the a2asrv.AgentExecutor interface, bridging AI SDK agents with A2A protocol.
 type Executor struct {
-	log    *slog.Logger
-	agent  agent.Agent
-	runner *runner.Runner
+	log     *slog.Logger
+	agent   agent.Agent
+	runner  *runner.Runner
+	pricing *pricing.Catalog
+}
+
+// Option configures optional Executor behavior.
+type Option func(*Executor)
+
+// WithPricing enables server-side cost reporting. Each model response's usage
+// metadata gains a "cost_microcents" entry computed against the given catalog,
+// and the final status event carries the invocation's cumulative cost.
+//
+// Pricing on the server is deliberate: the serving side knows the rate card
+// dimensions a UI client cannot see (cache-write vs cache-read rates, service
+// tier, inference region, custom per-deployment pricing). Clients should render
+// the reported cost rather than re-deriving it from token counts and a public
+// price table.
+func WithPricing(catalog *pricing.Catalog) Option {
+	return func(e *Executor) { e.pricing = catalog }
 }
 
 // NewExecutor creates a new A2A executor.
@@ -43,16 +61,22 @@ func NewExecutor(
 	agent agent.Agent,
 	runner *runner.Runner,
 	logger *slog.Logger,
+	opts ...Option,
 ) *Executor {
 	if logger == nil {
 		logger = slog.Default()
 	}
 
-	return &Executor{
+	e := &Executor{
 		log:    logger,
 		agent:  agent,
 		runner: runner,
 	}
+	for _, opt := range opts {
+		opt(e)
+	}
+
+	return e
 }
 
 // Execute implements a2asrv.AgentExecutor.
@@ -108,6 +132,45 @@ func (e *Executor) Cancel(ctx context.Context, reqCtx *a2asrv.RequestContext, qu
 	return nil
 }
 
+// usageMetadata converts token usage into the A2A metadata "usage" map.
+//
+// All counters are disjoint buckets (see llm.TokenUsage): total_tokens is the
+// billed sum of every bucket, so consumers can recover the full input side as
+// total - output - reasoning. cache_write_tokens aggregates the per-TTL
+// cache-creation counters; per-TTL granularity is a pricing concern and stays
+// server-side.
+func usageMetadata(u *llm.TokenUsage) map[string]any {
+	return map[string]any{
+		"input_tokens":       u.InputTokens,
+		"output_tokens":      u.OutputTokens,
+		"total_tokens":       u.TotalBilledTokens(),
+		"cached_tokens":      u.CachedInputTokens,
+		"reasoning_tokens":   u.ReasoningTokens,
+		"cache_write_tokens": u.CacheCreation5mTokens + u.CacheCreation1hTokens + u.CacheCreationUnknownTTLTokens,
+		"tool_use_tokens":    u.ToolUseInputTokens,
+	}
+}
+
+// priceResponse computes the microcent cost of one model call, resolving the
+// rate card from the response's own metadata (invoked model, service tier,
+// speed, region). Returns false when the model is not in the catalog; the
+// response then carries token counts without a cost rather than a guess.
+func (e *Executor) priceResponse(ctx context.Context, resp *llm.Response) (int64, bool) {
+	modelID := resp.InvokedModelID
+	if modelID == "" {
+		modelID = e.agent.Info().ModelName
+	}
+
+	cost, err := e.pricing.Calculate(modelID, resp.Usage, pricing.CalcRequest{Selector: pricing.SelectorFromResponse(resp)})
+	if err != nil {
+		e.log.DebugContext(ctx, "Skipping response cost", "model", modelID, "error", err)
+
+		return 0, false
+	}
+
+	return cost.Total, true
+}
+
 // processEvents handles the event stream from the runner and writes appropriate A2A events to the queue.
 func (e *Executor) processEvents(
 	ctx context.Context,
@@ -123,6 +186,15 @@ func (e *Executor) processEvents(
 
 	// Rolling current artifact ID for streaming text deltas
 	var currentArtifactID a2a.ArtifactID
+
+	// Cumulative cost across all model calls in this invocation. Summing
+	// per-response costs (rather than pricing the summed usage once at the
+	// end) keeps context-bracket rate resolution correct per call. The
+	// cumulative value is only reported when every response was priced, so
+	// a partially-priced invocation never understates its cost.
+	var costMicrocents int64
+
+	costComplete := e.pricing != nil
 
 	for event, err := range events {
 		if err != nil {
@@ -191,15 +263,18 @@ func (e *Executor) processEvents(
 
 			// Attach token usage to the message itself if available
 			if ev.Response.Usage != nil {
-				a2amsg.Metadata = map[string]any{
-					"usage": map[string]any{
-						"input_tokens":     ev.Response.Usage.InputTokens,
-						"output_tokens":    ev.Response.Usage.OutputTokens,
-						"total_tokens":     ev.Response.Usage.TotalBilledTokens(),
-						"cached_tokens":    ev.Response.Usage.CachedInputTokens,
-						"reasoning_tokens": ev.Response.Usage.ReasoningTokens,
-					},
+				usage := usageMetadata(ev.Response.Usage)
+
+				if e.pricing != nil {
+					if cost, ok := e.priceResponse(ctx, &ev.Response); ok {
+						usage["cost_microcents"] = cost
+						costMicrocents += cost
+					} else {
+						costComplete = false
+					}
 				}
+
+				a2amsg.Metadata = map[string]any{"usage": usage}
 			}
 
 			historyStatus := a2a.NewStatusUpdateEvent(reqCtx, a2a.TaskStateWorking, a2amsg)
@@ -275,13 +350,13 @@ func (e *Executor) processEvents(
 			}
 
 			if ev.Usage != nil {
-				metadata["usage"] = map[string]any{
-					"input_tokens":     ev.Usage.InputTokens,
-					"output_tokens":    ev.Usage.OutputTokens,
-					"total_tokens":     ev.Usage.TotalBilledTokens(),
-					"cached_tokens":    ev.Usage.CachedInputTokens,
-					"reasoning_tokens": ev.Usage.ReasoningTokens,
+				usage := usageMetadata(ev.Usage)
+
+				if e.pricing != nil && costComplete {
+					usage["cost_microcents"] = costMicrocents
 				}
+
+				metadata["usage"] = usage
 			}
 
 			statusEvent.Metadata = metadata

--- a/adapter/a2a/executor_test.go
+++ b/adapter/a2a/executor_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/redpanda-data/ai-sdk-go/agent/llmagent"
 	"github.com/redpanda-data/ai-sdk-go/llm"
 	"github.com/redpanda-data/ai-sdk-go/llm/fakellm"
+	"github.com/redpanda-data/ai-sdk-go/pricing"
 	"github.com/redpanda-data/ai-sdk-go/providers/openai"
 	"github.com/redpanda-data/ai-sdk-go/providers/openai/openaitest"
 	"github.com/redpanda-data/ai-sdk-go/runner"
@@ -1130,4 +1131,178 @@ func TestExecutor_ErrorHandling(t *testing.T) {
 	// The error message should contain details about what went wrong, not just "internal error"
 	assert.Contains(t, errorText, "context_length_exceeded", "Error message should contain API error details")
 	assert.Contains(t, errorText, "context window", "Error message should contain human-readable error explanation")
+}
+
+// runExecutorToCompletion drives one Execute call through the broadcast queue
+// pattern and returns every event written, after the final event was seen.
+func runExecutorToCompletion(t *testing.T, executor *Executor, reqCtx *a2asrv.RequestContext) []a2a.Event {
+	t.Helper()
+
+	ctx := context.Background()
+	queueMgr := eventqueue.NewInMemoryManager(eventqueue.WithQueueBufferSize(100))
+	readerQueue, err := queueMgr.GetOrCreate(ctx, reqCtx.TaskID)
+	require.NoError(t, err)
+	writerQueue, err := queueMgr.GetOrCreate(ctx, reqCtx.TaskID)
+	require.NoError(t, err)
+
+	events := []a2a.Event{}
+	eventsDone := make(chan struct{})
+	finalEventSeen := make(chan struct{})
+
+	go func() {
+		defer close(eventsDone)
+
+		for {
+			event, _, err := readerQueue.Read(ctx)
+			if err != nil {
+				return
+			}
+
+			events = append(events, event)
+
+			if statusEvent, ok := event.(*a2a.TaskStatusUpdateEvent); ok && statusEvent.Final {
+				close(finalEventSeen)
+			}
+		}
+	}()
+
+	require.NoError(t, executor.Execute(ctx, reqCtx, writerQueue))
+
+	<-finalEventSeen
+	writerQueue.Close()
+	readerQueue.Close()
+	<-eventsDone
+
+	return events
+}
+
+// usageMaps extracts the "usage" metadata from the assistant-message status
+// update and from the final status update.
+func usageMaps(t *testing.T, events []a2a.Event) (map[string]any, map[string]any) {
+	t.Helper()
+
+	var message, final map[string]any
+
+	for _, event := range events {
+		statusEvent, ok := event.(*a2a.TaskStatusUpdateEvent)
+		if !ok {
+			continue
+		}
+
+		if statusEvent.Final {
+			if u, ok := statusEvent.Metadata["usage"].(map[string]any); ok {
+				final = u
+			}
+
+			continue
+		}
+
+		if msg := statusEvent.Status.Message; msg != nil && msg.Role == a2a.MessageRoleAgent {
+			if u, ok := msg.Metadata["usage"].(map[string]any); ok {
+				message = u
+			}
+		}
+	}
+
+	require.NotNil(t, message, "assistant message status update should carry usage metadata")
+	require.NotNil(t, final, "final status update should carry usage metadata")
+
+	return message, final
+}
+
+func TestExecutor_UsageCostMetadata(t *testing.T) {
+	t.Parallel()
+
+	newExecutorWithUsage := func(t *testing.T, opts ...Option) *Executor {
+		t.Helper()
+
+		model := fakellm.NewFakeModel()
+		model.When(fakellm.Any()).ThenRespondWith(func(_ *llm.Request, _ *fakellm.CallContext) (*llm.Response, error) {
+			return &llm.Response{
+				Message:      llm.NewMessage(llm.RoleAssistant, llm.NewTextPart("done")),
+				FinishReason: llm.FinishReasonStop,
+				Usage: &llm.TokenUsage{
+					InputTokens:           1000,
+					CachedInputTokens:     2000,
+					CacheCreation5mTokens: 3000,
+					OutputTokens:          500,
+				},
+			}, nil
+		})
+
+		agentInstance, err := llmagent.New("test-agent", "You are a helpful assistant.", model)
+		require.NoError(t, err)
+
+		runnerInstance, err := runner.New(agentInstance, session.NewInMemoryStore())
+		require.NoError(t, err)
+
+		return NewExecutor(agentInstance, runnerInstance, slog.Default(), opts...)
+	}
+
+	newReqCtx := func(taskID string) *a2asrv.RequestContext {
+		return &a2asrv.RequestContext{
+			ContextID: "test-context-cost",
+			TaskID:    a2a.TaskID(taskID),
+			Message:   a2a.NewMessage(a2a.MessageRoleUser, a2a.TextPart{Text: "Do the thing."}),
+		}
+	}
+
+	t.Run("priced model reports per-response and cumulative cost", func(t *testing.T) {
+		t.Parallel()
+
+		// $3/M input, $15/M output, $0.30/M cached, $3.75/M 5m cache write.
+		catalog, err := pricing.NewCatalog(pricing.WithProvider("fake", map[string]pricing.Info{
+			"fake-model": pricing.FlatInfoFromRates(pricing.Rates{
+				InputPerMillion:           300_000_000,
+				OutputPerMillion:          1_500_000_000,
+				CachedInputPerMillion:     30_000_000,
+				CacheCreation5mPerMillion: 375_000_000,
+			}),
+		}))
+		require.NoError(t, err)
+
+		executor := newExecutorWithUsage(t, WithPricing(catalog))
+		events := runExecutorToCompletion(t, executor, newReqCtx("test-task-cost-priced"))
+		message, final := usageMaps(t, events)
+
+		// 1000*300 + 500*1500 + 2000*30 + 3000*375 microcents.
+		const wantCost = int64(2_235_000)
+
+		assert.Equal(t, wantCost, message["cost_microcents"])
+		assert.Equal(t, wantCost, final["cost_microcents"])
+
+		// The itemized buckets and the recoverable input side: total - output - reasoning.
+		assert.Equal(t, 3000, message["cache_write_tokens"])
+		assert.Equal(t, 0, message["tool_use_tokens"])
+		assert.Equal(t, 6500, message["total_tokens"])
+		assert.Equal(t, 3000, final["cache_write_tokens"])
+	})
+
+	t.Run("unknown model omits cost but keeps token counts", func(t *testing.T) {
+		t.Parallel()
+
+		catalog, err := pricing.NewCatalog(pricing.WithProvider("fake", map[string]pricing.Info{
+			"some-other-model": pricing.FlatInfo(3, 15, 0.3),
+		}))
+		require.NoError(t, err)
+
+		executor := newExecutorWithUsage(t, WithPricing(catalog))
+		events := runExecutorToCompletion(t, executor, newReqCtx("test-task-cost-unknown"))
+		message, final := usageMaps(t, events)
+
+		assert.NotContains(t, message, "cost_microcents")
+		assert.NotContains(t, final, "cost_microcents", "a partially priced invocation must not understate cumulative cost")
+		assert.Equal(t, 6500, message["total_tokens"])
+	})
+
+	t.Run("no pricing catalog emits no cost fields", func(t *testing.T) {
+		t.Parallel()
+
+		executor := newExecutorWithUsage(t)
+		events := runExecutorToCompletion(t, executor, newReqCtx("test-task-cost-disabled"))
+		message, final := usageMaps(t, events)
+
+		assert.NotContains(t, message, "cost_microcents")
+		assert.NotContains(t, final, "cost_microcents")
+	})
 }


### PR DESCRIPTION
## What

The A2A executor's usage metadata gains three fields:

- `cost_microcents` on each model response — the call's cost priced server-side against a `pricing.Catalog` (opt-in via the new `WithPricing` executor option)
- `cost_microcents` on the final status event — the invocation's cumulative cost
- `cache_write_tokens` and `tool_use_tokens` — input-side buckets the metadata previously folded into `total_tokens` only

Existing fields are unchanged; without `WithPricing` the executor behaves exactly as before, plus the two new token fields.

## Why

UI clients (the ADP agent inspector) currently re-derive dollar cost from token counts and a public price table (tokenlens). That is wrong on every axis the server can see and the client cannot: custom per-deployment rate cards, cache-write vs cache-read rates, service tier, inference region. The pricing package already models all of this — the executor just never used it. Cost belongs where the rate card lives.

The itemized buckets fix a related display gap: clients could recover the full input side as `total - output - reasoning` but could not attribute it per bucket, so cache-populating turns rendered with unexplained token mass.

## Implementation details

**Per-response pricing, summed — not summed usage, priced once.** Context-bracket rate resolution keys off the context size of each call; pricing a summed multi-turn usage against one bracket would misprice. The executor prices each `MessageEvent` via `Calculate(model, usage, CalcRequest{Selector: SelectorFromResponse(resp)})` and accumulates.

**No partial cumulative cost.** If any response in the invocation could not be priced (model not in the catalog), the final event omits `cost_microcents` entirely rather than understating. Per-response costs still appear on the responses that were priced.

**Model resolution.** `Response.InvokedModelID` when the provider reports it (post-routing snapshot normalization), falling back to the agent's configured model.

**Backward compatible.** `NewExecutor` grows a variadic `...Option`; all existing call sites compile unchanged.

## References

Follow-up from redpanda-data/cloudv2#28310 (agent inspector context-usage ring), which documented the client-side pricing and bucket-itemization gaps this closes. Consumer wiring in cloudv2 (`ai-agent` passing a catalog built from the provider `ModelPricing()` maps, UI rendering the reported cost) comes as a separate PR after this merges.