### PR TITLE
llm: per-model wire-API support in the model catalog

### DIFF
--- a/llm/types.go
+++ b/llm/types.go
@@ -345,6 +345,18 @@ type ModelCapabilities struct {
 	// defaults, so populating it is additive. It is authoritative where wire
 	// support varies per model (Bedrock).
 	WireAPIs []WireAPI
+
+	// PreferredWire is the wire a consumer should route to when the request
+	// needs a feature the model rejects on its default wire. It exists because
+	// a model can *list* a wire in WireAPIs yet refuse certain feature
+	// combinations there: gpt-5.6-sol serves both Chat Completions and
+	// Responses, but rejects function tools + a non-"none" reasoning effort on
+	// Chat Completions ("use /v1/responses"). Setting PreferredWire =
+	// WireAPIOpenAIResponses lets a router send tool/reasoning traffic to the
+	// wire that accepts it. Empty means no preference — the consumer uses its
+	// own default wire for the provider. When set, it must also appear in
+	// WireAPIs.
+	PreferredWire WireAPI
 }
 
 // ModelDiscoveryInfo provides metadata about a model that can be discovered at

--- a/llm/types.go
+++ b/llm/types.go
@@ -290,6 +290,43 @@ const (
 	FinishReasonUnknown FinishReason = "unknown"
 )
 
+// WireAPI identifies one request/response wire contract a hosted model can be
+// invoked with. The unit is the wire format, not the provider: the same
+// contract may be served by several providers (Anthropic Messages is spoken
+// by api.anthropic.com and by Bedrock InvokeModel for Claude models), and one
+// provider may serve several contracts for one model.
+//
+// This is the per-model dimension gateways route on: which APIs a model
+// answers varies by model on aggregator platforms — on Bedrock, Claude models
+// accept the Anthropic Messages body via InvokeModel while Nova/Mistral are
+// Converse-only and Gemma is served through the OpenAI-compatible mantle
+// endpoint.
+type WireAPI string
+
+const (
+	// WireAPIOpenAIChatCompletions is the OpenAI Chat Completions contract
+	// (POST …/chat/completions), including OpenAI-compatible endpoints.
+	WireAPIOpenAIChatCompletions WireAPI = "openai_chat_completions"
+
+	// WireAPIOpenAIResponses is the OpenAI Responses contract
+	// (POST …/responses), including OpenAI-compatible endpoints such as
+	// Bedrock mantle.
+	WireAPIOpenAIResponses WireAPI = "openai_responses"
+
+	// WireAPIAnthropicMessages is the Anthropic Messages contract — served
+	// natively (POST /v1/messages) and, for Claude models on Bedrock, via
+	// InvokeModel with the Messages body.
+	WireAPIAnthropicMessages WireAPI = "anthropic_messages"
+
+	// WireAPIGeminiGenerateContent is the Gemini generateContent contract
+	// (POST …/models/{model}:generateContent).
+	WireAPIGeminiGenerateContent WireAPI = "gemini_generate_content"
+
+	// WireAPIBedrockConverse is Bedrock's model-agnostic Converse contract
+	// (POST /model/{id}/converse).
+	WireAPIBedrockConverse WireAPI = "bedrock_converse"
+)
+
 // ModelCapabilities describes what features a model supports.
 // This enables compile-time and runtime validation of requests.
 type ModelCapabilities struct {
@@ -302,6 +339,12 @@ type ModelCapabilities struct {
 	MultiTurn        bool // Supports conversation history
 	SystemPrompts    bool // Supports system role messages
 	Reasoning        bool // Supports reasoning controls and exposes reasoning traces
+
+	// WireAPIs lists the wire contracts this model answers on its provider.
+	// Empty means unspecified — consumers fall back to their provider-level
+	// defaults, so populating it is additive. It is authoritative where wire
+	// support varies per model (Bedrock).
+	WireAPIs []WireAPI
 }
 
 // ModelDiscoveryInfo provides metadata about a model that can be discovered at

--- a/providers/anthropic/models.go
+++ b/providers/anthropic/models.go
@@ -96,11 +96,20 @@ func resolveModelFamily(model string) string {
 
 // supportedModels defines all Claude models with their capabilities and constraints.
 // Based on Anthropic API documentation and model specifications.
+// claudeWireAPIs is the wire set every cataloged Claude model answers on
+// api.anthropic.com: the native Messages API plus the OpenAI-compatible
+// Chat Completions endpoint (Anthropic documents the compat endpoint for
+// current models; verified by live calls against claude-fable-5,
+// claude-sonnet-5, claude-haiku-4-5, and claude-opus-4-8, July 2026).
+// Uniform today; move onto per-model entries if a model ever diverges.
+var claudeWireAPIs = []llm.WireAPI{llm.WireAPIAnthropicMessages, llm.WireAPIOpenAIChatCompletions}
+
 var supportedModels = map[string]ModelDefinition{
 	ModelClaudeFable5: {
 		Name:  ModelClaudeFable5,
 		Label: "Claude Fable 5",
 		Capabilities: llm.ModelCapabilities{
+			WireAPIs:         claudeWireAPIs,
 			Streaming:        true,
 			Tools:            true,
 			JSONMode:         false, // Anthropic doesn't have native JSON mode
@@ -131,6 +140,7 @@ var supportedModels = map[string]ModelDefinition{
 		Name:  ModelClaudeOpus48,
 		Label: "Claude Opus 4.8",
 		Capabilities: llm.ModelCapabilities{
+			WireAPIs:         claudeWireAPIs,
 			Streaming:        true,
 			Tools:            true,
 			JSONMode:         false, // Anthropic doesn't have native JSON mode
@@ -169,6 +179,7 @@ var supportedModels = map[string]ModelDefinition{
 		Name:  ModelClaudeOpus47,
 		Label: "Claude Opus 4.7",
 		Capabilities: llm.ModelCapabilities{
+			WireAPIs:         claudeWireAPIs,
 			Streaming:        true,
 			Tools:            true,
 			JSONMode:         false, // Anthropic doesn't have native JSON mode
@@ -197,6 +208,7 @@ var supportedModels = map[string]ModelDefinition{
 		Name:  ModelClaudeSonnet5,
 		Label: "Claude Sonnet 5",
 		Capabilities: llm.ModelCapabilities{
+			WireAPIs:         claudeWireAPIs,
 			Streaming:        true,
 			Tools:            true,
 			JSONMode:         false, // Anthropic doesn't have native JSON mode
@@ -230,6 +242,7 @@ var supportedModels = map[string]ModelDefinition{
 		Name:  ModelClaudeSonnet46,
 		Label: "Claude Sonnet 4.6",
 		Capabilities: llm.ModelCapabilities{
+			WireAPIs:         claudeWireAPIs,
 			Streaming:        true,
 			Tools:            true,
 			JSONMode:         false, // Anthropic doesn't have native JSON mode
@@ -256,6 +269,7 @@ var supportedModels = map[string]ModelDefinition{
 		Name:  ModelClaudeSonnet45,
 		Label: "Claude Sonnet 4.5",
 		Capabilities: llm.ModelCapabilities{
+			WireAPIs:         claudeWireAPIs,
 			Streaming:        true,
 			Tools:            true,
 			JSONMode:         false, // Anthropic doesn't have native JSON mode
@@ -280,6 +294,7 @@ var supportedModels = map[string]ModelDefinition{
 		Name:  ModelClaudeHaiku45,
 		Label: "Claude Haiku 4.5",
 		Capabilities: llm.ModelCapabilities{
+			WireAPIs:         claudeWireAPIs,
 			Streaming:        true,
 			Tools:            true,
 			JSONMode:         false, // Anthropic doesn't have native JSON mode
@@ -304,6 +319,7 @@ var supportedModels = map[string]ModelDefinition{
 		Name:  ModelClaudeOpus46,
 		Label: "Claude Opus 4.6",
 		Capabilities: llm.ModelCapabilities{
+			WireAPIs:         claudeWireAPIs,
 			Streaming:        true,
 			Tools:            true,
 			JSONMode:         false, // Anthropic doesn't have native JSON mode
@@ -337,6 +353,7 @@ var supportedModels = map[string]ModelDefinition{
 		Name:  ModelClaudeOpus41,
 		Label: "Claude Opus 4.1",
 		Capabilities: llm.ModelCapabilities{
+			WireAPIs:         claudeWireAPIs,
 			Streaming:        true,
 			Tools:            true,
 			JSONMode:         false, // Anthropic doesn't have native JSON mode
@@ -362,6 +379,7 @@ var supportedModels = map[string]ModelDefinition{
 		Name:  ModelClaudeOpus45,
 		Label: "Claude Opus 4.5",
 		Capabilities: llm.ModelCapabilities{
+			WireAPIs:         claudeWireAPIs,
 			Streaming:        true,
 			Tools:            true,
 			JSONMode:         false, // Anthropic doesn't have native JSON mode
@@ -384,4 +402,16 @@ var supportedModels = map[string]ModelDefinition{
 				WithCacheCreation(6.25, 10.00, 0),
 		),
 	},
+}
+
+// WireAPIsForModel reports which wire contracts an Anthropic-hosted model
+// answers (llm.ModelCapabilities.WireAPIs). Snapshot IDs resolve through the
+// usual family resolution. ok is false for models absent from the catalog;
+// callers decide their own fallback.
+func WireAPIsForModel(modelID string) (apis []llm.WireAPI, ok bool) {
+	def, found := supportedModels[resolveModelFamily(modelID)]
+	if !found {
+		return nil, false
+	}
+	return def.Capabilities.WireAPIs, true
 }

--- a/providers/anthropic/wireapis_test.go
+++ b/providers/anthropic/wireapis_test.go
@@ -1,0 +1,38 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package anthropic
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/redpanda-data/ai-sdk-go/llm"
+)
+
+func TestWireAPIsForModel(t *testing.T) {
+	t.Parallel()
+
+	want := []llm.WireAPI{llm.WireAPIAnthropicMessages, llm.WireAPIOpenAIChatCompletions}
+	for _, id := range []string{"claude-fable-5", "claude-sonnet-5", "claude-haiku-4-5"} {
+		got, ok := WireAPIsForModel(id)
+		if !ok || !slices.Equal(got, want) {
+			t.Fatalf("WireAPIsForModel(%q) = %v, %v; want %v, true", id, got, ok, want)
+		}
+	}
+
+	if _, ok := WireAPIsForModel("gpt-4o"); ok {
+		t.Fatal("foreign model must not resolve")
+	}
+}

--- a/providers/bedrock/models.go
+++ b/providers/bedrock/models.go
@@ -281,6 +281,41 @@ func lookupModel(modelName string) (ModelDefinition, bool) {
 	return def, ok
 }
 
+// WireAPIsForModel reports which wire contracts a Bedrock model answers
+// (llm.ModelCapabilities.WireAPIs) — the per-model dimension gateways route
+// on: Claude models accept the Anthropic Messages body via InvokeModel while
+// Nova/Mistral are Converse-only and Gemma is mantle-only.
+//
+// The model ID is matched exactly, and — because wire support is a property
+// of the model family, not the inference profile — falls back to the bare ID
+// with any geo/global profile prefix stripped, so a profile variant that is
+// not individually registered still resolves. ok is false for models absent
+// from the catalog; callers decide their own fallback (a gateway would fall
+// back to provider-level defaults).
+func WireAPIsForModel(modelID string) (apis []llm.WireAPI, ok bool) {
+	if def, found := lookupModel(modelID); found {
+		return def.Capabilities.WireAPIs, true
+	}
+	// The catalog registers profile variants (us./eu./global.…), not bare
+	// IDs. An unregistered variant (a profile AWS published after the catalog
+	// entry, or a bare ID) still resolves through any registered sibling of
+	// the same family: normalize to the bare ID, then probe each known
+	// prefix.
+	bare := modelID
+	if prefix, rest, found := strings.Cut(modelID, "."); found && geoProfilePrefixes[prefix] {
+		bare = rest
+	}
+	if def, found := lookupModel(bare); found {
+		return def.Capabilities.WireAPIs, true
+	}
+	for prefix := range geoProfilePrefixes {
+		if def, found := lookupModel(prefix + "." + bare); found {
+			return def.Capabilities.WireAPIs, true
+		}
+	}
+	return nil, false
+}
+
 // Capability and constraint shapes shared by Claude variants on Bedrock.
 // These are genuinely fixed per model generation (a Sonnet 4.5 has the same
 // context window in us-east-1 as in eu-west-1), so reusing them across
@@ -298,6 +333,10 @@ var (
 		MultiTurn:     true,
 		SystemPrompts: true,
 		Reasoning:     true,
+		// Claude on Bedrock answers both the model-agnostic Converse API and
+		// InvokeModel with the native Anthropic Messages body (the lossless
+		// same-model failover wire).
+		WireAPIs: []llm.WireAPI{llm.WireAPIBedrockConverse, llm.WireAPIAnthropicMessages},
 	}
 
 	claudeContext1MConstraints = llm.ModelConstraints{
@@ -345,6 +384,9 @@ var (
 		MultiTurn:        true,
 		SystemPrompts:    true,
 		Reasoning:        false,
+		// Nova speaks Converse only: its InvokeModel body is the Nova-native
+		// schema, not a contract in the WireAPI set.
+		WireAPIs: []llm.WireAPI{llm.WireAPIBedrockConverse},
 	}
 
 	nova2LiteConstraints = llm.ModelConstraints{
@@ -383,6 +425,8 @@ var (
 		MultiTurn:        true,
 		SystemPrompts:    true,
 		Reasoning:        false,
+		// Converse only, like Nova.
+		WireAPIs: []llm.WireAPI{llm.WireAPIBedrockConverse},
 	}
 
 	mistralLarge3Constraints = llm.ModelConstraints{
@@ -422,6 +466,11 @@ var (
 		MultiTurn:     true,
 		SystemPrompts: true,
 		Reasoning:     true,
+		// Gemma is served through the OpenAI-compatible bedrock-mantle
+		// endpoint; the SDK drives it via the Responses contract. Converse is
+		// deliberately absent. Chat Completions on mantle is unverified for
+		// Gemma — add it here once confirmed by a live call.
+		WireAPIs: []llm.WireAPI{llm.WireAPIOpenAIResponses},
 	}
 
 	gemma4Context256kConstraints = llm.ModelConstraints{

--- a/providers/bedrock/models.go
+++ b/providers/bedrock/models.go
@@ -334,8 +334,13 @@ var (
 		SystemPrompts: true,
 		Reasoning:     true,
 		// Claude on Bedrock answers both the model-agnostic Converse API and
-		// InvokeModel with the native Anthropic Messages body (the lossless
-		// same-model failover wire).
+		// the native Anthropic Messages contract — via InvokeModel for every
+		// generation, and additionally via the bedrock-mantle
+		// /anthropic/v1/messages endpoint for Opus 4.7+ / Sonnet 5 / Haiku 4.5
+		// / Fable 5 (AWS models-api-compatibility matrix, July 2026). WireAPIs
+		// records the contract, not the endpoint. No Claude model is on the
+		// OpenAI-compatible surface (Chat Completions / Responses both NO in
+		// the matrix; live probe returns model_not_found).
 		WireAPIs: []llm.WireAPI{llm.WireAPIBedrockConverse, llm.WireAPIAnthropicMessages},
 	}
 
@@ -384,8 +389,12 @@ var (
 		MultiTurn:        true,
 		SystemPrompts:    true,
 		Reasoning:        false,
-		// Nova speaks Converse only: its InvokeModel body is the Nova-native
-		// schema, not a contract in the WireAPI set.
+		// Nova answers Converse plus InvokeModel with the Nova-NATIVE schema
+		// (camelCase inferenceConfig; live probe confirms an Anthropic body is
+		// rejected) — that native schema is not a contract in the WireAPI set,
+		// so Converse is the only routable wire. Not on the OpenAI-compatible
+		// surface (models-api-compatibility: Chat Completions / Responses /
+		// Messages all NO).
 		WireAPIs: []llm.WireAPI{llm.WireAPIBedrockConverse},
 	}
 
@@ -425,8 +434,13 @@ var (
 		MultiTurn:        true,
 		SystemPrompts:    true,
 		Reasoning:        false,
-		// Converse only, like Nova.
-		WireAPIs: []llm.WireAPI{llm.WireAPIBedrockConverse},
+		// Mistral Large 3 answers Converse, InvokeModel with the
+		// Mistral-native body (not a modeled contract), AND OpenAI Chat
+		// Completions — the models-api-compatibility matrix marks Large 3
+		// Chat Completions=YES (served on bedrock-mantle and bedrock-runtime;
+		// the neighboring legacy Mistral rows are NO, so it is deliberate
+		// per-model data). Responses=NO.
+		WireAPIs: []llm.WireAPI{llm.WireAPIBedrockConverse, llm.WireAPIOpenAIChatCompletions},
 	}
 
 	mistralLarge3Constraints = llm.ModelConstraints{
@@ -466,11 +480,13 @@ var (
 		MultiTurn:     true,
 		SystemPrompts: true,
 		Reasoning:     true,
-		// Gemma is served through the OpenAI-compatible bedrock-mantle
-		// endpoint; the SDK drives it via the Responses contract. Converse is
-		// deliberately absent. Chat Completions on mantle is unverified for
-		// Gemma — add it here once confirmed by a live call.
-		WireAPIs: []llm.WireAPI{llm.WireAPIOpenAIResponses},
+		// Gemma 4 is bedrock-mantle-ONLY (Invoke/Converse/Messages all NO; no
+		// geo/global inference profiles) and answers BOTH OpenAI contracts:
+		// the gemma-4-31b model card lists Chat Completions=YES and
+		// Responses=YES, with the caveat that reasoning content is returned
+		// only via Responses — which is why the SDK drives Gemma through the
+		// Responses mapper.
+		WireAPIs: []llm.WireAPI{llm.WireAPIOpenAIChatCompletions, llm.WireAPIOpenAIResponses},
 	}
 
 	gemma4Context256kConstraints = llm.ModelConstraints{

--- a/providers/bedrock/models_test.go
+++ b/providers/bedrock/models_test.go
@@ -55,9 +55,15 @@ func TestWireAPIsForModel(t *testing.T) {
 			wantOK:  true,
 		},
 		{
-			name:    "gemma is mantle (Responses) only",
+			name:    "mistral large 3 answers Converse and OpenAI Chat Completions",
+			modelID: ModelMistralLarge3,
+			want:    []llm.WireAPI{llm.WireAPIBedrockConverse, llm.WireAPIOpenAIChatCompletions},
+			wantOK:  true,
+		},
+		{
+			name:    "gemma is mantle-only, both OpenAI contracts",
 			modelID: ModelGemma431B,
-			want:    []llm.WireAPI{llm.WireAPIOpenAIResponses},
+			want:    []llm.WireAPI{llm.WireAPIOpenAIChatCompletions, llm.WireAPIOpenAIResponses},
 			wantOK:  true,
 		},
 		{

--- a/providers/bedrock/models_test.go
+++ b/providers/bedrock/models_test.go
@@ -1,0 +1,84 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bedrock
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/redpanda-data/ai-sdk-go/llm"
+)
+
+func TestWireAPIsForModel(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		modelID string
+		want    []llm.WireAPI
+		wantOK  bool
+	}{
+		{
+			name:    "claude registered profile variant answers Converse and Anthropic Messages",
+			modelID: ModelClaudeSonnet45US,
+			want:    []llm.WireAPI{llm.WireAPIBedrockConverse, llm.WireAPIAnthropicMessages},
+			wantOK:  true,
+		},
+		{
+			name:    "bare claude ID resolves through a registered sibling variant",
+			modelID: ModelClaudeSonnet45,
+			want:    []llm.WireAPI{llm.WireAPIBedrockConverse, llm.WireAPIAnthropicMessages},
+			wantOK:  true,
+		},
+		{
+			name:    "unregistered profile variant resolves through a registered sibling",
+			modelID: "jp." + ModelClaudeHaiku45,
+			want:    []llm.WireAPI{llm.WireAPIBedrockConverse, llm.WireAPIAnthropicMessages},
+			wantOK:  true,
+		},
+		{
+			name:    "nova is Converse-only",
+			modelID: ModelNova2LiteUS,
+			want:    []llm.WireAPI{llm.WireAPIBedrockConverse},
+			wantOK:  true,
+		},
+		{
+			name:    "gemma is mantle (Responses) only",
+			modelID: ModelGemma431B,
+			want:    []llm.WireAPI{llm.WireAPIOpenAIResponses},
+			wantOK:  true,
+		},
+		{
+			name:    "unknown model is not resolved",
+			modelID: "meta.llama3-70b-instruct-v1:0",
+			wantOK:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, ok := WireAPIsForModel(tt.modelID)
+			if ok != tt.wantOK {
+				t.Fatalf("WireAPIsForModel(%q) ok = %v, want %v", tt.modelID, ok, tt.wantOK)
+			}
+
+			if !slices.Equal(got, tt.want) {
+				t.Fatalf("WireAPIsForModel(%q) = %v, want %v", tt.modelID, got, tt.want)
+			}
+		})
+	}
+}

--- a/providers/google/models.go
+++ b/providers/google/models.go
@@ -67,11 +67,20 @@ func resolveModelFamily(model string) string {
 
 // supportedModels defines all Gemini models with their capabilities and constraints.
 // Based on https://ai.google.dev/gemini-api/docs/models
+// geminiWireAPIs is the wire set every cataloged Gemini model answers on
+// generativelanguage.googleapis.com: native generateContent plus the
+// OpenAI-compatible Chat Completions endpoint (verified by live calls
+// against gemini-2.5-flash, gemini-3-flash-preview, gemini-3.5-flash, and
+// gemini-3.1-pro-preview, July 2026). Uniform today; move onto per-model
+// entries if a model ever diverges.
+var geminiWireAPIs = []llm.WireAPI{llm.WireAPIGeminiGenerateContent, llm.WireAPIOpenAIChatCompletions}
+
 var supportedModels = map[string]ModelDefinition{
 	ModelGemini35Flash: {
 		Name:  ModelGemini35Flash,
 		Label: "Gemini 3.5 Flash",
 		Capabilities: llm.ModelCapabilities{
+			WireAPIs:         geminiWireAPIs,
 			Streaming:        true,
 			Tools:            true,
 			JSONMode:         true,
@@ -94,6 +103,7 @@ var supportedModels = map[string]ModelDefinition{
 		Name:  ModelGemini31ProPreview,
 		Label: "Gemini 3.1 Pro Preview",
 		Capabilities: llm.ModelCapabilities{
+			WireAPIs:         geminiWireAPIs,
 			Streaming:        true,
 			Tools:            true,
 			JSONMode:         true,
@@ -122,6 +132,7 @@ var supportedModels = map[string]ModelDefinition{
 		Name:  ModelGemini3ProPreview,
 		Label: "Gemini 3 Pro Preview",
 		Capabilities: llm.ModelCapabilities{
+			WireAPIs:         geminiWireAPIs,
 			Streaming:        true,
 			Tools:            true,
 			JSONMode:         true,
@@ -150,6 +161,7 @@ var supportedModels = map[string]ModelDefinition{
 		Name:  ModelGemini3FlashPreview,
 		Label: "Gemini 3 Flash Preview",
 		Capabilities: llm.ModelCapabilities{
+			WireAPIs:         geminiWireAPIs,
 			Streaming:        true,
 			Tools:            true,
 			JSONMode:         true,
@@ -172,6 +184,7 @@ var supportedModels = map[string]ModelDefinition{
 		Name:  ModelGemini25Pro,
 		Label: "Gemini 2.5 Pro",
 		Capabilities: llm.ModelCapabilities{
+			WireAPIs:         geminiWireAPIs,
 			Streaming:        true,
 			Tools:            true,
 			JSONMode:         true, // Gemini supports JSON mode via response_mime_type
@@ -200,6 +213,7 @@ var supportedModels = map[string]ModelDefinition{
 		Name:  ModelGemini25Flash,
 		Label: "Gemini 2.5 Flash",
 		Capabilities: llm.ModelCapabilities{
+			WireAPIs:         geminiWireAPIs,
 			Streaming:        true,
 			Tools:            true,
 			JSONMode:         true,
@@ -222,6 +236,7 @@ var supportedModels = map[string]ModelDefinition{
 		Name:  ModelGemini25FlashLite,
 		Label: "Gemini 2.5 Flash Lite",
 		Capabilities: llm.ModelCapabilities{
+			WireAPIs:         geminiWireAPIs,
 			Streaming:        true,
 			Tools:            true,
 			JSONMode:         true,
@@ -240,4 +255,16 @@ var supportedModels = map[string]ModelDefinition{
 		},
 		Pricing: pricing.FlatInfo(0.10, 0.40, 0.01),
 	},
+}
+
+// WireAPIsForModel reports which wire contracts a Google-hosted Gemini model
+// answers (llm.ModelCapabilities.WireAPIs). Versioned IDs resolve through the
+// usual family resolution. ok is false for models absent from the catalog;
+// callers decide their own fallback.
+func WireAPIsForModel(modelID string) (apis []llm.WireAPI, ok bool) {
+	def, found := supportedModels[resolveModelFamily(modelID)]
+	if !found {
+		return nil, false
+	}
+	return def.Capabilities.WireAPIs, true
 }

--- a/providers/google/wireapis_test.go
+++ b/providers/google/wireapis_test.go
@@ -1,0 +1,38 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/redpanda-data/ai-sdk-go/llm"
+)
+
+func TestWireAPIsForModel(t *testing.T) {
+	t.Parallel()
+
+	want := []llm.WireAPI{llm.WireAPIGeminiGenerateContent, llm.WireAPIOpenAIChatCompletions}
+	for _, id := range []string{"gemini-2.5-flash", "gemini-3.5-flash"} {
+		got, ok := WireAPIsForModel(id)
+		if !ok || !slices.Equal(got, want) {
+			t.Fatalf("WireAPIsForModel(%q) = %v, %v; want %v, true", id, got, ok, want)
+		}
+	}
+
+	if _, ok := WireAPIsForModel("claude-fable-5"); ok {
+		t.Fatal("foreign model must not resolve")
+	}
+}

--- a/providers/openai/models.go
+++ b/providers/openai/models.go
@@ -75,12 +75,20 @@ func resolveModelFamily(model string) string {
 // supportedModels defines all current OpenAI models with their constraints.
 // Based on current OpenAI API documentation and model specifications.
 // When adding a new model, both capabilities and constraints must be defined here.
+// openaiWireAPIs is the wire set every cataloged OpenAI model answers:
+// Chat Completions plus Responses (verified by live calls against gpt-5.6,
+// o3, and gpt-4o on both endpoints, July 2026). Responses-only models
+// (the -pro / deep-research / computer-use lines) are not in this catalog;
+// give them per-model entries when they are added.
+var openaiWireAPIs = []llm.WireAPI{llm.WireAPIOpenAIChatCompletions, llm.WireAPIOpenAIResponses}
+
 var supportedModels = map[string]ModelDefinition{
 	// GPT-5 Series (2025 Flagship)
 	ModelGPT5: {
 		Name:  ModelGPT5,
 		Label: "OpenAI GPT-5",
 		Capabilities: llm.ModelCapabilities{
+			WireAPIs:         openaiWireAPIs,
 			Streaming:        true,
 			Tools:            true,
 			JSONMode:         true,
@@ -105,6 +113,7 @@ var supportedModels = map[string]ModelDefinition{
 		Name:  ModelGPT5Mini,
 		Label: "OpenAI GPT-5 Mini",
 		Capabilities: llm.ModelCapabilities{
+			WireAPIs:         openaiWireAPIs,
 			Streaming:        true,
 			Tools:            true,
 			JSONMode:         true,
@@ -130,6 +139,7 @@ var supportedModels = map[string]ModelDefinition{
 		Name:  ModelGPT5Nano,
 		Label: "OpenAI GPT-5 Nano",
 		Capabilities: llm.ModelCapabilities{
+			WireAPIs:         openaiWireAPIs,
 			Streaming:        true,
 			Tools:            true,
 			JSONMode:         true,
@@ -153,6 +163,7 @@ var supportedModels = map[string]ModelDefinition{
 		Name:  ModelGPT5_1,
 		Label: "OpenAI GPT-5.1",
 		Capabilities: llm.ModelCapabilities{
+			WireAPIs:         openaiWireAPIs,
 			Streaming:        true,
 			Tools:            true,
 			JSONMode:         true,
@@ -178,6 +189,7 @@ var supportedModels = map[string]ModelDefinition{
 		Name:  ModelGPT5_2,
 		Label: "OpenAI GPT-5.2 Thinking",
 		Capabilities: llm.ModelCapabilities{
+			WireAPIs:         openaiWireAPIs,
 			Streaming:        true,
 			Tools:            true,
 			JSONMode:         true,
@@ -202,6 +214,7 @@ var supportedModels = map[string]ModelDefinition{
 		Name:  ModelGPT5_2Instant,
 		Label: "OpenAI GPT-5.2 Instant",
 		Capabilities: llm.ModelCapabilities{
+			WireAPIs:         openaiWireAPIs,
 			Streaming:        true,
 			Tools:            true,
 			JSONMode:         true,
@@ -226,6 +239,7 @@ var supportedModels = map[string]ModelDefinition{
 		Name:  ModelGPT5_2Pro,
 		Label: "OpenAI GPT-5.2 Pro",
 		Capabilities: llm.ModelCapabilities{
+			WireAPIs:         openaiWireAPIs,
 			Streaming:        true,
 			Tools:            true,
 			JSONMode:         true,
@@ -252,6 +266,7 @@ var supportedModels = map[string]ModelDefinition{
 		Name:  ModelGPT5_3ChatLatest,
 		Label: "OpenAI GPT-5.3 Chat Latest",
 		Capabilities: llm.ModelCapabilities{
+			WireAPIs:         openaiWireAPIs,
 			Streaming:        true,
 			Tools:            true,
 			JSONMode:         true,
@@ -278,6 +293,7 @@ var supportedModels = map[string]ModelDefinition{
 		Name:  ModelGPT5_6Luna,
 		Label: "OpenAI GPT-5.6 Luna",
 		Capabilities: llm.ModelCapabilities{
+			WireAPIs:         openaiWireAPIs,
 			Streaming:        true,
 			Tools:            true,
 			JSONMode:         true,
@@ -309,6 +325,7 @@ var supportedModels = map[string]ModelDefinition{
 		Name:  ModelGPT5_6Terra,
 		Label: "OpenAI GPT-5.6 Terra",
 		Capabilities: llm.ModelCapabilities{
+			WireAPIs:         openaiWireAPIs,
 			Streaming:        true,
 			Tools:            true,
 			JSONMode:         true,
@@ -340,6 +357,7 @@ var supportedModels = map[string]ModelDefinition{
 		Name:  ModelGPT5_6Sol,
 		Label: "OpenAI GPT-5.6 Sol",
 		Capabilities: llm.ModelCapabilities{
+			WireAPIs:         openaiWireAPIs,
 			Streaming:        true,
 			Tools:            true,
 			JSONMode:         true,
@@ -373,6 +391,7 @@ var supportedModels = map[string]ModelDefinition{
 		Name:  ModelGPT5_5,
 		Label: "OpenAI GPT-5.5",
 		Capabilities: llm.ModelCapabilities{
+			WireAPIs:         openaiWireAPIs,
 			Streaming:        true,
 			Tools:            true,
 			JSONMode:         true,
@@ -399,6 +418,7 @@ var supportedModels = map[string]ModelDefinition{
 		Name:  ModelGPT5_4,
 		Label: "OpenAI GPT-5.4",
 		Capabilities: llm.ModelCapabilities{
+			WireAPIs:         openaiWireAPIs,
 			Streaming:        true,
 			Tools:            true,
 			JSONMode:         true,
@@ -423,6 +443,7 @@ var supportedModels = map[string]ModelDefinition{
 		Name:  ModelGPT5_4Mini,
 		Label: "OpenAI GPT-5.4 Mini",
 		Capabilities: llm.ModelCapabilities{
+			WireAPIs:         openaiWireAPIs,
 			Streaming:        true,
 			Tools:            true,
 			JSONMode:         true,
@@ -447,6 +468,7 @@ var supportedModels = map[string]ModelDefinition{
 		Name:  ModelGPT5_4Nano,
 		Label: "OpenAI GPT-5.4 Nano",
 		Capabilities: llm.ModelCapabilities{
+			WireAPIs:         openaiWireAPIs,
 			Streaming:        true,
 			Tools:            true,
 			JSONMode:         true,
@@ -472,6 +494,7 @@ var supportedModels = map[string]ModelDefinition{
 		Name:  ModelGPT41,
 		Label: "OpenAI GPT-4.1",
 		Capabilities: llm.ModelCapabilities{
+			WireAPIs:         openaiWireAPIs,
 			Streaming:        true,
 			Tools:            true,
 			JSONMode:         true,
@@ -493,6 +516,7 @@ var supportedModels = map[string]ModelDefinition{
 		Name:  ModelGPT41Mini,
 		Label: "OpenAI GPT-4.1 Mini",
 		Capabilities: llm.ModelCapabilities{
+			WireAPIs:         openaiWireAPIs,
 			Streaming:        true,
 			Tools:            true,
 			JSONMode:         true,
@@ -516,6 +540,7 @@ var supportedModels = map[string]ModelDefinition{
 		Name:  ModelO3,
 		Label: "OpenAI o3 (Reasoning)",
 		Capabilities: llm.ModelCapabilities{
+			WireAPIs:      openaiWireAPIs,
 			Streaming:     true,
 			Tools:         true,
 			Vision:        true, // Supports "thinking with images"
@@ -537,6 +562,7 @@ var supportedModels = map[string]ModelDefinition{
 		Name:  ModelO4Mini,
 		Label: "OpenAI o4-mini (Fast Reasoning)",
 		Capabilities: llm.ModelCapabilities{
+			WireAPIs:      openaiWireAPIs,
 			Streaming:     true,
 			Tools:         true,
 			Vision:        true,
@@ -560,6 +586,7 @@ var supportedModels = map[string]ModelDefinition{
 		Name:  ModelGPT4O,
 		Label: "OpenAI GPT-4o",
 		Capabilities: llm.ModelCapabilities{
+			WireAPIs:         openaiWireAPIs,
 			Streaming:        true,
 			Tools:            true,
 			JSONMode:         true,
@@ -589,6 +616,7 @@ var supportedModels = map[string]ModelDefinition{
 		Name:  ModelGPT4OMini,
 		Label: "OpenAI GPT-4o Mini",
 		Capabilities: llm.ModelCapabilities{
+			WireAPIs:         openaiWireAPIs,
 			Streaming:        true,
 			Tools:            true,
 			JSONMode:         true,
@@ -612,6 +640,7 @@ var supportedModels = map[string]ModelDefinition{
 		Name:  ModelGPT4Turbo,
 		Label: "OpenAI GPT-4 Turbo",
 		Capabilities: llm.ModelCapabilities{
+			WireAPIs:         openaiWireAPIs,
 			Streaming:        true,
 			Tools:            true,
 			JSONMode:         true,
@@ -633,6 +662,7 @@ var supportedModels = map[string]ModelDefinition{
 		Name:  ModelGPT35Turbo,
 		Label: "OpenAI GPT-3.5 Turbo",
 		Capabilities: llm.ModelCapabilities{
+			WireAPIs:         openaiWireAPIs,
 			Streaming:        true,
 			Tools:            true,
 			JSONMode:         true,
@@ -656,6 +686,7 @@ var supportedModels = map[string]ModelDefinition{
 		Name:  ModelO1Pro,
 		Label: "OpenAI o1-pro (Advanced Reasoning)",
 		Capabilities: llm.ModelCapabilities{
+			WireAPIs:      openaiWireAPIs,
 			Streaming:     true,
 			Tools:         true,
 			Vision:        true,
@@ -679,6 +710,7 @@ var supportedModels = map[string]ModelDefinition{
 		Name:  ModelO3Pro,
 		Label: "OpenAI o3-pro (Professional Reasoning)",
 		Capabilities: llm.ModelCapabilities{
+			WireAPIs:      openaiWireAPIs,
 			Streaming:     true,
 			Tools:         true,
 			Vision:        true,
@@ -696,4 +728,16 @@ var supportedModels = map[string]ModelDefinition{
 		SupportedReasoningEfforts: []ReasoningEffort{ReasoningEffortLow, ReasoningEffortMedium, ReasoningEffortHigh},
 		Pricing:                   pricing.FlatInfo(20.00, 80.00, 0),
 	},
+}
+
+// WireAPIsForModel reports which wire contracts an OpenAI model answers
+// (llm.ModelCapabilities.WireAPIs). Snapshot IDs resolve through the usual
+// family resolution. ok is false for models absent from the catalog; callers
+// decide their own fallback.
+func WireAPIsForModel(modelID string) (apis []llm.WireAPI, ok bool) {
+	def, found := supportedModels[resolveModelFamily(modelID)]
+	if !found {
+		return nil, false
+	}
+	return def.Capabilities.WireAPIs, true
 }

--- a/providers/openai/models.go
+++ b/providers/openai/models.go
@@ -294,6 +294,7 @@ var supportedModels = map[string]ModelDefinition{
 		Label: "OpenAI GPT-5.6 Luna",
 		Capabilities: llm.ModelCapabilities{
 			WireAPIs:         openaiWireAPIs,
+			PreferredWire:    llm.WireAPIOpenAIResponses, // rejects tools + non-none reasoning on Chat Completions
 			Streaming:        true,
 			Tools:            true,
 			JSONMode:         true,
@@ -326,6 +327,7 @@ var supportedModels = map[string]ModelDefinition{
 		Label: "OpenAI GPT-5.6 Terra",
 		Capabilities: llm.ModelCapabilities{
 			WireAPIs:         openaiWireAPIs,
+			PreferredWire:    llm.WireAPIOpenAIResponses, // rejects tools + non-none reasoning on Chat Completions
 			Streaming:        true,
 			Tools:            true,
 			JSONMode:         true,
@@ -358,6 +360,7 @@ var supportedModels = map[string]ModelDefinition{
 		Label: "OpenAI GPT-5.6 Sol",
 		Capabilities: llm.ModelCapabilities{
 			WireAPIs:         openaiWireAPIs,
+			PreferredWire:    llm.WireAPIOpenAIResponses, // rejects tools + non-none reasoning on Chat Completions
 			Streaming:        true,
 			Tools:            true,
 			JSONMode:         true,
@@ -740,4 +743,19 @@ func WireAPIsForModel(modelID string) (apis []llm.WireAPI, ok bool) {
 		return nil, false
 	}
 	return def.Capabilities.WireAPIs, true
+}
+
+// PreferredWireForModel reports the wire a consumer should route to when the
+// request needs a feature the model rejects on its default wire — see
+// llm.ModelCapabilities.PreferredWire. Returns ("", false) for models absent
+// from the catalog or with no preference (the common case); callers use their
+// own default wire then. The gpt-5.6 family returns WireAPIOpenAIResponses
+// because it rejects function tools + a non-"none" reasoning effort on Chat
+// Completions.
+func PreferredWireForModel(modelID string) (wire llm.WireAPI, ok bool) {
+	def, found := supportedModels[resolveModelFamily(modelID)]
+	if !found || def.Capabilities.PreferredWire == "" {
+		return "", false
+	}
+	return def.Capabilities.PreferredWire, true
 }

--- a/providers/openai/openai_test.go
+++ b/providers/openai/openai_test.go
@@ -159,6 +159,7 @@ func TestGPT56Models(t *testing.T) {
 		MultiTurn:        true,
 		SystemPrompts:    true,
 		Reasoning:        true,
+		WireAPIs:         openaiWireAPIs,
 	}
 	wantEfforts := []ReasoningEffort{
 		ReasoningEffortNone,

--- a/providers/openai/wireapis_test.go
+++ b/providers/openai/wireapis_test.go
@@ -1,0 +1,38 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package openai
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/redpanda-data/ai-sdk-go/llm"
+)
+
+func TestWireAPIsForModel(t *testing.T) {
+	t.Parallel()
+
+	want := []llm.WireAPI{llm.WireAPIOpenAIChatCompletions, llm.WireAPIOpenAIResponses}
+	for _, id := range []string{"gpt-4o", "o3-2025-04-16"} {
+		got, ok := WireAPIsForModel(id)
+		if !ok || !slices.Equal(got, want) {
+			t.Fatalf("WireAPIsForModel(%q) = %v, %v; want %v, true", id, got, ok, want)
+		}
+	}
+
+	if _, ok := WireAPIsForModel("claude-fable-5"); ok {
+		t.Fatal("foreign model must not resolve")
+	}
+}


### PR DESCRIPTION
## What

Add llm.WireAPI — the wire contract a hosted model answers — and a WireAPIs list on ModelCapabilities. Populate all four provider catalogs (Bedrock per family; Anthropic, Google, and OpenAI via shared per-provider sets) and export bedrock.WireAPIsForModel. Data verified against AWS's per-model API-compatibility matrix, the model card pages, and live bedrock-runtime probes.

## Why

Which APIs a model answers is a per-model property, not a per-provider one, and Bedrock is the proof: Claude models accept the native Anthropic Messages body via InvokeModel, Nova and Mistral are Converse-only, Mistral Large 3 additionally answers OpenAI Chat Completions, and Gemma 4 exists only on the bedrock-mantle endpoint. Anything routing traffic to these models needs that mapping. Guessing it from model-name prefixes is the kind of heuristic that breaks the day AWS ships a new family; the model catalog is already the centralized per-model database (capabilities, constraints, pricing), so the wire dimension belongs here.

## Implementation details

The unit is the wire contract, deliberately decoupled from the provider: Anthropic Messages is served by api.anthropic.com AND by Bedrock InvokeModel for Claude models, so one WireAPI value covers both. Five contracts: openai_chat_completions, openai_responses, anthropic_messages, gemini_generate_content, bedrock_converse.

Empty WireAPIs means unspecified — consumers fall back to their provider-level defaults, so the field is additive and existing catalogs keep working. Provider-native InvokeModel schemas (Nova, Mistral) are intentionally not modeled: nothing routes on them.

bedrock.WireAPIsForModel resolves exact IDs first, then falls back through registered sibling inference-profile variants (jp.anthropic.claude-haiku-... resolves via the us. entry): wire support is a family property while the catalog registers per-profile entries for pricing reasons.

Data corrections found during verification, relative to what this SDK's own usage would suggest: Gemma 4 answers BOTH OpenAI contracts, not Responses alone (reasoning content is Responses-only, which is why the SDK drives it through the Responses mapper), and Mistral Large 3 answers OpenAI Chat Completions in addition to Converse. No Claude model is on Bedrock's OpenAI-compatible surface (matrix says NO across the board; a live probe returns model_not_found).

## References

- https://docs.aws.amazon.com/bedrock/latest/userguide/models-api-compatibility.html
- https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-anthropic-claude-messages.html