### PR TITLE
anthropic: bill the >200K long-context tier on 1M-window models

### DIFF
--- a/.claude/skills/model-catalog/SKILL.md
+++ b/.claude/skills/model-catalog/SKILL.md
@@ -1,0 +1,132 @@
+---
+name: model-catalog
+description: >-
+  How to source and encode model pricing in this repo's provider catalogs
+  (providers/*/models.go) — where to pull authoritative rates, the microcents
+  convention, flat vs context-tiered pricing (TieredInfo/Bracket), Anthropic's
+  >200K long-context surcharge, cache-rate multipliers, and how to empirically
+  verify a model's real context window. Use when adding or correcting Pricing
+  on a catalog entry, or when a large-context request looks mis-costed. Pairs
+  with the model-maintenance skill and the "Adding New Models" rules in
+  CLAUDE.md.
+---
+
+# Model catalog pricing
+
+Every entry in a provider's `supportedModels` map carries a `Pricing pricing.Info`.
+Getting the numbers right — and the *shape* right (flat vs context-tiered) — is
+the point of this skill. Read the "Adding New Models" section in `CLAUDE.md` for
+the microcents rule; this skill covers where the rates come from and how to encode
+tiers.
+
+## Units: microcents per million tokens
+
+Rates are stored as `int64` microcents per million tokens.
+
+    dollars_per_million * 100_000_000 = microcents_per_million     # $2.50/M -> 250_000_000
+
+The dollar-valued constructors do this for you: `pricing.NewRates(inUSD, outUSD,
+cachedUSD)` and `.WithCacheCreation(w5mUSD, w1hUSD, unknownUSD)` take USD/M
+directly (see `pricing/rates.go`). Prefer them over hand-writing microcents, and
+keep a dollar comment on any non-obvious value.
+
+## Where to pull the rates
+
+1. **Provider's own pricing page is authoritative.** Always reconcile against it:
+   - Anthropic: https://docs.anthropic.com/en/docs/about-claude/pricing
+   - OpenAI: https://openai.com/api/pricing/
+   - Google: https://ai.google.dev/gemini-api/docs/pricing
+   - Bedrock: https://aws.amazon.com/bedrock/pricing/
+2. **LiteLLM's aggregated metadata** is the fastest cross-check and the only place
+   that spells out per-tier and per-region rates in one machine-readable file.
+   It is the source to grep for `*_above_200k_tokens`, cache-write, and regional
+   multipliers:
+
+   ```bash
+   curl -sSL -o /tmp/litellm.json \
+     https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json
+
+   # Dump the fields for one model (USD/token — multiply by 1e6 for USD/M)
+   python3 - <<'PY'
+   import json
+   d = json.load(open('/tmp/litellm.json'))
+   v = d['claude-sonnet-4-5']
+   for k, val in v.items():
+       if 'cost' in k and isinstance(val, (int, float)):
+           print(f'{k:55} {val*1_000_000:>10.4f} $/M')
+   PY
+   ```
+
+   LiteLLM values are USD **per token**; multiply by 1_000_000 for USD/M before
+   feeding the dollar constructors. LiteLLM lags new releases — if this repo's
+   catalog is ahead of it (forward-looking model names), derive from the
+   provider page + the documented multiplier structure below, and say so in a
+   comment.
+
+## Flat vs context-tiered pricing
+
+- **Flat** (rate independent of request size): `pricing.FlatInfoFromRates(base)`.
+- **Context-tiered** (rate steps up past a context-size threshold):
+  `pricing.TieredInfo(base, pricing.Bracket{MinContextTokens: N, Rates: ...})`.
+
+A `Bracket`'s `Rates` **fully replace** the base above `MinContextTokens` — they
+do not overlay — so a bracket must specify *every* rate field, not just the ones
+that change. The request's context size (`CalcRequest.ContextTokens`, falling
+back to `usage.BilledInputTokens()`) selects the bracket at cost time; the applied
+threshold is reported back as `Cost.AppliedBracketMinContextTokens`.
+
+Speed/region variants are `Info.WithOverride(selector, RateCard{...})`. An
+override `RateCard` has its **own** `Brackets` — if a model is context-tiered and
+has a fast mode, the fast override needs its own bracket too, or large fast-mode
+requests under-report.
+
+## Anthropic long-context surcharge (>200K)
+
+Anthropic bills 1M-window models at a higher rate once a request's context
+exceeds the 200K standard window. The published multiplier, confirmed across
+`claude-sonnet-4/4.5/4.6` on the provider page and LiteLLM's
+`*_above_200k_tokens` fields, is uniform:
+
+    input                2x base
+    output               1.5x base
+    cache read           2x base
+    cache write (5m/1h)  2x base
+
+Threshold is `MinContextTokens: 200_001` (matches Google's 200K and OpenAI's
+272K tiers). Apply it to **every 1M-window Anthropic model**, on both the default
+and any fast-mode override card. 200K-window models stay flat — no bracket. The
+`TestLongContextBracketsMatchSurcharge` / `TestNonLongContextModelsStayFlat`
+guards in `providers/anthropic/pricing_longcontext_test.go` enforce both
+directions, so the arithmetic is checked for you.
+
+Cache rates themselves derive from Anthropic's prompt-caching multipliers off
+base input: 5m-write 1.25x, 1h-write 2x, cache-read 0.10x. These compose with the
+long-context 2x, which is why the bracket's cache columns are exactly 2x the
+base cache columns.
+
+## Verify the real context window empirically
+
+The catalog's `MaxInputTokens` and the beta headers a provider *accepts* are not
+the same as what an account can actually use. Do not trust the number — probe it.
+Send a prompt sized just over the threshold with the raw provider SDK and observe:
+
+- A model whose window is genuinely 1M accepts a >200K request with **no** beta
+  header. On current Anthropic 1M models (Sonnet 5, Opus 4.6/4.7/4.8, Fable 5)
+  the `context-1m-2025-08-07` beta header is a **no-op** — the window is native,
+  so do not add per-request beta plumbing for it.
+- A 200K model returns HTTP 400 `prompt is too long: N tokens > 200000 maximum`,
+  and on an account without a 1M grant the beta header does **not** lift that cap.
+- Reported `Usage.InputTokens` excludes cache-write tokens (they land in
+  `CacheCreation*`). Disable caching when measuring raw prompt size, or sum
+  `BilledInputTokens()`.
+
+Roughly 4 characters per token for English text; size the probe by bytes and
+overshoot the threshold with margin, since tokenizers differ per model.
+
+## Checklist for a pricing change
+
+- [ ] Base rates match the provider page (cross-checked against LiteLLM).
+- [ ] 1M-window models are `TieredInfo` with a `200_001` bracket; 200K models are flat.
+- [ ] Every override card (fast/region) that needs a bracket has one.
+- [ ] `task test:unit` passes — `TestAllModelsHavePricing`, the long-context guards,
+      and per-provider ratio tests catch omissions and arithmetic slips.

--- a/.claude/skills/model-catalog/SKILL.md
+++ b/.claude/skills/model-catalog/SKILL.md
@@ -63,6 +63,11 @@ keep a dollar comment on any non-obvious value.
    provider page + the documented multiplier structure below, and say so in a
    comment.
 
+   License: LiteLLM is MIT (Copyright Berri AI), so referencing or even
+   vendoring the file is fine with attribution. In practice we vendor nothing —
+   we read it as a cross-check, and the rates themselves are facts, not
+   copyrightable expression.
+
 ## Flat vs context-tiered pricing
 
 - **Flat** (rate independent of request size): `pricing.FlatInfoFromRates(base)`.

--- a/.claude/skills/model-maintenance/SKILL.md
+++ b/.claude/skills/model-maintenance/SKILL.md
@@ -12,7 +12,9 @@ description: >-
 When you add a model to any provider's `supportedModels` map you **must** set
 `Pricing` (microcents per million tokens) — see the "Adding New Models" section
 in `CLAUDE.md` for the conversion and the per-provider `TestAllModelsHavePricing`
-requirement. Below is the extra process that is specific to Bedrock.
+requirement. For where to source rates, flat vs context-tiered pricing, and the
+long-context surcharge, see the `model-catalog` skill. Below is the extra process
+that is specific to Bedrock.
 
 ## Adding a new Bedrock model
 

--- a/providers/anthropic/models.go
+++ b/providers/anthropic/models.go
@@ -121,10 +121,15 @@ var supportedModels = map[string]ModelDefinition{
 		},
 		SupportedEfforts: []Effort{EffortLow, EffortMedium, EffortHigh, EffortXHigh, EffortMax},
 		AdaptiveThinking: true,
-		Pricing: pricing.FlatInfoFromRates(
+		Pricing: pricing.TieredInfo(
 			// Cache rates derived from Anthropic's prompt-caching multipliers
 			// (5m-write = 1.25x base input, 1h-write = 2x, cache-read = 0.10x).
 			pricing.NewRates(10.00, 50.00, 1.00).WithCacheCreation(12.50, 20.00, 0),
+			pricing.Bracket{
+				// Anthropic >200K long-context surcharge: input 2x, output 1.5x, cache 2x.
+				MinContextTokens: 200_001,
+				Rates:            pricing.NewRates(20.00, 75.00, 2.00).WithCacheCreation(25.00, 40.00, 0),
+			},
 		),
 	},
 	ModelClaudeOpus48: {
@@ -152,8 +157,13 @@ var supportedModels = map[string]ModelDefinition{
 		SupportedEfforts: []Effort{EffortLow, EffortMedium, EffortHigh, EffortXHigh, EffortMax},
 		SupportedSpeeds:  []Speed{SpeedStandard, SpeedFast},
 		AdaptiveThinking: true,
-		Pricing: pricing.FlatInfoFromRates(
+		Pricing: pricing.TieredInfo(
 			pricing.NewRates(5.00, 25.00, 0.50).WithCacheCreation(6.25, 10.00, 0),
+			pricing.Bracket{
+				// Anthropic >200K long-context surcharge: input 2x, output 1.5x, cache 2x.
+				MinContextTokens: 200_001,
+				Rates:            pricing.NewRates(10.00, 37.50, 1.00).WithCacheCreation(12.50, 20.00, 0),
+			},
 		).WithOverride(
 			pricing.Selector{Speed: SpeedFast},
 			pricing.RateCard{
@@ -162,6 +172,11 @@ var supportedModels = map[string]ModelDefinition{
 				// (5m-write = 1.25x base input, 1h-write = 2x, cache-read = 0.10x).
 				Base: pricing.NewRates(10.00, 50.00, 1.00).
 					WithCacheCreation(12.50, 20.00, 0),
+				Brackets: []pricing.Bracket{{
+					// >200K long-context surcharge on fast-mode rates.
+					MinContextTokens: 200_001,
+					Rates:            pricing.NewRates(20.00, 75.00, 2.00).WithCacheCreation(25.00, 40.00, 0),
+				}},
 			},
 		),
 	},
@@ -189,8 +204,13 @@ var supportedModels = map[string]ModelDefinition{
 		},
 		SupportedEfforts: []Effort{EffortLow, EffortMedium, EffortHigh, EffortXHigh, EffortMax},
 		AdaptiveThinking: true,
-		Pricing: pricing.FlatInfoFromRates(
+		Pricing: pricing.TieredInfo(
 			pricing.NewRates(5.00, 25.00, 0.50).WithCacheCreation(6.25, 10.00, 0),
+			pricing.Bracket{
+				// Anthropic >200K long-context surcharge: input 2x, output 1.5x, cache 2x.
+				MinContextTokens: 200_001,
+				Rates:            pricing.NewRates(10.00, 37.50, 1.00).WithCacheCreation(12.50, 20.00, 0),
+			},
 		),
 	},
 	ModelClaudeSonnet5: {
@@ -218,12 +238,18 @@ var supportedModels = map[string]ModelDefinition{
 		// First Sonnet-tier model with xhigh; supports the full effort range.
 		SupportedEfforts: []Effort{EffortLow, EffortMedium, EffortHigh, EffortXHigh, EffortMax},
 		AdaptiveThinking: true,
-		Pricing: pricing.FlatInfoFromRates(
+		Pricing: pricing.TieredInfo(
 			// List price $3/$15 per MTok (the introductory $2/$10 through
 			// 2026-08-31 is deliberately not tracked here). Cache rates from
 			// Anthropic's prompt-caching multipliers (5m-write 1.25x, 1h-write 2x,
 			// cache-read 0.10x of base input).
 			pricing.NewRates(3.00, 15.00, 0.30).WithCacheCreation(3.75, 6.00, 0),
+			pricing.Bracket{
+				// Anthropic >200K long-context surcharge: input 2x, output 1.5x, cache 2x.
+				// Matches Anthropic's published Sonnet 1M pricing ($6/$22.50 above 200K).
+				MinContextTokens: 200_001,
+				Rates:            pricing.NewRates(6.00, 22.50, 0.60).WithCacheCreation(7.50, 12.00, 0),
+			},
 		),
 	},
 	ModelClaudeSonnet46: {
@@ -323,13 +349,23 @@ var supportedModels = map[string]ModelDefinition{
 		SupportedEfforts: []Effort{EffortLow, EffortMedium, EffortHigh, EffortMax},
 		SupportedSpeeds:  []Speed{SpeedStandard, SpeedFast},
 		AdaptiveThinking: true,
-		Pricing: pricing.FlatInfoFromRates(
+		Pricing: pricing.TieredInfo(
 			pricing.NewRates(5.00, 25.00, 0.50).WithCacheCreation(6.25, 10.00, 0),
+			pricing.Bracket{
+				// Anthropic >200K long-context surcharge: input 2x, output 1.5x, cache 2x.
+				MinContextTokens: 200_001,
+				Rates:            pricing.NewRates(10.00, 37.50, 1.00).WithCacheCreation(12.50, 20.00, 0),
+			},
 		).WithOverride(
 			pricing.Selector{Speed: SpeedFast},
 			pricing.RateCard{
 				Base: pricing.NewRates(30.00, 150.00, 3.00).
 					WithCacheCreation(37.50, 60.00, 0),
+				Brackets: []pricing.Bracket{{
+					// >200K long-context surcharge on fast-mode rates.
+					MinContextTokens: 200_001,
+					Rates:            pricing.NewRates(60.00, 225.00, 6.00).WithCacheCreation(75.00, 120.00, 0),
+				}},
 			},
 		),
 	},

--- a/providers/anthropic/pricing_longcontext_test.go
+++ b/providers/anthropic/pricing_longcontext_test.go
@@ -1,0 +1,155 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package anthropic
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/redpanda-data/ai-sdk-go/llm"
+	"github.com/redpanda-data/ai-sdk-go/pricing"
+)
+
+// longContextThreshold is the inclusive lower bound of Anthropic's >200K
+// long-context pricing tier, mirrored from the catalog entries.
+const longContextThreshold = 200_001
+
+// TestLongContextBracketsMatchSurcharge verifies that every 1M-window model
+// prices requests above 200K tokens at Anthropic's published long-context
+// surcharge, on every rate card (default and each speed/region override):
+//
+//	input  = 2x base
+//	output = 1.5x base
+//	cache reads and writes = 2x base
+//
+// This surcharge is confirmed against Anthropic's Sonnet 1M pricing
+// ($3/$15 -> $6/$22.50 above 200K) and community catalogs (LiteLLM's
+// *_above_200k_tokens fields for claude-sonnet-4/4.5/4.6). Any 1M model that
+// under-reports large-request cost by staying on flat rates fails here.
+func TestLongContextBracketsMatchSurcharge(t *testing.T) {
+	t.Parallel()
+
+	for id, def := range supportedModels {
+		if def.Constraints.MaxInputTokens < 1_000_000 {
+			continue
+		}
+
+		t.Run(id, func(t *testing.T) {
+			t.Parallel()
+
+			cards := []struct {
+				name string
+				card pricing.RateCard
+			}{{"default", def.Pricing.Default}}
+			for _, ov := range def.Pricing.Overrides {
+				cards = append(cards, struct {
+					name string
+					card pricing.RateCard
+				}{fmt.Sprintf("%+v", ov.Match), ov.RateCard})
+			}
+
+			for _, c := range cards {
+				bracket := findBracket(c.card.Brackets, longContextThreshold)
+				require.NotNilf(t, bracket,
+					"%s card of 1M model %s has no >200K bracket — large requests under-report cost", c.name, id)
+
+				assertSurcharge(t, c.name, c.card.Base, bracket.Rates)
+			}
+		})
+	}
+}
+
+// TestNonLongContextModelsStayFlat guards the inverse: 200K models must not
+// grow a context bracket, which would silently overcharge above 200K.
+func TestNonLongContextModelsStayFlat(t *testing.T) {
+	t.Parallel()
+
+	for id, def := range supportedModels {
+		if def.Constraints.MaxInputTokens >= 1_000_000 {
+			continue
+		}
+
+		t.Run(id, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Emptyf(t, def.Pricing.Default.Brackets,
+				"200K model %s must not have context brackets", id)
+
+			for _, ov := range def.Pricing.Overrides {
+				assert.Emptyf(t, ov.RateCard.Brackets,
+					"200K model %s override %s must not have context brackets", id, fmt.Sprintf("%+v", ov.Match))
+			}
+		})
+	}
+}
+
+// TestLongContextPricingAppliesEndToEnd drives a real Catalog built from the
+// Anthropic model pricing and proves the >200K bracket actually fires: the same
+// token usage costs 2x on input when the request context crosses 200K, and the
+// applied bracket threshold is reported. This closes the loop from catalog entry
+// to computed cost.
+func TestLongContextPricingAppliesEndToEnd(t *testing.T) {
+	t.Parallel()
+
+	cat, err := pricing.NewCatalog(pricing.WithProvider("anthropic", ModelPricing()))
+	require.NoError(t, err)
+
+	usage := &llm.TokenUsage{InputTokens: 100_000, OutputTokens: 1_000}
+
+	below, err := cat.Calculate(ModelClaudeSonnet5, usage, pricing.CalcRequest{ContextTokens: 100_000})
+	require.NoError(t, err)
+
+	above, err := cat.Calculate(ModelClaudeSonnet5, usage, pricing.CalcRequest{ContextTokens: 300_000})
+	require.NoError(t, err)
+
+	assert.Equal(t, int64(0), below.AppliedBracketMinContextTokens,
+		"a sub-200K request must price on the base card")
+	assert.Equal(t, int64(longContextThreshold), above.AppliedBracketMinContextTokens,
+		"a >200K request must price on the long-context bracket")
+
+	assert.Equal(t,
+		below.Breakdown[pricing.UsageFieldInput]*2, above.Breakdown[pricing.UsageFieldInput],
+		"input above 200K must cost 2x the base rate for identical usage")
+	assert.Greater(t, above.Total, below.Total,
+		"the long-context request must cost more overall")
+}
+
+func findBracket(brackets []pricing.Bracket, minContext int64) *pricing.Bracket {
+	for i := range brackets {
+		if brackets[i].MinContextTokens == minContext {
+			return &brackets[i]
+		}
+	}
+
+	return nil
+}
+
+func assertSurcharge(t *testing.T, card string, base, got pricing.Rates) {
+	t.Helper()
+
+	assert.Equalf(t, base.InputPerMillion*2, got.InputPerMillion,
+		"%s: input above 200K must be 2x base", card)
+	assert.Equalf(t, base.OutputPerMillion*3/2, got.OutputPerMillion,
+		"%s: output above 200K must be 1.5x base", card)
+	assert.Equalf(t, base.CachedInputPerMillion*2, got.CachedInputPerMillion,
+		"%s: cache read above 200K must be 2x base", card)
+	assert.Equalf(t, base.CacheCreation5mPerMillion*2, got.CacheCreation5mPerMillion,
+		"%s: 5m cache write above 200K must be 2x base", card)
+	assert.Equalf(t, base.CacheCreation1hPerMillion*2, got.CacheCreation1hPerMillion,
+		"%s: 1h cache write above 200K must be 2x base", card)
+}

--- a/providers/anthropic/pricing_longcontext_test.go
+++ b/providers/anthropic/pricing_longcontext_test.go
@@ -52,15 +52,16 @@ func TestLongContextBracketsMatchSurcharge(t *testing.T) {
 		t.Run(id, func(t *testing.T) {
 			t.Parallel()
 
-			cards := []struct {
+			type namedCard struct {
 				name string
 				card pricing.RateCard
-			}{{"default", def.Pricing.Default}}
+			}
+
+			cards := make([]namedCard, 0, 1+len(def.Pricing.Overrides))
+			cards = append(cards, namedCard{"default", def.Pricing.Default})
+
 			for _, ov := range def.Pricing.Overrides {
-				cards = append(cards, struct {
-					name string
-					card pricing.RateCard
-				}{fmt.Sprintf("%+v", ov.Match), ov.RateCard})
+				cards = append(cards, namedCard{fmt.Sprintf("%+v", ov.Match), ov.RateCard})
 			}
 
 			for _, c := range cards {


### PR DESCRIPTION
## What

Price requests above 200K tokens at Anthropic's long-context rates on the 1M-window Anthropic models. Adds a >200K pricing bracket to Sonnet 5, Opus 4.6/4.7/4.8, and Fable 5 (default and fast-mode cards). Also adds a `model-catalog` skill documenting how pricing is sourced and encoded.

## Why

The pricing engine already models context-size split billing (`TieredInfo`/`Bracket`), and Google (200K) and OpenAI (272K) catalogs use it. Every Anthropic entry was `FlatInfoFromRates`, so a request above 200K on a 1M-window model was billed at the sub-200K flat rate. That undercounts cost on precisely the large requests a 1M window exists to serve.

This started as a task to send the `context-1m-2025-08-07` beta header. That turned out to be a dead end: on the real API the current 1M models (Sonnet 5, Opus 4.6/4.7/4.8, Fable 5) accept >200K requests with no beta header at all — the window is native, the header is a no-op. Sonnet 4.5 is 200K and the header does not lift it. So there is nothing to gate; the only real gap was pricing.

## Implementation details

The surcharge is Anthropic's published structure, uniform across `claude-sonnet-4/4.5/4.6` on the provider page and LiteLLM's `*_above_200k_tokens` fields:

```
input                2x base
output               1.5x base
cache read           2x base
cache write (5m/1h)  2x base
```

Threshold is `MinContextTokens: 200_001`, matching the Google/OpenAI tiers. Each model's default card and any fast-mode override card gets its own bracket (a bracket's `Rates` fully replace the base above the threshold, and an override card carries its own brackets). 200K models are left flat.

LiteLLM's metadata does not yet carry these forward-looking model names, so the brackets are derived from each model's base rates using that uniform multiplier rather than copied from a per-model table. `providers/anthropic/pricing_longcontext_test.go` pins the arithmetic on every card, asserts 200K models grow no bracket, and drives a real `Catalog` end to end to prove a >200K request costs 2x input. If Anthropic ever publishes a model-specific surcharge, that test is where it gets corrected.

The `model-catalog` skill captures the durable process behind this: where to pull rates, the LiteLLM fetch/grep recipe, the microcents convention, flat vs tiered pricing, the long-context surcharge, and how to empirically probe a model's real context window (including the beta-header no-op finding, so nobody repeats the dead end).

## References

- Anthropic pricing: https://docs.anthropic.com/en/docs/about-claude/pricing
- LiteLLM metadata: https://github.com/BerriAI/litellm/blob/main/model_prices_and_context_window.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)
