### PR TITLE
fix(agent): deliver truncated responses instead of failing the run

### DIFF
--- a/adapter/a2a/executor.go
+++ b/adapter/a2a/executor.go
@@ -247,9 +247,30 @@ func (e *Executor) processEvents(
 					Text: "Agent stopped: maximum iterations reached",
 				})
 			case agent.FinishReasonLength:
+				// Output truncation is non-fatal: the model produced a partial
+				// response and stopped at the output-token cap. Complete the task,
+				// deliver what we have (already streamed to history), and mark the
+				// turn truncated so the surface can offer a Continue action instead
+				// of a destructive failure card.
+				taskState = a2a.TaskStateCompleted
+				statusMsg = a2a.NewMessage(a2a.MessageRoleAgent, a2a.TextPart{
+					Text: "Response was truncated — the maximum output token limit was reached. Continue to get the rest.",
+				})
+				// The `truncated` marker is the load-bearing contract: it lives on
+				// the message metadata (where consumers read usage), NOT the event
+				// metadata. This notice is a UI affordance, not model output — a
+				// consumer that reconstructs conversation history from agent status
+				// messages MUST skip messages carrying `truncated: true`, otherwise a
+				// "Continue" would resume from a history where the assistant appears
+				// to have said "Continue to get the rest." The partial answer was
+				// already delivered as a separate Working-status MessageEvent.
+				statusMsg.Metadata = map[string]any{"truncated": true}
+			case agent.FinishReasonContextOverflow:
+				// Genuinely too long: the input exceeded the model's context window,
+				// so nothing could be generated. Terminal, but say so truthfully.
 				taskState = a2a.TaskStateFailed
 				statusMsg = a2a.NewMessage(a2a.MessageRoleAgent, a2a.TextPart{
-					Text: "Agent stopped: context length limit exceeded",
+					Text: "Agent stopped: the conversation exceeds the model's context window. Start a new conversation or shorten the input.",
 				})
 			case agent.FinishReasonError:
 				taskState = a2a.TaskStateFailed

--- a/adapter/a2a/truncation_test.go
+++ b/adapter/a2a/truncation_test.go
@@ -1,0 +1,198 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package a2a
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/a2aproject/a2a-go/a2a"
+	"github.com/a2aproject/a2a-go/a2asrv"
+	"github.com/a2aproject/a2a-go/a2asrv/eventqueue"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/redpanda-data/ai-sdk-go/agent/llmagent"
+	"github.com/redpanda-data/ai-sdk-go/llm"
+	"github.com/redpanda-data/ai-sdk-go/llm/fakellm"
+	"github.com/redpanda-data/ai-sdk-go/runner"
+	"github.com/redpanda-data/ai-sdk-go/store/session"
+)
+
+// runExecutorOnce drives the executor for a single user message against the
+// given fake model and returns every A2A event written to the queue.
+func runExecutorOnce(t *testing.T, model *fakellm.FakeModel, userText string) []a2a.Event {
+	t.Helper()
+
+	ag, err := llmagent.New("test-agent", "You are a helpful assistant.", model)
+	require.NoError(t, err)
+
+	runnerInstance, err := runner.New(ag, session.NewInMemoryStore())
+	require.NoError(t, err)
+
+	executor := NewExecutor(ag, runnerInstance, slog.Default())
+
+	reqCtx := &a2asrv.RequestContext{
+		ContextID: "test-context",
+		TaskID:    "test-task",
+		Message:   a2a.NewMessage(a2a.MessageRoleUser, a2a.TextPart{Text: userText}),
+	}
+
+	ctx := context.Background()
+	queueMgr := eventqueue.NewInMemoryManager(eventqueue.WithQueueBufferSize(100))
+	readerQueue, err := queueMgr.GetOrCreate(ctx, reqCtx.TaskID)
+	require.NoError(t, err)
+	writerQueue, err := queueMgr.GetOrCreate(ctx, reqCtx.TaskID)
+	require.NoError(t, err)
+
+	var events []a2a.Event
+
+	eventsDone := make(chan struct{})
+	finalEventSeen := make(chan struct{})
+
+	go func() {
+		defer close(eventsDone)
+
+		for {
+			event, _, readErr := readerQueue.Read(ctx)
+			if readErr != nil {
+				return
+			}
+
+			events = append(events, event)
+
+			if statusEvent, ok := event.(*a2a.TaskStatusUpdateEvent); ok && statusEvent.Final {
+				close(finalEventSeen)
+			}
+		}
+	}()
+
+	require.NoError(t, executor.Execute(ctx, reqCtx, writerQueue))
+
+	<-finalEventSeen
+	writerQueue.Close()
+	readerQueue.Close()
+	<-eventsDone
+
+	return events
+}
+
+func finalStatusEvent(t *testing.T, events []a2a.Event) *a2a.TaskStatusUpdateEvent {
+	t.Helper()
+
+	for _, event := range events {
+		if statusEvent, ok := event.(*a2a.TaskStatusUpdateEvent); ok && statusEvent.Final {
+			return statusEvent
+		}
+	}
+
+	require.FailNow(t, "no final status event found")
+
+	return nil
+}
+
+func statusText(status *a2a.TaskStatusUpdateEvent) string {
+	if status.Status.Message == nil {
+		return ""
+	}
+
+	var text strings.Builder
+
+	for _, part := range status.Status.Message.Parts {
+		if textPart, ok := part.(a2a.TextPart); ok {
+			text.WriteString(textPart.Text)
+		}
+	}
+
+	return text.String()
+}
+
+// TestExecutor_OutputTruncationIsNonFatal is the regression guard: an output
+// truncation (FinishReasonLength) must NOT fail the run. It completes the task,
+// delivers the partial content, and marks the turn truncated so the surface can
+// offer a Continue action instead of a destructive error card.
+func TestExecutor_OutputTruncationIsNonFatal(t *testing.T) {
+	t.Parallel()
+
+	const partial = "Here is the first half of the answer"
+
+	model := fakellm.NewFakeModel()
+	model.When(fakellm.Any()).
+		ThenRespondWith(func(_ *llm.Request, _ *fakellm.CallContext) (*llm.Response, error) {
+			return &llm.Response{
+				Message:      llm.NewMessage(llm.RoleAssistant, llm.NewTextPart(partial)),
+				FinishReason: llm.FinishReasonLength,
+				Usage:        &llm.TokenUsage{InputTokens: 10, OutputTokens: 16},
+			}, nil
+		})
+
+	events := runExecutorOnce(t, model, "Write a long essay.")
+
+	final := finalStatusEvent(t, events)
+	assert.Equal(t, a2a.TaskStateCompleted, final.Status.State,
+		"output truncation must complete the task, not fail it")
+
+	require.NotNil(t, final.Status.Message, "truncated completion should carry a notice message")
+	require.NotNil(t, final.Status.Message.Metadata, "truncation marker must live on the message metadata")
+	assert.Equal(t, true, final.Status.Message.Metadata["truncated"],
+		"consumer reads the truncated marker off the message metadata")
+
+	// A truncation must not carry the misleading context-length message.
+	assert.NotContains(t, statusText(final), "context length limit exceeded")
+
+	// The partial content must still have been delivered to history.
+	var delivered bool
+
+	for _, event := range events {
+		if statusEvent, ok := event.(*a2a.TaskStatusUpdateEvent); ok && statusEvent.Status.Message != nil {
+			if strings.Contains(statusText(statusEvent), partial) {
+				delivered = true
+			}
+		}
+	}
+
+	assert.True(t, delivered, "partial assistant content must be delivered")
+}
+
+// TestExecutor_ContextOverflowStaysFatalButTruthful verifies the other half of
+// the split: a genuine context-window overflow remains a terminal failure, but
+// with a truthful, actionable message rather than a misleading "context length
+// limit exceeded".
+func TestExecutor_ContextOverflowStaysFatalButTruthful(t *testing.T) {
+	t.Parallel()
+
+	model := fakellm.NewFakeModel()
+	model.When(fakellm.Any()).
+		ThenRespondWith(func(_ *llm.Request, _ *fakellm.CallContext) (*llm.Response, error) {
+			return &llm.Response{
+				Message:      llm.Message{Role: llm.RoleAssistant, Content: []llm.Part{}},
+				FinishReason: llm.FinishReasonContextOverflow,
+			}, nil
+		})
+
+	events := runExecutorOnce(t, model, "A very long conversation.")
+
+	final := finalStatusEvent(t, events)
+	assert.Equal(t, a2a.TaskStateFailed, final.Status.State,
+		"context overflow is terminal")
+
+	text := statusText(final)
+	assert.Contains(t, strings.ToLower(text), "context window",
+		"overflow message must name the real cause")
+	assert.NotContains(t, text, "context length limit exceeded",
+		"must not reuse the misleading legacy message")
+}

--- a/adapter/vercelaisdk/uimessagestream/handler.go
+++ b/adapter/vercelaisdk/uimessagestream/handler.go
@@ -984,6 +984,11 @@ func mapFinishReason(fr llm.FinishReason) string {
 		return finishReasonStop
 	case llm.FinishReasonLength:
 		return "length"
+	case llm.FinishReasonContextOverflow:
+		// The Vercel protocol has no dedicated overflow reason. Report it as
+		// "length" — the token-limit bucket — which is also the value overflow
+		// wired to before it was split out from FinishReasonLength.
+		return "length"
 	case llm.FinishReasonContentFilter:
 		return "content-filter"
 	case llm.FinishReasonToolCalls:

--- a/adapter/vercelaisdk/uimessagestream/handler_test.go
+++ b/adapter/vercelaisdk/uimessagestream/handler_test.go
@@ -477,6 +477,7 @@ func TestHandler_FinishReasonMapping(t *testing.T) {
 	}{
 		{llm.FinishReasonStop, "stop"},
 		{llm.FinishReasonLength, "length"},
+		{llm.FinishReasonContextOverflow, "length"},
 		{llm.FinishReasonContentFilter, "content-filter"},
 		{llm.FinishReasonToolCalls, "tool-calls"},
 		{llm.FinishReasonInterrupted, "other"},

--- a/agent/event.go
+++ b/agent/event.go
@@ -221,9 +221,18 @@ const (
 	// The agent hit the maximum allowed turns before completing.
 	FinishReasonMaxTurns FinishReason = "max_turns"
 
-	// FinishReasonLength indicates a context/token limit was hit.
-	// The LLM ran out of context space during generation.
+	// FinishReasonLength indicates the turn was truncated at the output-token cap.
+	// Non-fatal: the model produced a partial response and stopped. The turn can
+	// be continued. Distinct from FinishReasonContextOverflow.
 	FinishReasonLength FinishReason = "length"
+
+	// FinishReasonContextOverflow indicates generation stopped because the
+	// conversation exceeds the model's context window. Terminal: the conversation
+	// must be compacted or restarted, not continued. Distinct from
+	// FinishReasonLength (a continuable per-turn output-token cut). Any partial
+	// content produced before the limit is still delivered via the message event;
+	// this reason marks the cause, not that the turn was empty.
+	FinishReasonContextOverflow FinishReason = "context_overflow"
 
 	// FinishReasonInputRequired indicates execution paused waiting for external input.
 	// One or more tools require user input, approval, or external data before continuing.

--- a/agent/llmagent/context_overflow_test.go
+++ b/agent/llmagent/context_overflow_test.go
@@ -1,0 +1,60 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package llmagent_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/redpanda-data/ai-sdk-go/agent"
+	"github.com/redpanda-data/ai-sdk-go/agent/llmagent"
+	"github.com/redpanda-data/ai-sdk-go/llm"
+	"github.com/redpanda-data/ai-sdk-go/llm/fakellm"
+	"github.com/redpanda-data/ai-sdk-go/store/session"
+)
+
+// TestRun_ContextOverflowSurfacesDistinctly verifies that a genuine
+// context-window overflow (input too large for the model) propagates as the
+// dedicated agent.FinishReasonContextOverflow, distinct from the output
+// truncation signalled by FinishReasonLength.
+func TestRun_ContextOverflowSurfacesDistinctly(t *testing.T) {
+	t.Parallel()
+
+	model := fakellm.NewFakeModel()
+	model.When(fakellm.Any()).
+		ThenRespondWith(func(_ *llm.Request, _ *fakellm.CallContext) (*llm.Response, error) {
+			return &llm.Response{
+				Message:      llm.Message{Role: llm.RoleAssistant, Content: []llm.Part{}},
+				FinishReason: llm.FinishReasonContextOverflow,
+			}, nil
+		})
+
+	ag, err := llmagent.New("test-agent", "You are a helpful assistant", model)
+	require.NoError(t, err)
+
+	sess := &session.State{
+		ID:       "test-session",
+		Messages: []llm.Message{llm.NewMessage(llm.RoleUser, llm.NewTextPart("do the thing"))},
+	}
+	inv := agent.NewInvocationMetadata(sess, agent.Info{})
+
+	events := collectEvents(t, ag.Run(t.Context(), inv))
+
+	endEvent := findInvocationEndEvent(events)
+	require.NotNil(t, endEvent)
+	assert.Equal(t, agent.FinishReasonContextOverflow, endEvent.FinishReason)
+}

--- a/agent/llmagent/llmagent.go
+++ b/agent/llmagent/llmagent.go
@@ -766,6 +766,12 @@ func mapLLMFinishReason(reason llm.FinishReason) (agent.FinishReason, error) {
 	case llm.FinishReasonLength:
 		return agent.FinishReasonLength, nil
 
+	case llm.FinishReasonContextOverflow:
+		// Terminal but not an error condition — the executor turns this into a
+		// truthful "conversation too long" failure, distinct from output
+		// truncation (FinishReasonLength).
+		return agent.FinishReasonContextOverflow, nil
+
 	case llm.FinishReasonToolCalls:
 		// Not terminal - caller should continue to tool execution
 		return "", nil

--- a/llm/types.go
+++ b/llm/types.go
@@ -274,8 +274,19 @@ const (
 	// FinishReasonStop indicates the model completed naturally.
 	FinishReasonStop FinishReason = "stop"
 
-	// FinishReasonLength indicates the response was truncated due to length limits.
+	// FinishReasonLength indicates the response was truncated at the output-token
+	// cap. This is a non-fatal, per-turn truncation: the model produced a partial
+	// response and stopped. Distinct from FinishReasonContextOverflow.
 	FinishReasonLength FinishReason = "length"
+
+	// FinishReasonContextOverflow indicates generation stopped because the
+	// conversation exceeds the model's context window (the provider's
+	// context-window stop reason, e.g. Anthropic's model_context_window_exceeded),
+	// as opposed to FinishReasonLength which is a per-turn output-token cut.
+	// Terminal: the conversation must be shortened or restarted, not continued.
+	// Any content the model produced before the limit is still delivered on the
+	// response — this reason marks the cause, it does not imply empty content.
+	FinishReasonContextOverflow FinishReason = "context_overflow"
 
 	// FinishReasonToolCalls indicates the model wants to execute tools.
 	FinishReasonToolCalls FinishReason = "tool_calls"

--- a/plugins/otel/transform.go
+++ b/plugins/otel/transform.go
@@ -58,6 +58,11 @@ func mapFinishReason(fr llm.FinishReason) string {
 		return "stop"
 	case llm.FinishReasonLength:
 		return "length"
+	case llm.FinishReasonContextOverflow:
+		// OTel has no dedicated overflow reason; "length" is the token-limit
+		// bucket and matches the value overflow reported before it was split
+		// out from FinishReasonLength.
+		return "length"
 	case llm.FinishReasonContentFilter:
 		return "content_filter"
 	case llm.FinishReasonToolCalls:

--- a/providers/anthropic/max_tokens_integration_test.go
+++ b/providers/anthropic/max_tokens_integration_test.go
@@ -1,0 +1,102 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package anthropic_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/redpanda-data/ai-sdk-go/llm"
+	"github.com/redpanda-data/ai-sdk-go/providers/anthropic"
+	"github.com/redpanda-data/ai-sdk-go/providers/anthropic/anthropictest"
+)
+
+// TestMaxTokens_PerRequestOverride_Integration proves end to end, against the
+// real Anthropic API, that the per-request RequestOptions.MaxTokens override
+// actually reaches the provider and constrains generation — not just that it is
+// mapped onto the request struct.
+func TestMaxTokens_PerRequestOverride_Integration(t *testing.T) {
+	t.Parallel()
+
+	apiKey := anthropictest.GetAPIKeyOrSkipTest(t)
+
+	provider, err := anthropic.NewProvider(apiKey)
+	require.NoError(t, err)
+
+	// Build the model with a generous per-model budget so the ONLY thing that can
+	// cap the tiny-budget case below is the per-request override.
+	model, err := provider.NewModel(anthropictest.TestModelName, anthropic.WithMaxTokens(4096))
+	require.NoError(t, err)
+
+	longPrompt := "Write a detailed 1000-word essay about the history of computing."
+
+	t.Run("tiny per-request budget truncates the turn", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+		defer cancel()
+
+		budget := 16
+		req := &llm.Request{
+			Messages: []llm.Message{llm.NewMessage(llm.RoleUser, llm.NewTextPart(longPrompt))},
+			Options:  &anthropic.RequestOptions{MaxTokens: &budget},
+		}
+
+		resp, err := model.Generate(ctx, req)
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+
+		// The turn hit the per-request cap: truncated, not a natural stop.
+		assert.Equal(t, llm.FinishReasonLength, resp.FinishReason,
+			"a 16-token cap on a long-essay prompt must truncate")
+
+		require.NotNil(t, resp.Usage)
+		assert.LessOrEqual(t, resp.Usage.OutputTokens, 16,
+			"output tokens must not exceed the per-request cap; got %d", resp.Usage.OutputTokens)
+		assert.Positive(t, resp.Usage.OutputTokens, "the model should still produce some output")
+
+		t.Logf("tiny-cap: finish=%s output_tokens=%d", resp.FinishReason, resp.Usage.OutputTokens)
+	})
+
+	t.Run("generous per-request budget completes normally", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+		defer cancel()
+
+		budget := 1024
+		req := &llm.Request{
+			Messages: []llm.Message{llm.NewMessage(llm.RoleUser, llm.NewTextPart("Reply with exactly: hello"))},
+			Options:  &anthropic.RequestOptions{MaxTokens: &budget},
+		}
+
+		resp, err := model.Generate(ctx, req)
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+
+		assert.Equal(t, llm.FinishReasonStop, resp.FinishReason,
+			"a trivial prompt under a 1024-token cap must complete naturally")
+
+		require.NotNil(t, resp.Usage)
+		assert.Less(t, resp.Usage.OutputTokens, 1024,
+			"a one-word reply must stay well under the cap")
+
+		t.Logf("generous-cap: finish=%s output_tokens=%d", resp.FinishReason, resp.Usage.OutputTokens)
+	})
+}

--- a/providers/anthropic/max_tokens_test.go
+++ b/providers/anthropic/max_tokens_test.go
@@ -1,0 +1,105 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package anthropic
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/redpanda-data/ai-sdk-go/llm"
+)
+
+func mtTestModel(t *testing.T, opts ...Option) *Model {
+	t.Helper()
+
+	p, err := NewProvider("test-key")
+	require.NoError(t, err)
+
+	model, err := p.NewModel(ModelClaudeSonnet5, opts...)
+	require.NoError(t, err)
+
+	m, ok := model.(*Model)
+	require.True(t, ok, "NewModel must return *Model")
+
+	return m
+}
+
+func mtRequest(maxTokens *int) *llm.Request {
+	req := &llm.Request{
+		Messages: []llm.Message{llm.NewMessage(llm.RoleUser, llm.NewTextPart("hi"))},
+	}
+	if maxTokens != nil {
+		req.Options = &RequestOptions{MaxTokens: maxTokens}
+	}
+
+	return req
+}
+
+// TestMaxTokens_PerRequestOverride pins the contract the maintainers asked for:
+// the budget policy lives in the harness, so a caller must be able to set
+// max_tokens per request (without rebuilding the model) via llm.Request.Options.
+func TestMaxTokens_PerRequestOverride(t *testing.T) {
+	t.Parallel()
+
+	perReq := 8000
+
+	cases := []struct {
+		name string
+		opts []Option
+		req  *llm.Request
+		want int64
+	}{
+		{
+			name: "no override falls back to default",
+			req:  mtRequest(nil),
+			want: defaultMaxTokens,
+		},
+		{
+			name: "per-request Options overrides the fallback",
+			req:  mtRequest(&perReq),
+			want: 8000,
+		},
+		{
+			name: "per-request over MaxOutputTokens is clamped",
+			req:  mtRequest(new(999_999)),
+			want: 128_000, // ModelClaudeSonnet5 MaxOutputTokens
+		},
+		{
+			name: "WithMaxTokens sets the per-model value",
+			opts: []Option{WithMaxTokens(12_000)},
+			req:  mtRequest(nil),
+			want: 12_000,
+		},
+		{
+			name: "per-request overrides WithMaxTokens",
+			opts: []Option{WithMaxTokens(12_000)},
+			req:  mtRequest(&perReq),
+			want: 8000,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			m := mtTestModel(t, tc.opts...)
+			apiReq, err := m.requestMapper.ToProvider(tc.req)
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, apiReq.MaxTokens)
+		})
+	}
+}

--- a/providers/anthropic/options.go
+++ b/providers/anthropic/options.go
@@ -34,7 +34,7 @@ type Config struct {
 	Temperature *float64
 	TopP        *float64
 	TopK        *int
-	MaxTokens   int // Required by Anthropic API, defaults to 4096
+	MaxTokens   int // Required by Anthropic API; defaults to defaultMaxTokens
 	Stop        []string
 
 	// Extended thinking configuration

--- a/providers/anthropic/provider.go
+++ b/providers/anthropic/provider.go
@@ -167,6 +167,21 @@ func WithTimeout(timeout time.Duration) ProviderOption {
 	}
 }
 
+// defaultMaxTokens is a last-resort fallback, NOT a recommended budget.
+//
+// Anthropic requires max_tokens on every request, so the SDK must send some
+// value when neither WithMaxTokens nor a per-request override (RequestOptions)
+// is set. The budget *policy* belongs to the caller, not the SDK — so this value
+// only needs to be a safe default that works out of the box, not the "right"
+// number for any given workload.
+//
+// It is deliberately bounded rather than the model's output max: max_tokens is a
+// reservation against the context window (input + max_tokens must fit), so
+// defaulting to the model max would 400 long conversations. 16K is generous but
+// bounded: enough for long answers, small enough to stay clear of context-window
+// rejections on typical conversations.
+const defaultMaxTokens = 16384
+
 // NewModel creates a new Anthropic model instance with the specified configuration.
 func (p *Provider) NewModel(modelName string, opts ...Option) (llm.Model, error) {
 	family := resolveModelFamily(modelName)
@@ -179,7 +194,7 @@ func (p *Provider) NewModel(modelName string, opts ...Option) (llm.Model, error)
 	cfg := &Config{
 		ModelName:        modelName,
 		Constraints:      modelDef.Constraints,
-		MaxTokens:        4096, // Default required by Anthropic API
+		MaxTokens:        defaultMaxTokens, // Required by Anthropic API; see const.
 		EnableCaching:    p.EnableCaching,
 		AdaptiveThinking: modelDef.AdaptiveThinking,
 		setOptions:       make(map[string]bool),

--- a/providers/anthropic/provider_test.go
+++ b/providers/anthropic/provider_test.go
@@ -102,6 +102,26 @@ func TestWithBaseURLNormalization(t *testing.T) {
 	}
 }
 
+func TestNewModel_DefaultMaxTokens(t *testing.T) {
+	t.Parallel()
+
+	provider, err := NewProvider("test-key")
+	require.NoError(t, err)
+
+	model, err := provider.NewModel(ModelClaudeSonnet5)
+	require.NoError(t, err)
+
+	m, ok := model.(*Model)
+	require.True(t, ok, "expected *Model")
+
+	// The default output budget must be generous but bounded — large enough not to
+	// truncate ordinary agent turns, yet not the model max, which would reserve so
+	// much context window that long conversations 400 before generating.
+	assert.Equal(t, defaultMaxTokens, m.config.MaxTokens)
+	assert.Greater(t, m.config.MaxTokens, 4096,
+		"default output budget must be large enough for ordinary agent turns")
+}
+
 func TestModelsDiscoveryConstraints(t *testing.T) {
 	t.Parallel()
 

--- a/providers/anthropic/request_mapper.go
+++ b/providers/anthropic/request_mapper.go
@@ -26,6 +26,17 @@ import (
 	"github.com/redpanda-data/ai-sdk-go/llm"
 )
 
+// RequestOptions carries per-request overrides supplied through
+// llm.Request.Options. It lets a caller (typically the agent harness) vary
+// generation parameters per turn without rebuilding the model. A nil field
+// falls back to the model's configured value. Values are validated/clamped
+// against the model's constraints when applied.
+type RequestOptions struct {
+	// MaxTokens overrides the output-token budget for this single request.
+	// Clamped to the model's MaxOutputTokens; a non-positive value is ignored.
+	MaxTokens *int
+}
+
 // RequestMapper handles conversion from unified Request to Anthropic API format.
 type RequestMapper struct {
 	config       *Config
@@ -53,8 +64,16 @@ func (rm *RequestMapper) ToProvider(req *llm.Request) (anthropic.BetaMessageNewP
 		Model: anthropic.Model(modelName),
 	}
 
-	// MaxTokens is set by provider config (required by Anthropic API)
+	// MaxTokens is required by the Anthropic API. It defaults to the model's
+	// configured budget (WithMaxTokens, or the fallback default), but a caller
+	// may override it per request via llm.Request.Options so the harness owns the
+	// budget policy without rebuilding the model. Per-request values are clamped
+	// to the model's output ceiling.
 	apiReq.MaxTokens = int64(rm.config.MaxTokens)
+
+	if ro, ok := req.Options.(*RequestOptions); ok && ro != nil && ro.MaxTokens != nil && *ro.MaxTokens > 0 {
+		apiReq.MaxTokens = int64(min(*ro.MaxTokens, rm.config.Constraints.MaxOutputTokens))
+	}
 
 	// Map messages and system prompt
 	messages, systemPrompt, err := rm.mapMessages(req.Messages)

--- a/providers/anthropic/response_mapper.go
+++ b/providers/anthropic/response_mapper.go
@@ -162,7 +162,10 @@ func (m *ResponseMapper) mapStopReason(reason anthropic.BetaStopReason) llm.Fini
 		return llm.FinishReasonContentFilter
 
 	case anthropic.BetaStopReasonModelContextWindowExceeded:
-		return llm.FinishReasonLength
+		// Input overflowed the context window — a genuinely different condition
+		// from an output-token cut (max_tokens). Keep them distinct so downstream
+		// can deliver-and-continue on truncation but fail truthfully on overflow.
+		return llm.FinishReasonContextOverflow
 
 	case anthropic.BetaStopReasonPauseTurn:
 		// Paused turns are a special case - treat as incomplete

--- a/providers/anthropic/response_mapper_test.go
+++ b/providers/anthropic/response_mapper_test.go
@@ -95,10 +95,10 @@ func TestResponseMapper_FinishReasonTruncationWithToolCalls(t *testing.T) {
 			want:       llm.FinishReasonLength,
 		},
 		{
-			name:       "context_window with tool calls stays Length",
+			name:       "context_window with tool calls maps to ContextOverflow",
 			stopReason: anthropic.BetaStopReasonModelContextWindowExceeded,
 			content:    []anthropic.BetaContentBlockUnion{toolUseBlock},
-			want:       llm.FinishReasonLength,
+			want:       llm.FinishReasonContextOverflow,
 		},
 		{
 			name:       "refusal with tool calls stays ContentFilter",
@@ -111,6 +111,12 @@ func TestResponseMapper_FinishReasonTruncationWithToolCalls(t *testing.T) {
 			stopReason: anthropic.BetaStopReasonMaxTokens,
 			content:    []anthropic.BetaContentBlockUnion{textBlock},
 			want:       llm.FinishReasonLength,
+		},
+		{
+			name:       "context_window without tool calls maps to ContextOverflow",
+			stopReason: anthropic.BetaStopReasonModelContextWindowExceeded,
+			content:    []anthropic.BetaContentBlockUnion{textBlock},
+			want:       llm.FinishReasonContextOverflow,
 		},
 		{
 			name:       "end_turn without tool calls stays Stop",

--- a/providers/bedrock/finish_reason_test.go
+++ b/providers/bedrock/finish_reason_test.go
@@ -80,6 +80,18 @@ func TestResponseMapper_FinishReasonTruncationWithToolCalls(t *testing.T) {
 			want:       llm.FinishReasonLength,
 		},
 		{
+			name:       "context_window with tool calls maps to ContextOverflow",
+			stopReason: types.StopReasonModelContextWindowExceeded,
+			blocks:     []types.ContentBlock{toolUse},
+			want:       llm.FinishReasonContextOverflow,
+		},
+		{
+			name:       "context_window without tool calls maps to ContextOverflow",
+			stopReason: types.StopReasonModelContextWindowExceeded,
+			blocks:     []types.ContentBlock{text},
+			want:       llm.FinishReasonContextOverflow,
+		},
+		{
 			name:       "end_turn without tool calls stays Stop",
 			stopReason: types.StopReasonEndTurn,
 			blocks:     []types.ContentBlock{text},

--- a/providers/bedrock/response_mapper.go
+++ b/providers/bedrock/response_mapper.go
@@ -119,8 +119,14 @@ func (m *ResponseMapper) mapStopReason(reason types.StopReason) llm.FinishReason
 	case types.StopReasonToolUse:
 		return llm.FinishReasonToolCalls
 
-	case types.StopReasonMaxTokens, types.StopReasonModelContextWindowExceeded:
+	case types.StopReasonMaxTokens:
 		return llm.FinishReasonLength
+
+	case types.StopReasonModelContextWindowExceeded:
+		// Input overflowed the context window — a genuinely different condition
+		// from an output-token cut (max_tokens). Keep them distinct so downstream
+		// can deliver-and-continue on truncation but fail truthfully on overflow.
+		return llm.FinishReasonContextOverflow
 
 	case types.StopReasonContentFiltered, types.StopReasonGuardrailIntervened:
 		return llm.FinishReasonContentFilter


### PR DESCRIPTION
## What

Implements the ai-sdk-go side of RFC [`2607212300-ai-agent-output-truncation`](https://github.com/redpanda-data/cloudv2/pull/28392).

When a managed agent's turn was cut off at the model's `max_tokens` output cap, we **failed the whole run** with *"context length limit exceeded"* — both fatal (wrong) and mislabeled (it was an output-token cut, not a context problem). This PR makes output truncation non-fatal and stops conflating it with genuine context-window overflow, end to end.

## Why

Production incident on a managed agent (claude-sonnet-5): the turn ended `finish_reason: length` at ~103K tokens, far under the window. Three compounding defects, two of which live here:

1. Default output budget hardcoded to `4096` — tiny for an agent, hit routinely.
2. Executor mapped `FinishReasonLength` → `TaskStateFailed` + *"context length limit exceeded"*.
3. Response mapper collapsed `max_tokens` (output truncation) and `model_context_window_exceeded` (input overflow) into one `FinishReasonLength`.

## Changes

- **Split the finish reason end to end.** New `FinishReasonContextOverflow` on both the `llm` and `agent` enums; the provider stop reason for input overflow maps to it, while output truncation stays `FinishReasonLength`. Threaded `llm` → `agent` → executor.
- **Executor: truncation is `completed`, not `failed`** (`adapter/a2a/executor.go`). Output truncation emits `TaskStateCompleted` with a `truncated: true` marker on the **message** metadata (where the UI reads it) plus a truthful notice; the partial content is delivered. Genuine context overflow stays terminal with an accurate, actionable message. Continuation isn't offered for overflow because the input is already at the window ceiling — a new turn would immediately re-overflow.
- **Output budget: reframed 16K fallback + per-request override.** `defaultMaxTokens` (16K) is now documented as a last-resort fallback to satisfy Anthropic's required field, **not** a recommended budget — the budget *policy* belongs to the harness. Added `anthropic.RequestOptions{MaxTokens}`, read from `llm.Request.Options`, so a harness can set `max_tokens` per turn (clamped to `MaxOutputTokens`) without rebuilding the model. Precedence: per-request → `WithMaxTokens` → fallback.
- **Adapters keep the wire value stable** (`plugins/otel/transform.go`, `adapter/vercelaisdk/uimessagestream/handler.go`): explicit `FinishReasonContextOverflow` → `"length"` arms so the split doesn't silently reclassify overflow.

## Provider coverage (the finish-reason split)

The split matters only where overflow arrives as a **stop reason** rather than a 400 error:

| Provider | Output truncation | Context overflow | Status |
|---|---|---|---|
| Anthropic | `max_tokens`→Length | `model_context_window_exceeded`→ContextOverflow | ✅ fixed |
| Bedrock | `MaxTokens`→Length | `ModelContextWindowExceeded`→ContextOverflow | ✅ fixed |
| Google / OpenAI / openaicompat | truncation→Length | 400 `context_length_exceeded` → executor error path | ✅ already truthful, no change needed |

## Tests (TDD — written first, watched fail)

- `providers/anthropic` + `providers/bedrock`: `max_tokens` vs `model_context_window_exceeded` map to distinct reasons.
- `providers/anthropic`: per-request override wins / clamps to `MaxOutputTokens` / falls back; default budget > 4096.
- `providers/anthropic`: **e2e integration test** against the real Anthropic API — a 16-token per-request cap truncates a long turn to exactly 16 output tokens (overriding a per-model 4096), a generous cap completes normally.
- `agent/llmagent`: context overflow surfaces as `agent.FinishReasonContextOverflow`.
- `adapter/a2a`: output truncation → `Completed` + `truncated` marker + partial delivered; overflow → `Failed` with a truthful, non-misleading message.
- `adapter/vercelaisdk`: overflow maps to `"length"`.

`task lint:new` → 0 issues; `task license:check` clean; full `go test -short ./...` green; CI green (incl. the e2e integration test).

## Differences from the RFC

This PR is the ai-sdk-go slice only, and deviates from the RFC in a few places:

**Beyond the RFC:**
- The RFC named only the Anthropic response mapper for the split; this PR also splits **Bedrock** (it has the same stop reason and the same conflation).
- Added explicit **otel + vercelaisdk adapter** handling — the RFC didn't mention these, but the split would otherwise silently change their wire value (overflow → `"other"`/`"error"`).
- Added a **per-request `RequestOptions.MaxTokens` override**. The RFC only anticipated per-model `With*` options plus a future dynamic cap; per-maintainer review the budget policy belongs to the harness, so this is the mechanism that lets the harness own it.
- Chose to place the raised default in **ai-sdk-go** (the RFC left it "ai-sdk-go or ai-agent").

**Deferred to follow-ups / other repos (as the RFC scopes them):**
- **Dynamic per-request cap** (`min(MaxOutputTokens, window − est_input − margin)`) — RFC's preferred end state; belongs in apps/ai-agent, not the SDK.
- **apps/ai-agent**: persist the partial turn + marker, per-turn finish/stop-reason + token logging, catalog-driven generation config.
- **apps/adp-ui**: read the `truncated` marker, truncation notice + **Continue** action, error-card branching.

**Partial vs the RFC:**
- **Metadata placement**: the RFC flagged that the executor writes `finish_reason`/`usage` on the status-*event* metadata while adp-ui reads off the status-*message* metadata. This PR puts the new `truncated` signal on the **message** metadata (the part adp-ui keys on); `usage` is also already delivered on each message-event's metadata. The legacy `finish_reason`/`usage` on the terminal *event* metadata is left as-is.
- **State 2 (pre-generation `input + max_tokens > window` 400)**: surfaces through the executor's generic error path with the provider's raw error string, not a custom truthful message. The truthful-message treatment is implemented for the `model_context_window_exceeded` *stop-reason* path (`FinishReasonContextOverflow`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)