### PR TITLE
mcp: bound reconnect handshake attempts

### DIFF
--- a/tool/mcp/client.go
+++ b/tool/mcp/client.go
@@ -44,6 +44,16 @@ var (
 const (
 	reconnectInitialDelay = 200 * time.Millisecond
 	reconnectMaxDelay     = 30 * time.Second
+	// reconnectAttemptTimeout bounds one reconnect handshake (dial +
+	// initialize + notifications/initialized). Without it, an upstream
+	// that accepts the connection but never responds — a half-open
+	// connection through a load balancer, a wedged proxy — blocks the
+	// reconnect loop on that attempt forever and the client never
+	// recovers. Deadlining the attempt is safe: the go-sdk detaches the
+	// connect context from the established session's lifetime
+	// (xcontext.Detach in its streamable client), so cancelling after a
+	// successful connect does not kill the session.
+	reconnectAttemptTimeout = 30 * time.Second
 )
 
 // Client connects to an MCP server to discover and execute tools.
@@ -131,6 +141,9 @@ type clientImpl struct {
 	autoSyncInterval time.Duration
 	shutdownTimeout  time.Duration
 	toolTimeout      time.Duration
+	// reconnectTimeout bounds one reconnect handshake; defaults to
+	// reconnectAttemptTimeout (overridden only in tests).
+	reconnectTimeout time.Duration
 	logger           *slog.Logger
 	toolFilter       ToolFilterFunc
 
@@ -185,6 +198,7 @@ func NewClient(serverID string, transportFactory TransportFactory, opts ...Clien
 	c := &clientImpl{
 		serverID:         serverID,
 		transportFactory: transportFactory,
+		reconnectTimeout: reconnectAttemptTimeout,
 		logger:           slog.Default(),
 		tools:            make(map[string]*toolWrapper),
 		notifyCh:         make(chan struct{}, 1),
@@ -640,10 +654,18 @@ func (c *clientImpl) performReconnect(ctx context.Context) (*sdkmcp.ClientSessio
 		attempt++
 		c.logger.Info("attempting reconnect", "serverID", c.serverID, "attempt", attempt)
 
-		// Don't use a timeout context - the SDK retains the passed context for the
-		// connection's entire lifetime, using it for all HTTP requests including the
-		// long-lived "hanging GET" for SSE streaming. A timeout would kill the connection.
-		session, mcpClient, err := c.connect(ctx)
+		// Bound the attempt so a server that accepts the connection but
+		// never completes the handshake fails this attempt and backs off,
+		// instead of hanging the loop forever. (An earlier comment here
+		// claimed a timeout would kill the established connection because
+		// the SDK retained the connect context for the connection's
+		// lifetime — that is no longer true: the go-sdk detaches it, see
+		// reconnectAttemptTimeout.)
+		attemptCtx, cancel := context.WithTimeout(ctx, c.reconnectTimeout)
+		session, mcpClient, err := c.connect(attemptCtx)
+
+		cancel()
+
 		if err == nil {
 			return session, mcpClient, nil
 		}

--- a/tool/mcp/client_test.go
+++ b/tool/mcp/client_test.go
@@ -19,7 +19,9 @@ import (
 	"encoding/json"
 	"errors"
 	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/jsonrpc"
 	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
@@ -409,4 +411,64 @@ func TestConcurrentAccess(t *testing.T) {
 	}
 
 	wg.Wait()
+}
+
+// hangingTransport simulates an upstream that accepts the connection but
+// never completes the handshake: Connect blocks until the caller's context
+// expires — the shape of a half-open connection through a load balancer.
+type hangingTransport struct{}
+
+func (*hangingTransport) Connect(ctx context.Context) (sdkmcp.Connection, error) {
+	<-ctx.Done()
+	return nil, ctx.Err()
+}
+
+// TestPerformReconnectBoundsHungHandshake pins the per-attempt deadline on
+// the reconnect loop: an attempt whose handshake never completes must fail
+// and back off into the next attempt rather than hang the loop forever
+// (before the deadline existed, attempt 1 blocked indefinitely and the
+// client never recovered until process restart).
+func TestPerformReconnectBoundsHungHandshake(t *testing.T) {
+	t.Parallel()
+
+	var attempts atomic.Int32
+
+	factory := func() (sdkmcp.Transport, error) {
+		attempts.Add(1)
+
+		return &hangingTransport{}, nil
+	}
+
+	cl, err := NewClient("hung-server", factory)
+	require.NoError(t, err)
+
+	c, ok := cl.(*clientImpl)
+	require.True(t, ok)
+
+	c.reconnectTimeout = 50 * time.Millisecond // keep the test fast
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan struct{})
+
+	go func() {
+		_, _, _ = c.performReconnect(ctx)
+
+		close(done)
+	}()
+
+	// Multiple attempts prove the loop advances past a hung handshake.
+	require.Eventually(t, func() bool { return attempts.Load() >= 2 },
+		10*time.Second, 20*time.Millisecond,
+		"reconnect loop must time out a hung handshake and retry, not hang on attempt 1")
+
+	// And it still honors outer-context cancellation.
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("performReconnect did not return after context cancellation")
+	}
 }


### PR DESCRIPTION
## Problem

`performReconnect` (the `sessionManagerLoop` retry path) connects with the client's background context and deliberately no per-attempt deadline. Against an upstream that **accepts the connection but never completes the handshake** — a half-open connection through a load balancer, a wedged proxy — the attempt blocks forever: the backoff loop never advances and the client never recovers until process restart.

Consumers used to be shielded by whole-exchange `http.Client` timeouts on the injected client, but those break long-lived MCP shapes (the standalone SSE stream, tool calls that legitimately run minutes) and are being removed — redpanda-data/cloudv2#28448, where independent review flagged this hang three rounds in a row precisely because that shield is going away. This scenario is not hypothetical: we hit the accept-but-silent shape live during a pandabox pod rollover on integration cluster `d9grgbemrmde1d0oun80` (stale pooled connection through an NLB).

## Why the old comment no longer holds

The missing deadline was justified by:

> Don't use a timeout context - the SDK retains the passed context for the connection's entire lifetime […] A timeout would kill the connection.

That's stale: modelcontextprotocol/go-sdk (pinned here at v1.4.1) **detaches** the connect context from the session's lifetime (`xcontext.Detach` in its streamable client), so cancelling after a successful connect does not kill the session. Verified empirically — a consumer that cancels its 30s connect context immediately after `Start` had its session serve traffic for hours.

## Fix

Bound each reconnect attempt with a 30s deadline (`reconnectAttemptTimeout`, held as a `clientImpl` field so the test can shrink it). On timeout the attempt fails, backs off, and retries — the loop stays live. Note the SDK's own post-reconnect `SyncTools` already uses a 30s bounded context; this brings the connect step in line.

## Testing

`TestPerformReconnectBoundsHungHandshake`: a transport whose `Connect` blocks until context expiry. Without the deadline the loop hangs on attempt 1 (verified: test fails at its 10s window); with it, attempts advance and outer-context cancellation still exits the loop. Full `./tool/mcp` suite green; new/changed lines lint-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)