### PR TITLE
feat(providers): add Claude Opus 5 support

### DIFF
--- a/.claude/skills/model-maintenance/SKILL.md
+++ b/.claude/skills/model-maintenance/SKILL.md
@@ -18,23 +18,26 @@ that is specific to Bedrock.
 
 ## Adding a new Bedrock model
 
-Bedrock exposes each Claude model only through **cross-region inference
-profiles** (`us.`, `eu.`, `global.`, and so on), never the bare
-`anthropic.<model>` id — invoking the bare id returns a `ValidationException`
-("on-demand throughput isn't supported"), so register one entry per *published
-profile* in `providers/bedrock/models.go` and do **not** add a bare entry.
-Confirm which profiles actually exist by invoking each candidate with a one-token
-`Converse` request rather than guessing: a working profile returns output, an
-unpublished one returns `ValidationException` ("the provided model identifier is
-invalid") even from its home region, and a published-but-unsubscribed one returns
+Bedrock may expose a Claude model through a bare **in-region** ID, cross-region
+inference profiles (`us.`, `eu.`, `global.`, and so on), or both. Check the
+model card's Programmatic Access and Regional Availability tables for the exact
+IDs. Register the bare ID only when the bedrock-runtime row publishes an
+In-Region endpoint URL; a bare Model ID alone is not sufficient. Otherwise,
+invoking it returns `ValidationException` ("on-demand throughput isn't
+supported"). Do not treat a bedrock-mantle Anthropic Messages URL as
+bedrock-runtime support: this provider's mantle transport implements only the
+OpenAI-compatible Responses surface. Confirm uncertain IDs with a one-token
+`Converse` request rather than guessing: a working ID returns output, an
+unpublished one returns `ValidationException` ("the provided model identifier
+is invalid"), and a published-but-unsubscribed one returns
 `AccessDeniedException`. A newly released model is often US- and global-only at
 first, with other geos published later. Pricing is per-profile: the `global.`
-profile is the cheapest and each geo profile is exactly `1.10x` the global rate in
-every column (enforced by `TestGeoGlobalRatio`) — spell every rate out in place,
-and reuse the shared capability/constraint vars when the context window matches an
-existing generation. Add a lookup test (the new profiles present; the bare and any
-unpublished profile absent) plus a region-allow test; the integration conformance
-suite then picks the new entries up automatically through `Models()`.
+profile is the cheapest and each geo or in-region entry is exactly `1.10x` the
+global rate in every column (enforced by `TestGeoGlobalRatio`) — spell every
+rate out in place, and reuse the shared capability/constraint vars when the
+context window matches an existing generation. Add lookup tests for every
+published ID and region-allow tests; the integration conformance suite then
+picks new entries up automatically through `Models()`.
 
 Separately, a catalog entry is not invokable until the **account** has accepted
 the model's Bedrock agreement (an AWS Marketplace subscription) in **every region

--- a/providers/anthropic/alias_test.go
+++ b/providers/anthropic/alias_test.go
@@ -40,6 +40,11 @@ func TestModelResolution(t *testing.T) {
 			expectedModel: "claude-fable-5-20260604",
 		},
 		{
+			name:          "claude-opus-5 family name resolves",
+			modelKey:      ModelClaudeOpus5,
+			expectedModel: ModelClaudeOpus5,
+		},
+		{
 			name:          "claude-sonnet-5 family name resolves",
 			modelKey:      "claude-sonnet-5",
 			expectedModel: "claude-sonnet-5",
@@ -227,6 +232,14 @@ func TestWithThinkingBudget(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "thinking_budget")
 	})
+
+	t.Run("rejected on Opus 5", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := provider.NewModel(ModelClaudeOpus5, WithThinkingBudget(2048))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "thinking_budget")
+	})
 }
 
 func TestWithEffort(t *testing.T) {
@@ -297,6 +310,20 @@ func TestWithEffort(t *testing.T) {
 		}
 	})
 
+	t.Run("all effort levels accepted on Opus 5", func(t *testing.T) {
+		t.Parallel()
+
+		for _, effort := range []Effort{EffortLow, EffortMedium, EffortHigh, EffortXHigh, EffortMax} {
+			model, err := provider.NewModel(ModelClaudeOpus5, WithEffort(effort))
+			require.NoError(t, err)
+
+			m, ok := model.(*Model)
+			require.True(t, ok)
+			require.NotNil(t, m.config.Effort)
+			assert.Equal(t, effort, *m.config.Effort)
+		}
+	})
+
 	t.Run("rejected on model without effort support", func(t *testing.T) {
 		t.Parallel()
 
@@ -336,6 +363,18 @@ func TestWithSpeed(t *testing.T) {
 		assert.Equal(t, SpeedStandard, *m.config.Speed)
 	})
 
+	t.Run("fast speed on Opus 5", func(t *testing.T) {
+		t.Parallel()
+
+		model, err := provider.NewModel(ModelClaudeOpus5, WithSpeed(SpeedFast))
+		require.NoError(t, err)
+
+		m, ok := model.(*Model)
+		require.True(t, ok)
+		require.NotNil(t, m.config.Speed)
+		assert.Equal(t, SpeedFast, *m.config.Speed)
+	})
+
 	t.Run("rejected on model without speed support", func(t *testing.T) {
 		t.Parallel()
 
@@ -361,7 +400,7 @@ func TestWithSpeed(t *testing.T) {
 	})
 }
 
-func TestFable5SamplingParametersRejected(t *testing.T) {
+func TestRestrictedSamplingParametersRejected(t *testing.T) {
 	t.Parallel()
 
 	provider, err := NewProvider("test-key")
@@ -377,13 +416,19 @@ func TestFable5SamplingParametersRejected(t *testing.T) {
 		{name: "top_k", opt: WithTopK(10), want: "top_k"},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+	for _, model := range []string{ModelClaudeFable5, ModelClaudeOpus5} {
+		t.Run(model, func(t *testing.T) {
 			t.Parallel()
 
-			_, err := provider.NewModel(ModelClaudeFable5, tt.opt)
-			require.Error(t, err)
-			assert.Contains(t, err.Error(), tt.want)
+			for _, tt := range tests {
+				t.Run(tt.name, func(t *testing.T) {
+					t.Parallel()
+
+					_, err := provider.NewModel(model, tt.opt)
+					require.Error(t, err)
+					assert.Contains(t, err.Error(), tt.want)
+				})
+			}
 		})
 	}
 }

--- a/providers/anthropic/models.go
+++ b/providers/anthropic/models.go
@@ -26,6 +26,7 @@ import (
 // accepts them directly and resolves to the latest snapshot.
 const (
 	ModelClaudeFable5   = "claude-fable-5"
+	ModelClaudeOpus5    = "claude-opus-5"
 	ModelClaudeSonnet5  = "claude-sonnet-5"
 	ModelClaudeSonnet46 = "claude-sonnet-4-6"
 	ModelClaudeSonnet45 = "claude-sonnet-4-5"
@@ -111,9 +112,8 @@ var supportedModels = map[string]ModelDefinition{
 			Reasoning:        true, // Adaptive thinking only; use effort to bias toward more/less thinking
 		},
 		Constraints: llm.ModelConstraints{
-			TemperatureRange: [2]float64{0.0, 1.0},
-			MaxInputTokens:   1000000, // 1M context window
-			MaxOutputTokens:  128000,  // 128K output tokens
+			MaxInputTokens:  1000000, // 1M context window
+			MaxOutputTokens: 128000,  // 128K output tokens
 			// Fable 5 rejects thinking.type.enabled — thinking budget is not user-controllable.
 			// Use adaptive thinking + effort to bias reasoning depth. No fast mode, so no "speed".
 			SupportedParams:   []string{"max_tokens", "effort"},
@@ -129,6 +129,41 @@ var supportedModels = map[string]ModelDefinition{
 				// Anthropic >200K long-context surcharge: input 2x, output 1.5x, cache 2x.
 				MinContextTokens: 200_001,
 				Rates:            pricing.NewRates(20.00, 75.00, 2.00).WithCacheCreation(25.00, 40.00, 0),
+			},
+		),
+	},
+	ModelClaudeOpus5: {
+		Name:  ModelClaudeOpus5,
+		Label: "Claude Opus 5",
+		Capabilities: llm.ModelCapabilities{
+			Streaming:        true,
+			Tools:            true,
+			JSONMode:         false, // Anthropic doesn't have native JSON mode
+			StructuredOutput: false, // Use tool calling for structured output instead
+			Vision:           true,
+			MultiTurn:        true,
+			SystemPrompts:    true,
+			Reasoning:        true, // Thinking defaults on; use effort to bias reasoning depth
+		},
+		Constraints: llm.ModelConstraints{
+			MaxInputTokens:  1000000, // 1M context window
+			MaxOutputTokens: 128000,  // 128K output tokens
+			// Opus 5 rejects thinking.type.enabled — thinking budget is not user-controllable.
+			// Non-default sampling parameters are also rejected. Use adaptive
+			// thinking + effort to bias reasoning depth.
+			SupportedParams:   []string{"max_tokens", "effort", "speed"},
+			MutuallyExclusive: [][]string{},
+		},
+		SupportedEfforts: []Effort{EffortLow, EffortMedium, EffortHigh, EffortXHigh, EffortMax},
+		SupportedSpeeds:  []Speed{SpeedStandard, SpeedFast},
+		AdaptiveThinking: true,
+		Pricing: pricing.FlatInfoFromRates(
+			pricing.NewRates(5.00, 25.00, 0.50).WithCacheCreation(6.25, 10.00, 0),
+		).WithOverride(
+			pricing.Selector{Speed: SpeedFast},
+			pricing.RateCard{
+				Base: pricing.NewRates(10.00, 50.00, 1.00).
+					WithCacheCreation(12.50, 20.00, 0),
 			},
 		),
 	},

--- a/providers/anthropic/pricing_longcontext_test.go
+++ b/providers/anthropic/pricing_longcontext_test.go
@@ -29,23 +29,26 @@ import (
 // long-context pricing tier, mirrored from the catalog entries.
 const longContextThreshold = 200_001
 
-// TestLongContextBracketsMatchSurcharge verifies that every 1M-window model
-// prices requests above 200K tokens at Anthropic's published long-context
-// surcharge, on every rate card (default and each speed/region override):
+// TestLongContextBracketsMatchSurcharge preserves main's pre-existing
+// assertions for older catalog entries. Anthropic now documents Claude 4.6+
+// pricing as flat across the full 1M context window; Opus 5 is correct here,
+// while removal of the remaining stale brackets is tracked in #183.
 //
 //	input  = 2x base
 //	output = 1.5x base
 //	cache reads and writes = 2x base
 //
-// This surcharge is confirmed against Anthropic's Sonnet 1M pricing
-// ($3/$15 -> $6/$22.50 above 200K) and community catalogs (LiteLLM's
-// *_above_200k_tokens fields for claude-sonnet-4/4.5/4.6). Any 1M model that
-// under-reports large-request cost by staying on flat rates fails here.
+// This narrow exclusion keeps the Opus 5 feature independent from #183 while
+// still guarding the current main-branch behavior for every existing entry.
 func TestLongContextBracketsMatchSurcharge(t *testing.T) {
 	t.Parallel()
 
 	for id, def := range supportedModels {
 		if def.Constraints.MaxInputTokens < 1_000_000 {
+			continue
+		}
+
+		if id == ModelClaudeOpus5 {
 			continue
 		}
 
@@ -72,6 +75,20 @@ func TestLongContextBracketsMatchSurcharge(t *testing.T) {
 				assertSurcharge(t, c.name, c.card.Base, bracket.Rates)
 			}
 		})
+	}
+}
+
+// TestOpus5PricingStaysFlatAcrossContextWindow guards Opus 5's documented
+// exception to Anthropic's older >200K long-context surcharge.
+func TestOpus5PricingStaysFlatAcrossContextWindow(t *testing.T) {
+	t.Parallel()
+
+	def, ok := supportedModels[ModelClaudeOpus5]
+	require.True(t, ok)
+	assert.Empty(t, def.Pricing.Default.Brackets)
+
+	for _, ov := range def.Pricing.Overrides {
+		assert.Empty(t, ov.RateCard.Brackets)
 	}
 }
 

--- a/providers/anthropic/pricing_test.go
+++ b/providers/anthropic/pricing_test.go
@@ -58,6 +58,27 @@ func TestFastModeModelsHaveFastPricing(t *testing.T) {
 	}
 }
 
+func TestClaudeOpus5Pricing(t *testing.T) {
+	t.Parallel()
+
+	def, ok := supportedModels[ModelClaudeOpus5]
+	require.True(t, ok)
+
+	assert.Equal(t,
+		pricing.NewRates(5.00, 25.00, 0.50).WithCacheCreation(6.25, 10.00, 0),
+		def.Pricing.Default.Base,
+	)
+	assert.Empty(t, def.Pricing.Default.Brackets)
+
+	fast, found := findFastOverride(def.Pricing.Overrides)
+	require.True(t, found)
+	assert.Equal(t,
+		pricing.NewRates(10.00, 50.00, 1.00).WithCacheCreation(12.50, 20.00, 0),
+		fast.Base,
+	)
+	assert.Empty(t, fast.Brackets)
+}
+
 func TestModelPricingMatchesModels(t *testing.T) {
 	t.Parallel()
 

--- a/providers/bedrock/cross_region.go
+++ b/providers/bedrock/cross_region.go
@@ -16,6 +16,8 @@ package bedrock
 
 import "strings"
 
+const globalProfileRegion = "global"
+
 // IsModelAllowedFromRegion reports whether invoking modelID from awsRegion
 // crosses a Bedrock inference-profile geography boundary.
 //
@@ -31,12 +33,16 @@ import "strings"
 // route the call, so we err on the side of failing fast rather than letting
 // the request reach AWS just to be rejected there.
 //
+// Models registered with a per-family profile resolver use their published
+// availability table instead of the shared source-region mapping.
+//
 // Examples:
 //
 //	IsModelAllowedFromRegion("eu.anthropic.claude-sonnet-4-6", "us-east-1") → false
 //	IsModelAllowedFromRegion("us.anthropic.claude-sonnet-4-6", "us-east-1") → true
 //	IsModelAllowedFromRegion("us.anthropic.claude-sonnet-4-6", "ca-central-1") → true
 //	IsModelAllowedFromRegion("jp.anthropic.claude-sonnet-4-5-…", "ap-northeast-1") → true
+//	IsModelAllowedFromRegion("au.anthropic.claude-opus-5", "ap-southeast-6") → false
 //	IsModelAllowedFromRegion("global.anthropic.claude-opus-4-6-v1", "me-central-1") → true
 //	IsModelAllowedFromRegion("anthropic.claude-sonnet-4-6", "us-east-1") → true (bare)
 func IsModelAllowedFromRegion(modelID, awsRegion string) bool {
@@ -45,11 +51,68 @@ func IsModelAllowedFromRegion(modelID, awsRegion string) bool {
 	}
 
 	prefix, _, _ := strings.Cut(modelID, ".")
-	if prefix == "global" {
+	if prefix == globalProfileRegion {
 		return true
 	}
 
+	if resolver, ok := profileRegionResolverFor(modelID); ok {
+		profile, known := resolver(awsRegion)
+
+		return known && prefix == profile
+	}
+
 	return prefix == sourceRegionGeoPrefix(awsRegion)
+}
+
+// claudeOpus5ProfileRegions maps every published source region to its
+// preferred profile. Opus 5 publishes US, EU, AU, and global profiles, with
+// AU limited to Sydney and Melbourne. Other published commercial regions use
+// global.
+//
+// Source: https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-opus-5.html
+var claudeOpus5ProfileRegions = map[string]string{
+	"us-east-1":    "us",
+	"us-east-2":    "us",
+	"us-west-1":    "us",
+	"us-west-2":    "us",
+	"ca-central-1": "us",
+	"ca-west-1":    "us",
+
+	"eu-central-1": "eu",
+	"eu-central-2": "eu",
+	"eu-north-1":   "eu",
+	"eu-south-1":   "eu",
+	"eu-south-2":   "eu",
+	"eu-west-1":    "eu",
+	"eu-west-2":    "eu",
+	"eu-west-3":    "eu",
+
+	"ap-southeast-2": "au",
+	"ap-southeast-4": "au",
+
+	"ap-east-2":      globalProfileRegion,
+	"ap-northeast-1": globalProfileRegion,
+	"ap-northeast-2": globalProfileRegion,
+	"ap-northeast-3": globalProfileRegion,
+	"ap-south-1":     globalProfileRegion,
+	"ap-south-2":     globalProfileRegion,
+	"ap-southeast-1": globalProfileRegion,
+	"ap-southeast-3": globalProfileRegion,
+	"ap-southeast-5": globalProfileRegion,
+	"ap-southeast-6": globalProfileRegion,
+	"ap-southeast-7": globalProfileRegion,
+	"il-central-1":   globalProfileRegion,
+	"me-central-1":   globalProfileRegion,
+	"me-south-1":     globalProfileRegion,
+	"af-south-1":     globalProfileRegion,
+	"sa-east-1":      globalProfileRegion,
+	"mx-central-1":   globalProfileRegion,
+}
+
+func claudeOpus5ProfileRegion(awsRegion string) (string, bool) {
+	profileRegion, ok := claudeOpus5ProfileRegions[awsRegion]
+
+	return profileRegion, ok
 }
 
 // sourceRegionGeoPrefix returns the geo-inference-profile prefix that AWS

--- a/providers/bedrock/cross_region_test.go
+++ b/providers/bedrock/cross_region_test.go
@@ -16,6 +16,9 @@ package bedrock
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestIsModelAllowedFromRegion(t *testing.T) {
@@ -38,6 +41,21 @@ func TestIsModelAllowedFromRegion(t *testing.T) {
 		{"sonnet5 us from ca-central-1 (Canada is US Geo)", ModelClaudeSonnet5US, "ca-central-1", true},
 		{"sonnet5 us from eu-west-1 (cross-geo)", ModelClaudeSonnet5US, "eu-west-1", false},
 		{"sonnet5 global from me-central-1", ModelClaudeSonnet5Global, "me-central-1", true},
+
+		// Opus 5 — US, EU, AU, and global profiles are published.
+		{"opus5 us from us-east-1", ModelClaudeOpus5US, "us-east-1", true},
+		{"opus5 us from unset region", ModelClaudeOpus5US, "", false},
+		{"opus5 us from ca-central-1", ModelClaudeOpus5US, "ca-central-1", true},
+		{"opus5 us from ca-west-1", ModelClaudeOpus5US, "ca-west-1", true},
+		{"opus5 eu from eu-west-1", ModelClaudeOpus5EU, "eu-west-1", true},
+		{"opus5 au from ap-southeast-2", ModelClaudeOpus5AU, "ap-southeast-2", true},
+		{"opus5 au from ap-southeast-4", ModelClaudeOpus5AU, "ap-southeast-4", true},
+		{"opus5 au from ap-southeast-6 (New Zealand is global-only)", ModelClaudeOpus5AU, "ap-southeast-6", false},
+		{"opus5 us from eu-west-1", ModelClaudeOpus5US, "eu-west-1", false},
+		{"opus5 eu from us-east-1", ModelClaudeOpus5EU, "us-east-1", false},
+		{"opus5 global from me-central-1", ModelClaudeOpus5Global, "me-central-1", true},
+		{"opus5 global from China", ModelClaudeOpus5Global, "cn-north-1", true},
+		{"opus5 global from future region", ModelClaudeOpus5Global, "future-north-1", true},
 
 		// global.* is always allowed.
 		{"global from us", ModelClaudeSonnet46Global, "us-east-1", true},
@@ -117,6 +135,64 @@ func TestIsModelAllowedFromRegion(t *testing.T) {
 					tc.modelID, tc.region, got, tc.want)
 			}
 		})
+	}
+}
+
+func TestClaudeOpus5ProfileRegion_UnknownRegions(t *testing.T) {
+	t.Parallel()
+
+	for _, region := range []string{"us-gov-west-1", "cn-north-1", "ap-southeast-8", "unknown"} {
+		t.Run(region, func(t *testing.T) {
+			t.Parallel()
+
+			got, known := claudeOpus5ProfileRegion(region)
+			assert.False(t, known)
+			assert.Empty(t, got)
+		})
+	}
+}
+
+func TestProfileRegionResolverLookup(t *testing.T) {
+	t.Parallel()
+
+	for _, modelID := range []string{
+		ModelClaudeOpus5,
+		ModelClaudeOpus5Global,
+		ModelClaudeOpus5US,
+		ModelClaudeOpus5EU,
+		ModelClaudeOpus5AU,
+	} {
+		t.Run(modelID, func(t *testing.T) {
+			t.Parallel()
+
+			resolver, ok := profileRegionResolverFor(modelID)
+			require.True(t, ok)
+
+			profile, known := resolver("ca-west-1")
+			assert.True(t, known)
+			assert.Equal(t, "us", profile)
+		})
+	}
+
+	_, ok := profileRegionResolverFor(ModelClaudeSonnet5)
+	assert.False(t, ok)
+}
+
+func TestProfileRegionResolversReturnCatalogedProfiles(t *testing.T) {
+	t.Parallel()
+
+	for bareID, resolver := range profileRegionResolvers {
+		regions, ok := profileRegionResolverRegions[bareID]
+		require.Truef(t, ok, "resolver family %s has no source-region table", bareID)
+
+		for region, want := range regions {
+			got, known := resolver(region)
+			require.Truef(t, known, "resolver family %s does not recognize region %s", bareID, region)
+			require.Equalf(t, want, got, "resolver family %s routed region %s incorrectly", bareID, region)
+
+			_, cataloged := supportedModels[got+"."+bareID]
+			assert.Truef(t, cataloged, "resolver family %s returns uncataloged profile %s", bareID, got)
+		}
 	}
 }
 

--- a/providers/bedrock/models.go
+++ b/providers/bedrock/models.go
@@ -35,13 +35,12 @@ import (
 //     and the two side-by-side Anthropic tables on
 //     https://aws.amazon.com/bedrock/pricing/.
 //
-// This catalog registers inference-profile variants instead of bare Claude
-// IDs so each entry carries the correct routing and pricing metadata. For
-// earlier 4.5+ models, invoking the bare ID via bedrock-runtime returned
-// ValidationException "Invocation of model ID … with on-demand throughput
-// isn't supported" in empirical checks (2026-04); the bare consts below exist
-// only as building blocks for the prefixed variants and are NOT registered in
-// supportedModels.
+// This catalog registers every published inference-profile variant and any
+// bare ID that Bedrock documents as in-region invokable. For earlier 4.5+
+// models, invoking the bare ID via bedrock-runtime returned ValidationException
+// "Invocation of model ID … with on-demand throughput isn't supported" in
+// empirical checks (2026-04); those bare consts remain building blocks for the
+// prefixed variants and are not registered in supportedModels.
 const (
 	// ModelClaudeFable5 is the bare Bedrock ID for Claude Fable 5
 	// (inference-profile-only — invoke via one of the prefixed variants).
@@ -84,6 +83,17 @@ const (
 	ModelClaudeHaiku45US     = "us." + ModelClaudeHaiku45
 	ModelClaudeHaiku45EU     = "eu." + ModelClaudeHaiku45
 	ModelClaudeHaiku45AU     = "au." + ModelClaudeHaiku45
+
+	// ModelClaudeOpus5 is the bare building block for Claude Opus 5 profile IDs.
+	// bedrock-runtime publishes only global, US, EU, and AU profiles. The bare
+	// ID is invokable through bedrock-mantle's Anthropic Messages surface, but
+	// this provider's mantle transport implements only the OpenAI-compatible
+	// Responses surface.
+	ModelClaudeOpus5       = "anthropic.claude-opus-5"
+	ModelClaudeOpus5Global = "global." + ModelClaudeOpus5
+	ModelClaudeOpus5US     = "us." + ModelClaudeOpus5
+	ModelClaudeOpus5EU     = "eu." + ModelClaudeOpus5
+	ModelClaudeOpus5AU     = "au." + ModelClaudeOpus5
 
 	// ModelClaudeOpus48 is the bare Bedrock ID for Claude Opus 4.8
 	// (inference-profile-only — invoke via one of the prefixed variants).
@@ -254,6 +264,19 @@ var geoProfilePrefixes = map[string]bool{
 	"global": true,
 }
 
+// profileRegionResolvers opts model families into exact, model-specific geo
+// routing. Families absent from this map retain the catalog's historical
+// generic routing behavior.
+var profileRegionResolvers = map[string]func(string) (string, bool){
+	ModelClaudeOpus5: claudeOpus5ProfileRegion,
+}
+
+// profileRegionResolverRegions exposes each resolver's complete source-region
+// domain so catalog invariants can verify every returned profile is registered.
+var profileRegionResolverRegions = map[string]map[string]string{
+	ModelClaudeOpus5: claudeOpus5ProfileRegions,
+}
+
 // hasRegionPrefix reports whether a model ID already begins with a Bedrock
 // region/global inference-profile prefix (e.g. "us.anthropic.claude-sonnet-4-6"
 // or "global.anthropic.claude-opus-4-6-v1").
@@ -271,6 +294,17 @@ func hasRegionPrefix(modelID string) bool {
 	}
 
 	return geoProfilePrefixes[prefix]
+}
+
+func profileRegionResolverFor(modelID string) (func(string) (string, bool), bool) {
+	prefix, family, ok := strings.Cut(modelID, ".")
+	if ok && geoProfilePrefixes[prefix] {
+		modelID = family
+	}
+
+	resolver, ok := profileRegionResolvers[modelID]
+
+	return resolver, ok
 }
 
 // lookupModel finds a ModelDefinition by exact model ID. Each inference
@@ -307,11 +341,10 @@ var (
 		SupportedParams:  []string{"temperature", "top_p", "max_tokens", "stop"},
 	}
 
-	claudeFable5Constraints = llm.ModelConstraints{
-		TemperatureRange: [2]float64{0.0, 1.0},
-		MaxInputTokens:   1000000,
-		MaxOutputTokens:  128000,
-		SupportedParams:  []string{"max_tokens", "stop"},
+	claudeNoSampling1MConstraints = llm.ModelConstraints{
+		MaxInputTokens:  1000000,
+		MaxOutputTokens: 128000,
+		SupportedParams: []string{"max_tokens", "stop"},
 	}
 
 	claudeContext200kConstraints = llm.ModelConstraints{
@@ -459,7 +492,7 @@ var supportedModels = map[string]ModelDefinition{
 		Name:                        ModelClaudeFable5Global,
 		Label:                       "Claude Fable 5 (Global)",
 		Capabilities:                claudeStandardCaps,
-		Constraints:                 claudeFable5Constraints,
+		Constraints:                 claudeNoSampling1MConstraints,
 		RequiresProviderDataSharing: true,
 		Pricing: pricing.FlatInfoFromRates(
 			pricing.NewRates(10.00, 50.00, 1.00).WithCacheCreation(12.50, 20.00, 0),
@@ -469,7 +502,7 @@ var supportedModels = map[string]ModelDefinition{
 		Name:                        ModelClaudeFable5US,
 		Label:                       "Claude Fable 5 (US)",
 		Capabilities:                claudeStandardCaps,
-		Constraints:                 claudeFable5Constraints,
+		Constraints:                 claudeNoSampling1MConstraints,
 		RequiresProviderDataSharing: true,
 		Pricing: pricing.FlatInfoFromRates(
 			pricing.NewRates(11.00, 55.00, 1.10).WithCacheCreation(13.75, 22.00, 0),
@@ -479,10 +512,52 @@ var supportedModels = map[string]ModelDefinition{
 		Name:                        ModelClaudeFable5EU,
 		Label:                       "Claude Fable 5 (EU)",
 		Capabilities:                claudeStandardCaps,
-		Constraints:                 claudeFable5Constraints,
+		Constraints:                 claudeNoSampling1MConstraints,
 		RequiresProviderDataSharing: true,
 		Pricing: pricing.FlatInfoFromRates(
 			pricing.NewRates(11.00, 55.00, 1.10).WithCacheCreation(13.75, 22.00, 0),
+		),
+	},
+
+	// ----------------------------------------------------------------
+	// Claude Opus 5 — inference-profile-only on bedrock-runtime. AWS publishes
+	// global, US, EU, and AU profiles:
+	// https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-opus-5.html
+	// ----------------------------------------------------------------
+	ModelClaudeOpus5Global: {
+		Name:         ModelClaudeOpus5Global,
+		Label:        "Claude Opus 5 (Global)",
+		Capabilities: claudeStandardCaps,
+		Constraints:  claudeNoSampling1MConstraints,
+		Pricing: pricing.FlatInfoFromRates(
+			pricing.NewRates(5.00, 25.00, 0.50).WithCacheCreation(6.25, 10.00, 0),
+		),
+	},
+	ModelClaudeOpus5US: {
+		Name:         ModelClaudeOpus5US,
+		Label:        "Claude Opus 5 (US)",
+		Capabilities: claudeStandardCaps,
+		Constraints:  claudeNoSampling1MConstraints,
+		Pricing: pricing.FlatInfoFromRates(
+			pricing.NewRates(5.50, 27.50, 0.55).WithCacheCreation(6.875, 11.00, 0),
+		),
+	},
+	ModelClaudeOpus5EU: {
+		Name:         ModelClaudeOpus5EU,
+		Label:        "Claude Opus 5 (EU)",
+		Capabilities: claudeStandardCaps,
+		Constraints:  claudeNoSampling1MConstraints,
+		Pricing: pricing.FlatInfoFromRates(
+			pricing.NewRates(5.50, 27.50, 0.55).WithCacheCreation(6.875, 11.00, 0),
+		),
+	},
+	ModelClaudeOpus5AU: {
+		Name:         ModelClaudeOpus5AU,
+		Label:        "Claude Opus 5 (AU)",
+		Capabilities: claudeStandardCaps,
+		Constraints:  claudeNoSampling1MConstraints,
+		Pricing: pricing.FlatInfoFromRates(
+			pricing.NewRates(5.50, 27.50, 0.55).WithCacheCreation(6.875, 11.00, 0),
 		),
 	},
 

--- a/providers/bedrock/pricing_test.go
+++ b/providers/bedrock/pricing_test.go
@@ -20,6 +20,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/redpanda-data/ai-sdk-go/pricing"
 )
 
 // freeCacheWriteModels lists Bedrock models AWS documents as charging nothing
@@ -100,6 +102,29 @@ func TestModelPricingMatchesModels(t *testing.T) {
 	pricingMap := ModelPricing()
 	assert.Len(t, pricingMap, len(supportedModels),
 		"ModelPricing should return exactly one entry per supported model")
+}
+
+func TestClaudeOpus5Pricing(t *testing.T) {
+	t.Parallel()
+
+	global, globalOK := supportedModels[ModelClaudeOpus5Global]
+	require.True(t, globalOK)
+	assert.Equal(t,
+		pricing.NewRates(5.00, 25.00, 0.50).WithCacheCreation(6.25, 10.00, 0),
+		global.Pricing.Default.Base,
+	)
+
+	geoRates := pricing.NewRates(5.50, 27.50, 0.55).WithCacheCreation(6.875, 11.00, 0)
+
+	for _, id := range []string{
+		ModelClaudeOpus5US,
+		ModelClaudeOpus5EU,
+		ModelClaudeOpus5AU,
+	} {
+		def, ok := supportedModels[id]
+		require.True(t, ok)
+		assert.Equal(t, geoRates, def.Pricing.Default.Base)
+	}
 }
 
 // TestGeoGlobalRatio pins, per logical model, the relationship between the

--- a/providers/bedrock/provider.go
+++ b/providers/bedrock/provider.go
@@ -218,7 +218,20 @@ func (p *Provider) NewModel(modelName string, opts ...Option) (llm.Model, error)
 	apiModelID := modelName
 
 	if _, registered := lookupModel(apiModelID); !registered && !hasRegionPrefix(apiModelID) {
-		apiModelID = InferenceProfileRegion(p.region) + "." + apiModelID
+		profileRegion := InferenceProfileRegion(p.region)
+
+		// Per-family resolvers are opt-in. Existing models retain their historical
+		// routing; generalizing validation for them is a separate behavior change.
+		if resolver, ok := profileRegionResolverFor(modelName); ok && p.region != "" {
+			var known bool
+
+			profileRegion, known = resolver(p.region)
+			if !known {
+				return nil, fmt.Errorf("unsupported Bedrock model: %s in region %s", modelName, p.region)
+			}
+		}
+
+		apiModelID = profileRegion + "." + apiModelID
 	}
 
 	// Look up by the prefixed ID — each inference profile variant is a
@@ -227,6 +240,11 @@ func (p *Provider) NewModel(modelName string, opts ...Option) (llm.Model, error)
 	modelDef, ok := lookupModel(apiModelID)
 	if !ok {
 		return nil, fmt.Errorf("unsupported Bedrock model: %s", modelName)
+	}
+
+	if _, resolvedByFamily := profileRegionResolverFor(apiModelID); p.region != "" &&
+		resolvedByFamily && !IsModelAllowedFromRegion(apiModelID, p.region) {
+		return nil, fmt.Errorf("unsupported Bedrock model: %s in region %s", modelName, p.region)
 	}
 
 	cfg := &Config{

--- a/providers/bedrock/provider_test.go
+++ b/providers/bedrock/provider_test.go
@@ -117,6 +117,40 @@ func TestLookupModel(t *testing.T) {
 			wantOK: false,
 		},
 		{
+			name:   "Opus 5 bare ID is not in the bedrock-runtime catalog",
+			input:  ModelClaudeOpus5,
+			wantOK: false,
+		},
+		{
+			name:   "Opus 5 JP profile is not published",
+			input:  "jp." + ModelClaudeOpus5,
+			wantOK: false,
+		},
+		{
+			name:    "Opus 5 US profile is its own entry",
+			input:   ModelClaudeOpus5US,
+			wantOK:  true,
+			wantDef: ModelClaudeOpus5US,
+		},
+		{
+			name:    "Opus 5 EU profile is its own entry",
+			input:   ModelClaudeOpus5EU,
+			wantOK:  true,
+			wantDef: ModelClaudeOpus5EU,
+		},
+		{
+			name:    "Opus 5 AU profile is its own entry",
+			input:   ModelClaudeOpus5AU,
+			wantOK:  true,
+			wantDef: ModelClaudeOpus5AU,
+		},
+		{
+			name:    "Opus 5 global profile is its own entry",
+			input:   ModelClaudeOpus5Global,
+			wantOK:  true,
+			wantDef: ModelClaudeOpus5Global,
+		},
+		{
 			name:   "Sonnet 5 bare ID is not in the catalog",
 			input:  ModelClaudeSonnet5,
 			wantOK: false,
@@ -489,7 +523,64 @@ func TestNewModel_Fable5RegionPrefix(t *testing.T) {
 	assert.Equal(t, ModelClaudeFable5US, m.config.APIModelID)
 }
 
-func TestNewModel_Fable5SamplingParametersRejected(t *testing.T) {
+func TestNewModel_ClaudeOpus5Routing(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		region    string
+		modelName string
+		wantID    string
+		wantErr   bool
+	}{
+		{"bare defaults to US", "", ModelClaudeOpus5, ModelClaudeOpus5US, false},
+		{"bare from US", "us-east-1", ModelClaudeOpus5, ModelClaudeOpus5US, false},
+		{"bare from Canada Central", "ca-central-1", ModelClaudeOpus5, ModelClaudeOpus5US, false},
+		{"bare from Calgary", "ca-west-1", ModelClaudeOpus5, ModelClaudeOpus5US, false},
+		{"bare from EU", "eu-west-1", ModelClaudeOpus5, ModelClaudeOpus5EU, false},
+		{"bare from Sydney", "ap-southeast-2", ModelClaudeOpus5, ModelClaudeOpus5AU, false},
+		{"bare from Melbourne", "ap-southeast-4", ModelClaudeOpus5, ModelClaudeOpus5AU, false},
+		{"bare from New Zealand", "ap-southeast-6", ModelClaudeOpus5, ModelClaudeOpus5Global, false},
+		{"bare from Tokyo", "ap-northeast-1", ModelClaudeOpus5, ModelClaudeOpus5Global, false},
+		{"bare from global-only region", "me-central-1", ModelClaudeOpus5, ModelClaudeOpus5Global, false},
+		{"bare from GovCloud", "us-gov-west-1", ModelClaudeOpus5, "", true},
+		{"bare from China", "cn-north-1", ModelClaudeOpus5, "", true},
+		{"bare from unlisted AP region", "ap-southeast-8", ModelClaudeOpus5, "", true},
+		{"bare from unknown region", "unknown", ModelClaudeOpus5, "", true},
+		{"explicit US from US", "us-east-1", ModelClaudeOpus5US, ModelClaudeOpus5US, false},
+		{"explicit EU from EU", "eu-west-1", ModelClaudeOpus5EU, ModelClaudeOpus5EU, false},
+		{"explicit AU from Sydney", "ap-southeast-2", ModelClaudeOpus5AU, ModelClaudeOpus5AU, false},
+		{"explicit global from UAE", "me-central-1", ModelClaudeOpus5Global, ModelClaudeOpus5Global, false},
+		{"explicit US from EU", "eu-west-1", ModelClaudeOpus5US, "", true},
+		{"explicit AU from New Zealand", "ap-southeast-6", ModelClaudeOpus5AU, "", true},
+		{"explicit global from China", "cn-north-1", ModelClaudeOpus5Global, ModelClaudeOpus5Global, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			p := &Provider{client: nil, region: tt.region}
+
+			model, err := p.NewModel(tt.modelName)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.modelName)
+				assert.Contains(t, err.Error(), tt.region)
+
+				return
+			}
+
+			require.NoError(t, err)
+
+			m, ok := model.(*Model)
+			require.True(t, ok)
+			assert.Equal(t, tt.wantID, m.config.APIModelID)
+		})
+	}
+}
+
+func TestNewModel_RestrictedSamplingParametersRejected(t *testing.T) {
 	t.Parallel()
 
 	p := &Provider{client: nil, region: "us-east-1"}
@@ -503,13 +594,19 @@ func TestNewModel_Fable5SamplingParametersRejected(t *testing.T) {
 		{name: "top_p", opt: WithTopP(0.9), want: "top_p"},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+	for _, model := range []string{ModelClaudeFable5, ModelClaudeOpus5} {
+		t.Run(model, func(t *testing.T) {
 			t.Parallel()
 
-			_, err := p.NewModel(ModelClaudeFable5, tt.opt)
-			require.Error(t, err)
-			assert.Contains(t, err.Error(), tt.want)
+			for _, tt := range tests {
+				t.Run(tt.name, func(t *testing.T) {
+					t.Parallel()
+
+					_, err := p.NewModel(model, tt.opt)
+					require.Error(t, err)
+					assert.Contains(t, err.Error(), tt.want)
+				})
+			}
 		})
 	}
 }


### PR DESCRIPTION
## Summary

- add Claude Opus 5 to the native Anthropic catalog with its 1M-token input, 128K-token output, adaptive thinking, full effort ladder, fast mode, and exact pricing
- add the published Bedrock global, US, EU, and AU inference profiles with exact geo pricing and model-specific source-region routing
- reject unsupported sampling and manual thinking-budget options; keep the non-invokable bare Bedrock Runtime ID outside the catalog
- integrate Opus 5's flat full-context pricing with main's long-context pricing guards
- cover model resolution, options, pricing, lookup, every documented Bedrock source region, explicit-profile validation, and fallback behavior

## Test plan

- `task lint:new`
- exact CI `golangci-lint --new-from-rev=origin/main`
- `task test:unit`
- `task license:check`

## Sources

- [Anthropic model overview](https://platform.claude.com/docs/en/about-claude/models/overview)
- [Anthropic Opus 5 release notes](https://platform.claude.com/docs/en/about-claude/models/whats-new-opus-5)
- [Anthropic fast mode](https://platform.claude.com/docs/en/build-with-claude/fast-mode)
- [Anthropic effort](https://platform.claude.com/docs/en/build-with-claude/effort)
- [Anthropic pricing](https://platform.claude.com/docs/en/about-claude/pricing)
- [AWS Bedrock model card](https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-opus-5.html)

## Review notes

- targets `main` directly and does not depend on #183
- reuses the accurate no-sampling constraint shape for Fable 5; runtime behavior is unchanged and discovery no longer advertises an unreachable temperature range
- backend-only model catalog change; no screenshots
