### PR TITLE
fix(providers): correct pricing, options, and routing

### DIFF
--- a/.claude/skills/model-catalog/SKILL.md
+++ b/.claude/skills/model-catalog/SKILL.md
@@ -95,9 +95,9 @@ page publishes one for that exact model.
 
 Cache rates derive from Anthropic's prompt-caching multipliers off base input:
 5m-write 1.25x, 1h-write 2x, cache-read 0.10x. These stay flat across the native
-1M window. `TestAllModelsStayFlatAcrossContextWindow` and
+1M window. `TestNative1MModelsStayFlatAcrossContextWindow` and
 `TestNative1MContextPricingStaysFlatEndToEnd` in
-`providers/anthropic/pricing_longcontext_test.go` guard this contract.
+`providers/anthropic/pricing_context_test.go` guard this contract.
 
 ## Verify the real context window empirically
 

--- a/.claude/skills/model-catalog/SKILL.md
+++ b/.claude/skills/model-catalog/SKILL.md
@@ -106,7 +106,7 @@ the same as what an account can actually use. Do not trust the number — probe 
 Send a prompt sized just over the threshold with the raw provider SDK and observe:
 
 - A model whose window is genuinely 1M accepts a >200K request with **no** beta
-  header. On current Anthropic 1M models (Sonnet 5, Opus 4.6/4.7/4.8, Fable 5)
+  header. On current Anthropic 1M models (Sonnet 4.6/5, Opus 4.6/4.7/4.8, Fable 5)
   the `context-1m-2025-08-07` beta header is a **no-op** — the window is native,
   so do not add per-request beta plumbing for it.
 - A 200K model returns HTTP 400 `prompt is too long: N tokens > 200000 maximum`,

--- a/.claude/skills/model-catalog/SKILL.md
+++ b/.claude/skills/model-catalog/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   How to source and encode model pricing in this repo's provider catalogs
   (providers/*/models.go) — where to pull authoritative rates, the microcents
   convention, flat vs context-tiered pricing (TieredInfo/Bracket), Anthropic's
-  >200K long-context surcharge, cache-rate multipliers, and how to empirically
+  native 1M-window pricing, cache-rate multipliers, and how to empirically
   verify a model's real context window. Use when adding or correcting Pricing
   on a catalog entry, or when a large-context request looks mis-costed. Pairs
   with the model-maintenance skill and the "Adding New Models" rules in
@@ -59,9 +59,8 @@ keep a dollar comment on any non-obvious value.
 
    LiteLLM values are USD **per token**; multiply by 1_000_000 for USD/M before
    feeding the dollar constructors. LiteLLM lags new releases — if this repo's
-   catalog is ahead of it (forward-looking model names), derive from the
-   provider page + the documented multiplier structure below, and say so in a
-   comment.
+   catalog is ahead of it (forward-looking model names), use the provider page
+   and say so in a comment rather than extrapolating an older model's tiers.
 
    License: LiteLLM is MIT (Copyright Berri AI), so referencing or even
    vendoring the file is fine with attribution. In practice we vendor nothing —
@@ -85,29 +84,20 @@ override `RateCard` has its **own** `Brackets` — if a model is context-tiered 
 has a fast mode, the fast override needs its own bracket too, or large fast-mode
 requests under-report.
 
-## Anthropic long-context surcharge (>200K)
+## Anthropic native 1M-window pricing
 
-Anthropic bills 1M-window models at a higher rate once a request's context
-exceeds the 200K standard window. The published multiplier, confirmed across
-`claude-sonnet-4/4.5/4.6` on the provider page and LiteLLM's
-`*_above_200k_tokens` fields, is uniform:
+Claude 4.6 and later models include their full native 1M context window at
+standard pricing. Do not add a legacy `200_001` bracket to those models or to a
+fast-mode override: Anthropic explicitly states that both standard and fast
+rates apply across the full window. Older optional 1M beta windows may have
+model-specific premiums, so encode a bracket only when the current provider
+page publishes one for that exact model.
 
-    input                2x base
-    output               1.5x base
-    cache read           2x base
-    cache write (5m/1h)  2x base
-
-Threshold is `MinContextTokens: 200_001` (matches Google's 200K and OpenAI's
-272K tiers). Apply it to **every 1M-window Anthropic model**, on both the default
-and any fast-mode override card. 200K-window models stay flat — no bracket. The
-`TestLongContextBracketsMatchSurcharge` / `TestNonLongContextModelsStayFlat`
-guards in `providers/anthropic/pricing_longcontext_test.go` enforce both
-directions, so the arithmetic is checked for you.
-
-Cache rates themselves derive from Anthropic's prompt-caching multipliers off
-base input: 5m-write 1.25x, 1h-write 2x, cache-read 0.10x. These compose with the
-long-context 2x, which is why the bracket's cache columns are exactly 2x the
-base cache columns.
+Cache rates derive from Anthropic's prompt-caching multipliers off base input:
+5m-write 1.25x, 1h-write 2x, cache-read 0.10x. These stay flat across the native
+1M window. `TestAllModelsStayFlatAcrossContextWindow` and
+`TestNative1MContextPricingStaysFlatEndToEnd` in
+`providers/anthropic/pricing_longcontext_test.go` guard this contract.
 
 ## Verify the real context window empirically
 
@@ -131,7 +121,8 @@ overshoot the threshold with margin, since tokenizers differ per model.
 ## Checklist for a pricing change
 
 - [ ] Base rates match the provider page (cross-checked against LiteLLM).
-- [ ] 1M-window models are `TieredInfo` with a `200_001` bracket; 200K models are flat.
-- [ ] Every override card (fast/region) that needs a bracket has one.
-- [ ] `task test:unit` passes — `TestAllModelsHavePricing`, the long-context guards,
+- [ ] Native 1M-window Anthropic models stay flat; use a bracket only when the
+      provider publishes one for that exact model.
+- [ ] Every override card (fast/region) matches the provider's published tier shape.
+- [ ] `task test:unit` passes — `TestAllModelsHavePricing`, the context-window guards,
       and per-provider ratio tests catch omissions and arithmetic slips.

--- a/.claude/skills/model-maintenance/SKILL.md
+++ b/.claude/skills/model-maintenance/SKILL.md
@@ -13,7 +13,7 @@ When you add a model to any provider's `supportedModels` map you **must** set
 `Pricing` (microcents per million tokens) — see the "Adding New Models" section
 in `CLAUDE.md` for the conversion and the per-provider `TestAllModelsHavePricing`
 requirement. For where to source rates, flat vs context-tiered pricing, and the
-long-context surcharge, see the `model-catalog` skill. Below is the extra process
+native 1M-window rules, see the `model-catalog` skill. Below is the extra process
 that is specific to Bedrock.
 
 ## Adding a new Bedrock model

--- a/llm/constraints.go
+++ b/llm/constraints.go
@@ -25,6 +25,12 @@ type ModelConstraints struct {
 	// TemperatureRange defines the valid range for temperature parameter [min, max]
 	TemperatureRange [2]float64
 
+	// TopPRange defines the valid range for top_p. The zero value uses [0, 1].
+	TopPRange [2]float64
+
+	// TopPMaxExclusive makes the upper bound of TopPRange exclusive.
+	TopPMaxExclusive bool
+
 	// MaxInputTokens is the maximum context window size (input tokens)
 	MaxInputTokens int
 
@@ -70,6 +76,30 @@ func (c *ModelConstraints) ValidateTemperature(temp float64) error {
 	minTemp, maxTemp := c.TemperatureRange[0], c.TemperatureRange[1]
 	if temp < minTemp || temp > maxTemp {
 		return fmt.Errorf("temperature %f out of range [%f, %f]", temp, minTemp, maxTemp)
+	}
+
+	return nil
+}
+
+// ValidateTopP checks if a top_p value is valid for these constraints.
+func (c *ModelConstraints) ValidateTopP(topP float64) error {
+	minTopP, maxTopP := c.TopPRange[0], c.TopPRange[1]
+	if c.TopPRange == [2]float64{} {
+		maxTopP = 1
+	}
+
+	outOfRange := topP < minTopP || topP > maxTopP
+	if c.TopPMaxExclusive {
+		outOfRange = outOfRange || topP == maxTopP
+	}
+
+	if outOfRange {
+		closingBracket := "]"
+		if c.TopPMaxExclusive {
+			closingBracket = ")"
+		}
+
+		return fmt.Errorf("top_p %f out of range [%f, %f%s", topP, minTopP, maxTopP, closingBracket)
 	}
 
 	return nil

--- a/llm/constraints_test.go
+++ b/llm/constraints_test.go
@@ -1,0 +1,36 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package llm
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateTopP(t *testing.T) {
+	t.Parallel()
+
+	require.NoError(t, (&ModelConstraints{}).ValidateTopP(0))
+	require.NoError(t, (&ModelConstraints{}).ValidateTopP(1))
+
+	narrow := &ModelConstraints{
+		TopPRange:        [2]float64{0.99, 1},
+		TopPMaxExclusive: true,
+	}
+	require.NoError(t, narrow.ValidateTopP(0.99))
+	require.Error(t, narrow.ValidateTopP(0.98))
+	require.Error(t, narrow.ValidateTopP(1))
+}

--- a/llm/constraints_test.go
+++ b/llm/constraints_test.go
@@ -26,6 +26,11 @@ func TestValidateTopP(t *testing.T) {
 	require.NoError(t, (&ModelConstraints{}).ValidateTopP(0))
 	require.NoError(t, (&ModelConstraints{}).ValidateTopP(1))
 
+	inclusive := &ModelConstraints{TopPRange: [2]float64{0.25, 0.75}}
+	require.NoError(t, inclusive.ValidateTopP(0.25))
+	require.NoError(t, inclusive.ValidateTopP(0.75))
+	require.Error(t, inclusive.ValidateTopP(0.751))
+
 	narrow := &ModelConstraints{
 		TopPRange:        [2]float64{0.99, 1},
 		TopPMaxExclusive: true,

--- a/providers/anthropic/alias_test.go
+++ b/providers/anthropic/alias_test.go
@@ -312,10 +312,10 @@ func TestWithSpeed(t *testing.T) {
 	provider, err := NewProvider("test-key")
 	require.NoError(t, err)
 
-	t.Run("fast speed on Opus 4.6", func(t *testing.T) {
+	t.Run("fast speed on Opus 4.8", func(t *testing.T) {
 		t.Parallel()
 
-		model, err := provider.NewModel(ModelClaudeOpus46, WithSpeed(SpeedFast))
+		model, err := provider.NewModel(ModelClaudeOpus48, WithSpeed(SpeedFast))
 		require.NoError(t, err)
 
 		m, ok := model.(*Model)
@@ -324,41 +324,21 @@ func TestWithSpeed(t *testing.T) {
 		assert.Equal(t, SpeedFast, *m.config.Speed)
 	})
 
-	t.Run("standard speed on Opus 4.6", func(t *testing.T) {
-		t.Parallel()
+	for _, model := range []string{
+		ModelClaudeFable5,
+		ModelClaudeOpus46,
+		ModelClaudeOpus47,
+		ModelClaudeSonnet46,
+		ModelClaudeSonnet45,
+	} {
+		t.Run("rejected on "+model, func(t *testing.T) {
+			t.Parallel()
 
-		model, err := provider.NewModel(ModelClaudeOpus46, WithSpeed(SpeedStandard))
-		require.NoError(t, err)
-
-		m, ok := model.(*Model)
-		require.True(t, ok)
-		require.NotNil(t, m.config.Speed)
-		assert.Equal(t, SpeedStandard, *m.config.Speed)
-	})
-
-	t.Run("rejected on model without speed support", func(t *testing.T) {
-		t.Parallel()
-
-		_, err := provider.NewModel(ModelClaudeSonnet46, WithSpeed(SpeedFast))
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "speed")
-	})
-
-	t.Run("rejected on Sonnet 4.5", func(t *testing.T) {
-		t.Parallel()
-
-		_, err := provider.NewModel(ModelClaudeSonnet45, WithSpeed(SpeedFast))
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "speed")
-	})
-
-	t.Run("rejected on Fable 5", func(t *testing.T) {
-		t.Parallel()
-
-		_, err := provider.NewModel(ModelClaudeFable5, WithSpeed(SpeedFast))
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "speed")
-	})
+			_, err := provider.NewModel(model, WithSpeed(SpeedFast))
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "speed")
+		})
+	}
 }
 
 func TestSamplingParametersRejected(t *testing.T) {
@@ -387,9 +367,13 @@ func TestSamplingParametersRejected(t *testing.T) {
 			t.Parallel()
 
 			for _, tt := range options {
-				_, err := provider.NewModel(model, tt.opt)
-				require.Error(t, err, tt.name)
-				assert.Contains(t, err.Error(), tt.want, tt.name)
+				t.Run(tt.name, func(t *testing.T) {
+					t.Parallel()
+
+					_, err := provider.NewModel(model, tt.opt)
+					require.Error(t, err)
+					assert.Contains(t, err.Error(), tt.want)
+				})
 			}
 		})
 	}

--- a/providers/anthropic/alias_test.go
+++ b/providers/anthropic/alias_test.go
@@ -424,7 +424,7 @@ func TestFable5SamplingParameters(t *testing.T) {
 		{"non-default temperature", WithTemperature(0.5), true},
 		{"minimum top_p", WithTopP(0.99), false},
 		{"top_p below minimum", WithTopP(0.98), true},
-		{"top_p maximum", WithTopP(1), false},
+		{"top_p maximum is exclusive", WithTopP(1), true},
 		{"top_k unsupported", WithTopK(10), true},
 	} {
 		t.Run(tt.name, func(t *testing.T) {

--- a/providers/anthropic/alias_test.go
+++ b/providers/anthropic/alias_test.go
@@ -166,7 +166,7 @@ func TestSonnet46ContextLimits(t *testing.T) {
 	def, ok := supportedModels[ModelClaudeSonnet46]
 	require.True(t, ok)
 	assert.Equal(t, 1_000_000, def.Constraints.MaxInputTokens)
-	assert.Equal(t, 64_000, def.Constraints.MaxOutputTokens)
+	assert.Equal(t, 128_000, def.Constraints.MaxOutputTokens)
 }
 
 func TestUnsupportedModelRejected(t *testing.T) {
@@ -389,7 +389,6 @@ func TestSamplingParametersRejected(t *testing.T) {
 	}
 
 	for _, model := range []string{
-		ModelClaudeFable5,
 		ModelClaudeOpus47,
 		ModelClaudeOpus48,
 		ModelClaudeSonnet5,
@@ -406,6 +405,38 @@ func TestSamplingParametersRejected(t *testing.T) {
 					assert.Contains(t, err.Error(), tt.want)
 				})
 			}
+		})
+	}
+}
+
+func TestFable5SamplingParameters(t *testing.T) {
+	t.Parallel()
+
+	provider, err := NewProvider("test-key")
+	require.NoError(t, err)
+
+	for _, tt := range []struct {
+		name    string
+		opt     Option
+		wantErr bool
+	}{
+		{"default temperature", WithTemperature(1), false},
+		{"non-default temperature", WithTemperature(0.5), true},
+		{"minimum top_p", WithTopP(0.99), false},
+		{"top_p below minimum", WithTopP(0.98), true},
+		{"top_p maximum", WithTopP(1), false},
+		{"top_k unsupported", WithTopK(10), true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := provider.NewModel(ModelClaudeFable5, tt.opt)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
 		})
 	}
 }

--- a/providers/anthropic/alias_test.go
+++ b/providers/anthropic/alias_test.go
@@ -361,13 +361,13 @@ func TestWithSpeed(t *testing.T) {
 	})
 }
 
-func TestFable5SamplingParametersRejected(t *testing.T) {
+func TestSamplingParametersRejected(t *testing.T) {
 	t.Parallel()
 
 	provider, err := NewProvider("test-key")
 	require.NoError(t, err)
 
-	tests := []struct {
+	options := []struct {
 		name string
 		opt  Option
 		want string
@@ -377,13 +377,20 @@ func TestFable5SamplingParametersRejected(t *testing.T) {
 		{name: "top_k", opt: WithTopK(10), want: "top_k"},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+	for _, model := range []string{
+		ModelClaudeFable5,
+		ModelClaudeOpus47,
+		ModelClaudeOpus48,
+		ModelClaudeSonnet5,
+	} {
+		t.Run(model, func(t *testing.T) {
 			t.Parallel()
 
-			_, err := provider.NewModel(ModelClaudeFable5, tt.opt)
-			require.Error(t, err)
-			assert.Contains(t, err.Error(), tt.want)
+			for _, tt := range options {
+				_, err := provider.NewModel(model, tt.opt)
+				require.Error(t, err, tt.name)
+				assert.Contains(t, err.Error(), tt.want, tt.name)
+			}
 		})
 	}
 }

--- a/providers/anthropic/alias_test.go
+++ b/providers/anthropic/alias_test.go
@@ -160,6 +160,15 @@ func TestCustomModelName(t *testing.T) {
 	assert.Equal(t, int(200000), m.config.Constraints.MaxInputTokens)
 }
 
+func TestSonnet46ContextLimits(t *testing.T) {
+	t.Parallel()
+
+	def, ok := supportedModels[ModelClaudeSonnet46]
+	require.True(t, ok)
+	assert.Equal(t, 1_000_000, def.Constraints.MaxInputTokens)
+	assert.Equal(t, 64_000, def.Constraints.MaxOutputTokens)
+}
+
 func TestUnsupportedModelRejected(t *testing.T) {
 	t.Parallel()
 
@@ -324,14 +333,36 @@ func TestWithSpeed(t *testing.T) {
 		assert.Equal(t, SpeedFast, *m.config.Speed)
 	})
 
+	for _, model := range []string{ModelClaudeOpus46, ModelClaudeOpus47} {
+		t.Run("standard speed on "+model, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := provider.NewModel(model, WithSpeed(SpeedStandard))
+			require.NoError(t, err)
+
+			m, ok := got.(*Model)
+			require.True(t, ok)
+			require.NotNil(t, m.config.Speed)
+			assert.Equal(t, SpeedStandard, *m.config.Speed)
+		})
+	}
+
 	for _, model := range []string{
 		ModelClaudeFable5,
-		ModelClaudeOpus46,
-		ModelClaudeOpus47,
 		ModelClaudeSonnet46,
 		ModelClaudeSonnet45,
 	} {
 		t.Run("rejected on "+model, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := provider.NewModel(model, WithSpeed(SpeedFast))
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "speed")
+		})
+	}
+
+	for _, model := range []string{ModelClaudeOpus46, ModelClaudeOpus47} {
+		t.Run("fast rejected on "+model, func(t *testing.T) {
 			t.Parallel()
 
 			_, err := provider.NewModel(model, WithSpeed(SpeedFast))

--- a/providers/anthropic/models.go
+++ b/providers/anthropic/models.go
@@ -96,6 +96,14 @@ func resolveModelFamily(model string) string {
 
 // supportedModels defines all Claude models with their capabilities and constraints.
 // Based on Anthropic API documentation and model specifications.
+//
+// Anthropic documents that non-default temperature, top_p, and top_k return
+// HTTP 400 on Opus 4.7+ and Sonnet 5:
+// https://platform.claude.com/docs/en/about-claude/models/migration-guide
+//
+// Among the pre-5 models, only Opus 4.8 supports fast mode; Opus 4.7 rejects
+// it and Opus 4.6 runs at standard speed and pricing:
+// https://platform.claude.com/docs/en/build-with-claude/fast-mode#supported-models
 var supportedModels = map[string]ModelDefinition{
 	ModelClaudeFable5: {
 		Name:  ModelClaudeFable5,

--- a/providers/anthropic/models.go
+++ b/providers/anthropic/models.go
@@ -190,10 +190,11 @@ var supportedModels = map[string]ModelDefinition{
 			// Opus 4.7 rejects thinking.type.enabled — thinking budget is not user-controllable.
 			// Non-default sampling parameters are also rejected. Use adaptive
 			// thinking + effort to bias reasoning depth.
-			SupportedParams:   []string{"max_tokens", "effort"},
+			SupportedParams:   []string{"max_tokens", "effort", "speed"},
 			MutuallyExclusive: [][]string{},
 		},
 		SupportedEfforts: []Effort{EffortLow, EffortMedium, EffortHigh, EffortXHigh, EffortMax},
+		SupportedSpeeds:  []Speed{SpeedStandard},
 		AdaptiveThinking: true,
 		Pricing: pricing.FlatInfoFromRates(
 			pricing.NewRates(5.00, 25.00, 0.50).WithCacheCreation(6.25, 10.00, 0),
@@ -247,8 +248,8 @@ var supportedModels = map[string]ModelDefinition{
 		},
 		Constraints: llm.ModelConstraints{
 			TemperatureRange:  [2]float64{0.0, 1.0},
-			MaxInputTokens:    200000, // 200K context window
-			MaxOutputTokens:   64000,  // 64K output tokens
+			MaxInputTokens:    1000000, // Native 1M context window
+			MaxOutputTokens:   64000,   // 64K output tokens
 			SupportedParams:   []string{"temperature", "top_p", "top_k", "max_tokens", "effort", "thinking_budget"},
 			MutuallyExclusive: [][]string{},
 		},
@@ -325,10 +326,11 @@ var supportedModels = map[string]ModelDefinition{
 			// https://platform.claude.com/docs/en/about-claude/pricing#long-context-pricing
 			MaxInputTokens:    1000000,
 			MaxOutputTokens:   128000, // 128K output tokens
-			SupportedParams:   []string{"temperature", "top_p", "top_k", "max_tokens", "effort", "thinking_budget"},
+			SupportedParams:   []string{"temperature", "top_p", "top_k", "max_tokens", "effort", "thinking_budget", "speed"},
 			MutuallyExclusive: [][]string{},
 		},
 		SupportedEfforts: []Effort{EffortLow, EffortMedium, EffortHigh, EffortMax},
+		SupportedSpeeds:  []Speed{SpeedStandard},
 		AdaptiveThinking: true,
 		Pricing: pricing.FlatInfoFromRates(
 			pricing.NewRates(5.00, 25.00, 0.50).WithCacheCreation(6.25, 10.00, 0),

--- a/providers/anthropic/models.go
+++ b/providers/anthropic/models.go
@@ -111,9 +111,8 @@ var supportedModels = map[string]ModelDefinition{
 			Reasoning:        true, // Adaptive thinking only; use effort to bias toward more/less thinking
 		},
 		Constraints: llm.ModelConstraints{
-			TemperatureRange: [2]float64{0.0, 1.0},
-			MaxInputTokens:   1000000, // 1M context window
-			MaxOutputTokens:  128000,  // 128K output tokens
+			MaxInputTokens:  1000000, // 1M context window
+			MaxOutputTokens: 128000,  // 128K output tokens
 			// Fable 5 rejects thinking.type.enabled — thinking budget is not user-controllable.
 			// Use adaptive thinking + effort to bias reasoning depth. No fast mode, so no "speed".
 			SupportedParams:   []string{"max_tokens", "effort"},
@@ -141,9 +140,8 @@ var supportedModels = map[string]ModelDefinition{
 			Reasoning:        true, // Adaptive thinking only; use effort to bias toward more/less thinking
 		},
 		Constraints: llm.ModelConstraints{
-			TemperatureRange: [2]float64{0.0, 1.0},
-			MaxInputTokens:   1000000, // 1M context window
-			MaxOutputTokens:  128000,  // 128K output tokens
+			MaxInputTokens:  1000000, // 1M context window
+			MaxOutputTokens: 128000,  // 128K output tokens
 			// Opus 4.8 rejects thinking.type.enabled — thinking budget is not user-controllable.
 			// Non-default sampling parameters are also rejected. Use adaptive
 			// thinking + effort to bias reasoning depth.
@@ -158,7 +156,6 @@ var supportedModels = map[string]ModelDefinition{
 		).WithOverride(
 			pricing.Selector{Speed: SpeedFast},
 			pricing.RateCard{
-				// Opus 4.8 fast mode is 3x cheaper than Opus 4.6/4.7's fast mode.
 				// Cache rates derived from Anthropic's prompt-caching multipliers
 				// (5m-write = 1.25x base input, 1h-write = 2x, cache-read = 0.10x).
 				Base: pricing.NewRates(10.00, 50.00, 1.00).
@@ -180,13 +177,12 @@ var supportedModels = map[string]ModelDefinition{
 			Reasoning:        true, // Adaptive thinking only; use effort to bias toward more/less thinking
 		},
 		Constraints: llm.ModelConstraints{
-			TemperatureRange: [2]float64{0.0, 1.0},
-			MaxInputTokens:   1000000, // 1M context window
-			MaxOutputTokens:  128000,  // 128K output tokens
+			MaxInputTokens:  1000000, // 1M context window
+			MaxOutputTokens: 128000,  // 128K output tokens
 			// Opus 4.7 rejects thinking.type.enabled — thinking budget is not user-controllable.
 			// Non-default sampling parameters are also rejected. Use adaptive
 			// thinking + effort to bias reasoning depth.
-			SupportedParams:   []string{"max_tokens", "effort", "speed"},
+			SupportedParams:   []string{"max_tokens", "effort"},
 			MutuallyExclusive: [][]string{},
 		},
 		SupportedEfforts: []Effort{EffortLow, EffortMedium, EffortHigh, EffortXHigh, EffortMax},
@@ -209,9 +205,8 @@ var supportedModels = map[string]ModelDefinition{
 			Reasoning:        true, // Adaptive thinking only; use effort to bias toward more/less thinking
 		},
 		Constraints: llm.ModelConstraints{
-			TemperatureRange: [2]float64{0.0, 1.0},
-			MaxInputTokens:   1000000, // 1M context window
-			MaxOutputTokens:  128000,  // 128K output tokens
+			MaxInputTokens:  1000000, // 1M context window
+			MaxOutputTokens: 128000,  // 128K output tokens
 			// Sonnet 5 shares Opus 4.7's request surface: manual thinking budget
 			// and non-default sampling are rejected. It uses adaptive thinking
 			// + effort instead and has no fast mode.
@@ -317,23 +312,18 @@ var supportedModels = map[string]ModelDefinition{
 			Reasoning:        true, // Extended thinking + adaptive thinking support
 		},
 		Constraints: llm.ModelConstraints{
-			TemperatureRange:  [2]float64{0.0, 1.0},
-			MaxInputTokens:    1000000, // 1M context window (beta)
-			MaxOutputTokens:   128000,  // 128K output tokens
-			SupportedParams:   []string{"temperature", "top_p", "top_k", "max_tokens", "effort", "thinking_budget", "speed"},
+			TemperatureRange: [2]float64{0.0, 1.0},
+			// Anthropic documents Opus 4.6's full 1M window at standard pricing:
+			// https://platform.claude.com/docs/en/about-claude/pricing#long-context-pricing
+			MaxInputTokens:    1000000,
+			MaxOutputTokens:   128000, // 128K output tokens
+			SupportedParams:   []string{"temperature", "top_p", "top_k", "max_tokens", "effort", "thinking_budget"},
 			MutuallyExclusive: [][]string{},
 		},
 		SupportedEfforts: []Effort{EffortLow, EffortMedium, EffortHigh, EffortMax},
-		SupportedSpeeds:  []Speed{SpeedStandard, SpeedFast},
 		AdaptiveThinking: true,
 		Pricing: pricing.FlatInfoFromRates(
 			pricing.NewRates(5.00, 25.00, 0.50).WithCacheCreation(6.25, 10.00, 0),
-		).WithOverride(
-			pricing.Selector{Speed: SpeedFast},
-			pricing.RateCard{
-				Base: pricing.NewRates(30.00, 150.00, 3.00).
-					WithCacheCreation(37.50, 60.00, 0),
-			},
 		),
 	},
 	ModelClaudeOpus41: {

--- a/providers/anthropic/models.go
+++ b/providers/anthropic/models.go
@@ -119,11 +119,15 @@ var supportedModels = map[string]ModelDefinition{
 			Reasoning:        true, // Adaptive thinking only; use effort to bias toward more/less thinking
 		},
 		Constraints: llm.ModelConstraints{
-			MaxInputTokens:  1000000, // 1M context window
-			MaxOutputTokens: 128000,  // 128K output tokens
+			TemperatureRange: [2]float64{1, 1},
+			TopPRange:        [2]float64{0.99, 1},
+			MaxInputTokens:   1000000, // 1M context window
+			MaxOutputTokens:  128000,  // 128K output tokens
 			// Fable 5 rejects thinking.type.enabled — thinking budget is not user-controllable.
+			// It accepts only the default temperature and top_p >= 0.99:
+			// https://platform.claude.com/docs/en/api/messages
 			// Use adaptive thinking + effort to bias reasoning depth. No fast mode, so no "speed".
-			SupportedParams:   []string{"max_tokens", "effort"},
+			SupportedParams:   []string{"temperature", "top_p", "max_tokens", "effort"},
 			MutuallyExclusive: [][]string{},
 		},
 		SupportedEfforts: []Effort{EffortLow, EffortMedium, EffortHigh, EffortXHigh, EffortMax},
@@ -247,9 +251,11 @@ var supportedModels = map[string]ModelDefinition{
 			Reasoning:        true, // Extended thinking + adaptive thinking support
 		},
 		Constraints: llm.ModelConstraints{
-			TemperatureRange:  [2]float64{0.0, 1.0},
-			MaxInputTokens:    1000000, // Native 1M context window
-			MaxOutputTokens:   64000,   // 64K output tokens
+			TemperatureRange: [2]float64{0.0, 1.0},
+			MaxInputTokens:   1000000, // Native 1M context window
+			// Native Anthropic supports 128K output; Bedrock currently limits
+			// this model to 64K.
+			MaxOutputTokens:   128000,
 			SupportedParams:   []string{"temperature", "top_p", "top_k", "max_tokens", "effort", "thinking_budget"},
 			MutuallyExclusive: [][]string{},
 		},

--- a/providers/anthropic/models.go
+++ b/providers/anthropic/models.go
@@ -121,11 +121,13 @@ var supportedModels = map[string]ModelDefinition{
 		Constraints: llm.ModelConstraints{
 			TemperatureRange: [2]float64{1, 1},
 			TopPRange:        [2]float64{0.99, 1},
+			TopPMaxExclusive: true,
 			MaxInputTokens:   1000000, // 1M context window
 			MaxOutputTokens:  128000,  // 128K output tokens
 			// Fable 5 rejects thinking.type.enabled — thinking budget is not user-controllable.
-			// It accepts only the default temperature and top_p >= 0.99:
-			// https://platform.claude.com/docs/en/api/messages
+			// The AWS model card is the only primary source that publishes
+			// Fable-specific sampling bounds, so use its conservative window:
+			// https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-fable-5.html
 			// Use adaptive thinking + effort to bias reasoning depth. No fast mode, so no "speed".
 			SupportedParams:   []string{"temperature", "top_p", "max_tokens", "effort"},
 			MutuallyExclusive: [][]string{},

--- a/providers/anthropic/models.go
+++ b/providers/anthropic/models.go
@@ -121,15 +121,10 @@ var supportedModels = map[string]ModelDefinition{
 		},
 		SupportedEfforts: []Effort{EffortLow, EffortMedium, EffortHigh, EffortXHigh, EffortMax},
 		AdaptiveThinking: true,
-		Pricing: pricing.TieredInfo(
+		Pricing: pricing.FlatInfoFromRates(
 			// Cache rates derived from Anthropic's prompt-caching multipliers
 			// (5m-write = 1.25x base input, 1h-write = 2x, cache-read = 0.10x).
 			pricing.NewRates(10.00, 50.00, 1.00).WithCacheCreation(12.50, 20.00, 0),
-			pricing.Bracket{
-				// Anthropic >200K long-context surcharge: input 2x, output 1.5x, cache 2x.
-				MinContextTokens: 200_001,
-				Rates:            pricing.NewRates(20.00, 75.00, 2.00).WithCacheCreation(25.00, 40.00, 0),
-			},
 		),
 	},
 	ModelClaudeOpus48: {
@@ -150,20 +145,16 @@ var supportedModels = map[string]ModelDefinition{
 			MaxInputTokens:   1000000, // 1M context window
 			MaxOutputTokens:  128000,  // 128K output tokens
 			// Opus 4.8 rejects thinking.type.enabled — thinking budget is not user-controllable.
-			// Use adaptive thinking + effort to bias reasoning depth.
-			SupportedParams:   []string{"temperature", "top_p", "top_k", "max_tokens", "effort", "speed"},
+			// Non-default sampling parameters are also rejected. Use adaptive
+			// thinking + effort to bias reasoning depth.
+			SupportedParams:   []string{"max_tokens", "effort", "speed"},
 			MutuallyExclusive: [][]string{},
 		},
 		SupportedEfforts: []Effort{EffortLow, EffortMedium, EffortHigh, EffortXHigh, EffortMax},
 		SupportedSpeeds:  []Speed{SpeedStandard, SpeedFast},
 		AdaptiveThinking: true,
-		Pricing: pricing.TieredInfo(
+		Pricing: pricing.FlatInfoFromRates(
 			pricing.NewRates(5.00, 25.00, 0.50).WithCacheCreation(6.25, 10.00, 0),
-			pricing.Bracket{
-				// Anthropic >200K long-context surcharge: input 2x, output 1.5x, cache 2x.
-				MinContextTokens: 200_001,
-				Rates:            pricing.NewRates(10.00, 37.50, 1.00).WithCacheCreation(12.50, 20.00, 0),
-			},
 		).WithOverride(
 			pricing.Selector{Speed: SpeedFast},
 			pricing.RateCard{
@@ -172,11 +163,6 @@ var supportedModels = map[string]ModelDefinition{
 				// (5m-write = 1.25x base input, 1h-write = 2x, cache-read = 0.10x).
 				Base: pricing.NewRates(10.00, 50.00, 1.00).
 					WithCacheCreation(12.50, 20.00, 0),
-				Brackets: []pricing.Bracket{{
-					// >200K long-context surcharge on fast-mode rates.
-					MinContextTokens: 200_001,
-					Rates:            pricing.NewRates(20.00, 75.00, 2.00).WithCacheCreation(25.00, 40.00, 0),
-				}},
 			},
 		),
 	},
@@ -198,19 +184,15 @@ var supportedModels = map[string]ModelDefinition{
 			MaxInputTokens:   1000000, // 1M context window
 			MaxOutputTokens:  128000,  // 128K output tokens
 			// Opus 4.7 rejects thinking.type.enabled — thinking budget is not user-controllable.
-			// Use adaptive thinking + effort to bias reasoning depth.
-			SupportedParams:   []string{"temperature", "top_p", "top_k", "max_tokens", "effort", "speed"},
+			// Non-default sampling parameters are also rejected. Use adaptive
+			// thinking + effort to bias reasoning depth.
+			SupportedParams:   []string{"max_tokens", "effort", "speed"},
 			MutuallyExclusive: [][]string{},
 		},
 		SupportedEfforts: []Effort{EffortLow, EffortMedium, EffortHigh, EffortXHigh, EffortMax},
 		AdaptiveThinking: true,
-		Pricing: pricing.TieredInfo(
+		Pricing: pricing.FlatInfoFromRates(
 			pricing.NewRates(5.00, 25.00, 0.50).WithCacheCreation(6.25, 10.00, 0),
-			pricing.Bracket{
-				// Anthropic >200K long-context surcharge: input 2x, output 1.5x, cache 2x.
-				MinContextTokens: 200_001,
-				Rates:            pricing.NewRates(10.00, 37.50, 1.00).WithCacheCreation(12.50, 20.00, 0),
-			},
 		),
 	},
 	ModelClaudeSonnet5: {
@@ -231,25 +213,20 @@ var supportedModels = map[string]ModelDefinition{
 			MaxInputTokens:   1000000, // 1M context window
 			MaxOutputTokens:  128000,  // 128K output tokens
 			// Sonnet 5 shares Opus 4.7's request surface: manual thinking budget
-			// is removed (adaptive thinking + effort instead), no fast mode.
-			SupportedParams:   []string{"temperature", "top_p", "top_k", "max_tokens", "effort"},
+			// and non-default sampling are rejected. It uses adaptive thinking
+			// + effort instead and has no fast mode.
+			SupportedParams:   []string{"max_tokens", "effort"},
 			MutuallyExclusive: [][]string{},
 		},
 		// First Sonnet-tier model with xhigh; supports the full effort range.
 		SupportedEfforts: []Effort{EffortLow, EffortMedium, EffortHigh, EffortXHigh, EffortMax},
 		AdaptiveThinking: true,
-		Pricing: pricing.TieredInfo(
+		Pricing: pricing.FlatInfoFromRates(
 			// List price $3/$15 per MTok (the introductory $2/$10 through
 			// 2026-08-31 is deliberately not tracked here). Cache rates from
 			// Anthropic's prompt-caching multipliers (5m-write 1.25x, 1h-write 2x,
 			// cache-read 0.10x of base input).
 			pricing.NewRates(3.00, 15.00, 0.30).WithCacheCreation(3.75, 6.00, 0),
-			pricing.Bracket{
-				// Anthropic >200K long-context surcharge: input 2x, output 1.5x, cache 2x.
-				// Matches Anthropic's published Sonnet 1M pricing ($6/$22.50 above 200K).
-				MinContextTokens: 200_001,
-				Rates:            pricing.NewRates(6.00, 22.50, 0.60).WithCacheCreation(7.50, 12.00, 0),
-			},
 		),
 	},
 	ModelClaudeSonnet46: {
@@ -349,23 +326,13 @@ var supportedModels = map[string]ModelDefinition{
 		SupportedEfforts: []Effort{EffortLow, EffortMedium, EffortHigh, EffortMax},
 		SupportedSpeeds:  []Speed{SpeedStandard, SpeedFast},
 		AdaptiveThinking: true,
-		Pricing: pricing.TieredInfo(
+		Pricing: pricing.FlatInfoFromRates(
 			pricing.NewRates(5.00, 25.00, 0.50).WithCacheCreation(6.25, 10.00, 0),
-			pricing.Bracket{
-				// Anthropic >200K long-context surcharge: input 2x, output 1.5x, cache 2x.
-				MinContextTokens: 200_001,
-				Rates:            pricing.NewRates(10.00, 37.50, 1.00).WithCacheCreation(12.50, 20.00, 0),
-			},
 		).WithOverride(
 			pricing.Selector{Speed: SpeedFast},
 			pricing.RateCard{
 				Base: pricing.NewRates(30.00, 150.00, 3.00).
 					WithCacheCreation(37.50, 60.00, 0),
-				Brackets: []pricing.Bracket{{
-					// >200K long-context surcharge on fast-mode rates.
-					MinContextTokens: 200_001,
-					Rates:            pricing.NewRates(60.00, 225.00, 6.00).WithCacheCreation(75.00, 120.00, 0),
-				}},
 			},
 		),
 	},

--- a/providers/anthropic/options.go
+++ b/providers/anthropic/options.go
@@ -94,8 +94,8 @@ func WithTopP(topP float64) Option {
 			return fmt.Errorf("%s: %w", cfg.ModelName, err)
 		}
 
-		if topP < 0 || topP > 1 {
-			return fmt.Errorf("%s: top_p must be 0.0-1.0, got %f", cfg.ModelName, topP)
+		if err = cfg.Constraints.ValidateTopP(topP); err != nil {
+			return fmt.Errorf("%s: %w", cfg.ModelName, err)
 		}
 
 		cfg.setOptions["top_p"] = true

--- a/providers/anthropic/pricing_context_test.go
+++ b/providers/anthropic/pricing_context_test.go
@@ -35,12 +35,14 @@ func TestNative1MModelsStayFlatAcrossContextWindow(t *testing.T) {
 		ModelClaudeOpus46,
 		ModelClaudeOpus47,
 		ModelClaudeOpus48,
+		ModelClaudeSonnet46,
 		ModelClaudeSonnet5,
 	} {
 		t.Run(id, func(t *testing.T) {
 			t.Parallel()
 
-			def := supportedModels[id]
+			def, ok := supportedModels[id]
+			require.True(t, ok, "native 1M model %s must remain registered", id)
 			assert.Emptyf(t, def.Pricing.Default.Brackets,
 				"native 1M model %s must stay flat across its full context window", id)
 

--- a/providers/anthropic/pricing_context_test.go
+++ b/providers/anthropic/pricing_context_test.go
@@ -64,6 +64,7 @@ func TestNative1MContextPricingStaysFlatEndToEnd(t *testing.T) {
 	usage := &llm.TokenUsage{InputTokens: 100_000, OutputTokens: 1_000}
 
 	totals := make([]int64, 0, 2)
+
 	for _, req := range []pricing.CalcRequest{
 		{},
 		{Selector: pricing.Selector{Speed: SpeedFast}},

--- a/providers/anthropic/pricing_context_test.go
+++ b/providers/anthropic/pricing_context_test.go
@@ -25,19 +25,24 @@ import (
 	"github.com/redpanda-data/ai-sdk-go/pricing"
 )
 
-// TestAllModelsStayFlatAcrossContextWindow guards Anthropic's current pricing
-// contract: every cataloged model is billed at its base rate across its full
-// advertised context window. Claude 4.6 and later include the native 1M window
-// without the legacy >200K premium.
-func TestAllModelsStayFlatAcrossContextWindow(t *testing.T) {
+// TestNative1MModelsStayFlatAcrossContextWindow guards the models Anthropic
+// currently documents as flat across their native 1M context windows.
+func TestNative1MModelsStayFlatAcrossContextWindow(t *testing.T) {
 	t.Parallel()
 
-	for id, def := range supportedModels {
+	for _, id := range []string{
+		ModelClaudeFable5,
+		ModelClaudeOpus46,
+		ModelClaudeOpus47,
+		ModelClaudeOpus48,
+		ModelClaudeSonnet5,
+	} {
 		t.Run(id, func(t *testing.T) {
 			t.Parallel()
 
+			def := supportedModels[id]
 			assert.Emptyf(t, def.Pricing.Default.Brackets,
-				"model %s must stay flat across its full context window", id)
+				"native 1M model %s must stay flat across its full context window", id)
 
 			for _, ov := range def.Pricing.Overrides {
 				assert.Emptyf(t, ov.RateCard.Brackets,
@@ -58,6 +63,7 @@ func TestNative1MContextPricingStaysFlatEndToEnd(t *testing.T) {
 
 	usage := &llm.TokenUsage{InputTokens: 100_000, OutputTokens: 1_000}
 
+	totals := make([]int64, 0, 2)
 	for _, req := range []pricing.CalcRequest{
 		{},
 		{Selector: pricing.Selector{Speed: SpeedFast}},
@@ -78,5 +84,9 @@ func TestNative1MContextPricingStaysFlatEndToEnd(t *testing.T) {
 			"identical usage must cost the same across the native 1M window")
 		assert.Equal(t, below.Breakdown, above.Breakdown,
 			"rate breakdown must stay unchanged across the native 1M window")
+		totals = append(totals, above.Total)
 	}
+
+	require.Len(t, totals, 2)
+	assert.Greater(t, totals[1], totals[0], "fast selector must use the premium rate card")
 }

--- a/providers/anthropic/pricing_context_test.go
+++ b/providers/anthropic/pricing_context_test.go
@@ -55,6 +55,21 @@ func TestNative1MModelsStayFlatAcrossContextWindow(t *testing.T) {
 	}
 }
 
+func TestNativeCatalogHasNoContextBrackets(t *testing.T) {
+	t.Parallel()
+
+	for id, def := range supportedModels {
+		assert.Emptyf(t, def.Pricing.Default.Brackets,
+			"native model %s must not have a context pricing bracket", id)
+
+		for _, ov := range def.Pricing.Overrides {
+			assert.Emptyf(t, ov.RateCard.Brackets,
+				"model %s override %s must not have a context pricing bracket",
+				id, fmt.Sprintf("%+v", ov.Match))
+		}
+	}
+}
+
 // TestNative1MContextPricingStaysFlatEndToEnd proves a large Opus 4.8 request
 // uses the same rate card as a small request, including fast mode.
 func TestNative1MContextPricingStaysFlatEndToEnd(t *testing.T) {

--- a/providers/anthropic/pricing_longcontext_test.go
+++ b/providers/anthropic/pricing_longcontext_test.go
@@ -25,86 +25,32 @@ import (
 	"github.com/redpanda-data/ai-sdk-go/pricing"
 )
 
-// longContextThreshold is the inclusive lower bound of Anthropic's >200K
-// long-context pricing tier, mirrored from the catalog entries.
-const longContextThreshold = 200_001
-
-// TestLongContextBracketsMatchSurcharge verifies that every 1M-window model
-// prices requests above 200K tokens at Anthropic's published long-context
-// surcharge, on every rate card (default and each speed/region override):
-//
-//	input  = 2x base
-//	output = 1.5x base
-//	cache reads and writes = 2x base
-//
-// This surcharge is confirmed against Anthropic's Sonnet 1M pricing
-// ($3/$15 -> $6/$22.50 above 200K) and community catalogs (LiteLLM's
-// *_above_200k_tokens fields for claude-sonnet-4/4.5/4.6). Any 1M model that
-// under-reports large-request cost by staying on flat rates fails here.
-func TestLongContextBracketsMatchSurcharge(t *testing.T) {
+// TestAllModelsStayFlatAcrossContextWindow guards Anthropic's current pricing
+// contract: every cataloged model is billed at its base rate across its full
+// advertised context window. Claude 4.6 and later include the native 1M window
+// without the legacy >200K premium.
+func TestAllModelsStayFlatAcrossContextWindow(t *testing.T) {
 	t.Parallel()
 
 	for id, def := range supportedModels {
-		if def.Constraints.MaxInputTokens < 1_000_000 {
-			continue
-		}
-
-		t.Run(id, func(t *testing.T) {
-			t.Parallel()
-
-			type namedCard struct {
-				name string
-				card pricing.RateCard
-			}
-
-			cards := make([]namedCard, 0, 1+len(def.Pricing.Overrides))
-			cards = append(cards, namedCard{"default", def.Pricing.Default})
-
-			for _, ov := range def.Pricing.Overrides {
-				cards = append(cards, namedCard{fmt.Sprintf("%+v", ov.Match), ov.RateCard})
-			}
-
-			for _, c := range cards {
-				bracket := findBracket(c.card.Brackets, longContextThreshold)
-				require.NotNilf(t, bracket,
-					"%s card of 1M model %s has no >200K bracket — large requests under-report cost", c.name, id)
-
-				assertSurcharge(t, c.name, c.card.Base, bracket.Rates)
-			}
-		})
-	}
-}
-
-// TestNonLongContextModelsStayFlat guards the inverse: 200K models must not
-// grow a context bracket, which would silently overcharge above 200K.
-func TestNonLongContextModelsStayFlat(t *testing.T) {
-	t.Parallel()
-
-	for id, def := range supportedModels {
-		if def.Constraints.MaxInputTokens >= 1_000_000 {
-			continue
-		}
-
 		t.Run(id, func(t *testing.T) {
 			t.Parallel()
 
 			assert.Emptyf(t, def.Pricing.Default.Brackets,
-				"200K model %s must not have context brackets", id)
+				"model %s must stay flat across its full context window", id)
 
 			for _, ov := range def.Pricing.Overrides {
 				assert.Emptyf(t, ov.RateCard.Brackets,
-					"200K model %s override %s must not have context brackets", id, fmt.Sprintf("%+v", ov.Match))
+					"model %s override %s must stay flat across its full context window",
+					id, fmt.Sprintf("%+v", ov.Match))
 			}
 		})
 	}
 }
 
-// TestLongContextPricingAppliesEndToEnd drives a real Catalog built from the
-// Anthropic model pricing and proves the >200K bracket actually fires: the same
-// token usage costs 2x on input when the request context crosses 200K, and the
-// applied bracket threshold is reported. This closes the loop from catalog entry
-// to computed cost.
-func TestLongContextPricingAppliesEndToEnd(t *testing.T) {
+// TestNative1MContextPricingStaysFlatEndToEnd proves a large Opus 4.8 request
+// uses the same rate card as a small request, including fast mode.
+func TestNative1MContextPricingStaysFlatEndToEnd(t *testing.T) {
 	t.Parallel()
 
 	cat, err := pricing.NewCatalog(pricing.WithProvider("anthropic", ModelPricing()))
@@ -112,45 +58,25 @@ func TestLongContextPricingAppliesEndToEnd(t *testing.T) {
 
 	usage := &llm.TokenUsage{InputTokens: 100_000, OutputTokens: 1_000}
 
-	below, err := cat.Calculate(ModelClaudeSonnet5, usage, pricing.CalcRequest{ContextTokens: 100_000})
-	require.NoError(t, err)
+	for _, req := range []pricing.CalcRequest{
+		{},
+		{Selector: pricing.Selector{Speed: SpeedFast}},
+	} {
+		belowReq := req
+		belowReq.ContextTokens = 100_000
+		below, err := cat.Calculate(ModelClaudeOpus48, usage, belowReq)
+		require.NoError(t, err)
 
-	above, err := cat.Calculate(ModelClaudeSonnet5, usage, pricing.CalcRequest{ContextTokens: 300_000})
-	require.NoError(t, err)
+		aboveReq := req
+		aboveReq.ContextTokens = 900_000
+		above, err := cat.Calculate(ModelClaudeOpus48, usage, aboveReq)
+		require.NoError(t, err)
 
-	assert.Equal(t, int64(0), below.AppliedBracketMinContextTokens,
-		"a sub-200K request must price on the base card")
-	assert.Equal(t, int64(longContextThreshold), above.AppliedBracketMinContextTokens,
-		"a >200K request must price on the long-context bracket")
-
-	assert.Equal(t,
-		below.Breakdown[pricing.UsageFieldInput]*2, above.Breakdown[pricing.UsageFieldInput],
-		"input above 200K must cost 2x the base rate for identical usage")
-	assert.Greater(t, above.Total, below.Total,
-		"the long-context request must cost more overall")
-}
-
-func findBracket(brackets []pricing.Bracket, minContext int64) *pricing.Bracket {
-	for i := range brackets {
-		if brackets[i].MinContextTokens == minContext {
-			return &brackets[i]
-		}
+		assert.Equal(t, int64(0), below.AppliedBracketMinContextTokens)
+		assert.Equal(t, int64(0), above.AppliedBracketMinContextTokens)
+		assert.Equal(t, below.Total, above.Total,
+			"identical usage must cost the same across the native 1M window")
+		assert.Equal(t, below.Breakdown, above.Breakdown,
+			"rate breakdown must stay unchanged across the native 1M window")
 	}
-
-	return nil
-}
-
-func assertSurcharge(t *testing.T, card string, base, got pricing.Rates) {
-	t.Helper()
-
-	assert.Equalf(t, base.InputPerMillion*2, got.InputPerMillion,
-		"%s: input above 200K must be 2x base", card)
-	assert.Equalf(t, base.OutputPerMillion*3/2, got.OutputPerMillion,
-		"%s: output above 200K must be 1.5x base", card)
-	assert.Equalf(t, base.CachedInputPerMillion*2, got.CachedInputPerMillion,
-		"%s: cache read above 200K must be 2x base", card)
-	assert.Equalf(t, base.CacheCreation5mPerMillion*2, got.CacheCreation5mPerMillion,
-		"%s: 5m cache write above 200K must be 2x base", card)
-	assert.Equalf(t, base.CacheCreation1hPerMillion*2, got.CacheCreation1hPerMillion,
-		"%s: 1h cache write above 200K must be 2x base", card)
 }

--- a/providers/anthropic/response_mapper_test.go
+++ b/providers/anthropic/response_mapper_test.go
@@ -27,11 +27,11 @@ import (
 func TestResponseMapper_Metadata(t *testing.T) {
 	t.Parallel()
 
-	mapper := NewResponseMapper(supportedModels[ModelClaudeOpus46])
+	mapper := NewResponseMapper(supportedModels[ModelClaudeOpus48])
 
 	resp, err := mapper.FromProvider(&anthropic.BetaMessage{
 		ID:    "msg_123",
-		Model: anthropic.Model("claude-opus-4-6-20260401"),
+		Model: anthropic.Model(ModelClaudeOpus48),
 		Content: []anthropic.BetaContentBlockUnion{{
 			Type: blockTypeText,
 			Text: "Hello",
@@ -50,7 +50,7 @@ func TestResponseMapper_Metadata(t *testing.T) {
 	assert.Equal(t, llm.ServiceTierDefault, resp.ServiceTier)
 	assert.Equal(t, llm.SpeedFast, resp.Speed)
 	assert.Equal(t, "us-east-1", resp.InferenceRegion)
-	assert.Equal(t, ModelClaudeOpus46, resp.InvokedModelID)
+	assert.Equal(t, ModelClaudeOpus48, resp.InvokedModelID)
 }
 
 // TestResponseMapper_FinishReasonTruncationWithToolCalls locks in the rule

--- a/providers/bedrock/cross_region.go
+++ b/providers/bedrock/cross_region.go
@@ -19,11 +19,10 @@ import "strings"
 // IsModelAllowedFromRegion reports whether invoking modelID from awsRegion
 // crosses a Bedrock inference-profile geography boundary.
 //
-// Bedrock geo inference profiles (us./eu./au./jp.) only accept source regions
-// in the same geography. The "global." profile is unrestricted, and bare
-// model IDs (no profile prefix) defer to AWS in-region availability. This
-// function returns false only for the cross-geography case — e.g. "eu.*"
-// invoked from us-east-1, or "jp.*" invoked from eu-west-1.
+// Bedrock geo inference profiles (us./eu./au./jp.) accept only the source
+// regions listed on each model card. The "global." profile is unrestricted
+// outside GovCloud, and bare model IDs (no profile prefix) defer to AWS
+// in-region availability.
 //
 // Unknown regions and regions that AWS lists as global-only (no Geo profile
 // at all, e.g. me-central-1, sa-east-1) cause any prefixed call other than
@@ -45,6 +44,13 @@ func IsModelAllowedFromRegion(modelID, awsRegion string) bool {
 	}
 
 	prefix, _, _ := strings.Cut(modelID, ".")
+
+	// The Sonnet 4.5 US profile is the only current Claude profile published
+	// for GovCloud source regions. Global routing is not available there.
+	if strings.HasPrefix(awsRegion, "us-gov-") {
+		return modelID == ModelClaudeSonnet45US
+	}
+
 	if prefix == "global" {
 		return true
 	}
@@ -54,6 +60,8 @@ func IsModelAllowedFromRegion(modelID, awsRegion string) bool {
 	switch modelID {
 	case ModelClaudeOpus47AU, ModelClaudeOpus48AU:
 		return awsRegion == "ap-southeast-2" || awsRegion == "ap-southeast-4"
+	case ModelClaudeHaiku45US, ModelClaudeOpus45US:
+		return awsRegion != "ca-west-1" && prefix == sourceRegionGeoPrefix(awsRegion)
 	}
 
 	return prefix == sourceRegionGeoPrefix(awsRegion)
@@ -70,13 +78,9 @@ func IsModelAllowedFromRegion(modelID, awsRegion string) bool {
 //   - https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-opus-4-7.html
 //   - https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-opus-4-8.html
 //   - https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-haiku-4-5.html
+//   - https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-sonnet-4-5.html
+//   - https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-opus-4-5.html
 func sourceRegionGeoPrefix(awsRegion string) string {
-	// GovCloud profile availability is model-specific, so the default bare-ID
-	// resolver does not infer a profile there.
-	if strings.HasPrefix(awsRegion, "us-gov-") {
-		return ""
-	}
-
 	// Regions where the geo doesn't match the AWS region prefix —
 	// Canada is part of the US Geo, ap-northeast-* maps to JP, and a
 	// subset of ap-southeast-* maps to AU.
@@ -89,7 +93,7 @@ func sourceRegionGeoPrefix(awsRegion string) string {
 		return "au"
 	}
 
-	// Commercial us-* and eu-* regions line up with their region prefix.
+	// US (including GovCloud) and EU regions line up with their region prefix.
 	idx := strings.IndexByte(awsRegion, '-')
 	if idx <= 0 {
 		return ""

--- a/providers/bedrock/cross_region.go
+++ b/providers/bedrock/cross_region.go
@@ -54,13 +54,11 @@ func IsModelAllowedFromRegion(modelID, awsRegion string) bool {
 
 // sourceRegionGeoPrefix returns the geo-inference-profile prefix that AWS
 // accepts when calling from awsRegion (e.g. "us-east-1" → "us",
-// "ap-northeast-1" → "jp", "ap-southeast-2" → "au"). Returns "" for regions
-// that have no Geo profile assignment (global-only) or that the SDK does not
-// recognise.
+// "ap-northeast-1" → "jp", "ap-southeast-2" → "au"). It returns "global"
+// for known global-only regions and "" for regions the SDK does not recognize.
 //
-// Source: per-model regional availability tables on the Anthropic Claude
-// model cards in the Bedrock user guide. As of 2026-05 every Claude model
-// uses the same source-region → geo assignments, so a single table is enough.
+// This is the default profile family used for bare-ID resolution. Individual
+// model cards may narrow availability within a geography.
 func sourceRegionGeoPrefix(awsRegion string) string {
 	// Regions where the geo doesn't match the AWS region prefix —
 	// Canada is part of the US Geo, ap-northeast-* maps to JP, and a
@@ -83,10 +81,11 @@ func sourceRegionGeoPrefix(awsRegion string) string {
 	switch awsRegion[:idx] {
 	case "us", "eu":
 		return awsRegion[:idx]
+	case "ap", "il", "me", "af", "sa", "mx":
+		// Remaining listed regions have no default Geo assignment.
+		return "global"
 	}
 
-	// Everything else is global-only as far as Claude on Bedrock is
-	// concerned (ap-east-2, ap-northeast-2, ap-south-*, ap-southeast-1/3/5/7,
-	// il-*, me-*, af-*, sa-*, mx-*).
+	// Unknown region.
 	return ""
 }

--- a/providers/bedrock/cross_region.go
+++ b/providers/bedrock/cross_region.go
@@ -21,14 +21,13 @@ import "strings"
 //
 // Bedrock geo inference profiles (us./eu./au./jp.) accept only the source
 // regions listed on each model card. The "global." profile is unrestricted
-// outside GovCloud, and bare model IDs (no profile prefix) defer to AWS
+// outside GovCloud and China, and bare model IDs (no profile prefix) defer to AWS
 // in-region availability.
 //
-// Unknown regions and regions that AWS lists as global-only (no Geo profile
-// at all, e.g. me-central-1, sa-east-1) cause any prefixed call other than
-// "global." to be rejected — the SDK has no way to know whether AWS would
-// route the call, so we err on the side of failing fast rather than letting
-// the request reach AWS just to be rejected there.
+// Unknown regions and regions that AWS lists as global-only (no Geo profile at
+// all, e.g. me-central-1, sa-east-1) reject geo-prefixed calls but permit
+// "global.". China rejects every profile because Bedrock does not publish
+// Claude there. The SDK errs on the side of failing before an AWS API call.
 //
 // Examples:
 //
@@ -37,6 +36,7 @@ import "strings"
 //	IsModelAllowedFromRegion("us.anthropic.claude-sonnet-4-6", "ca-central-1") → true
 //	IsModelAllowedFromRegion("jp.anthropic.claude-sonnet-4-5-…", "ap-northeast-1") → true
 //	IsModelAllowedFromRegion("global.anthropic.claude-opus-4-6-v1", "me-central-1") → true
+//	IsModelAllowedFromRegion("global.anthropic.claude-sonnet-4-6", "cn-north-1") → false
 //	IsModelAllowedFromRegion("anthropic.claude-sonnet-4-6", "us-east-1") → true (bare)
 func IsModelAllowedFromRegion(modelID, awsRegion string) bool {
 	if !hasRegionPrefix(modelID) {

--- a/providers/bedrock/cross_region.go
+++ b/providers/bedrock/cross_region.go
@@ -49,6 +49,13 @@ func IsModelAllowedFromRegion(modelID, awsRegion string) bool {
 		return true
 	}
 
+	// Opus 4.7 and 4.8 narrow the AU profile to Sydney and Melbourne.
+	// Their model cards list New Zealand as global-only.
+	switch modelID {
+	case ModelClaudeOpus47AU, ModelClaudeOpus48AU:
+		return awsRegion == "ap-southeast-2" || awsRegion == "ap-southeast-4"
+	}
+
 	return prefix == sourceRegionGeoPrefix(awsRegion)
 }
 
@@ -58,9 +65,14 @@ func IsModelAllowedFromRegion(modelID, awsRegion string) bool {
 // for known global-only regions and "" for regions the SDK does not recognize.
 //
 // This is the default profile family used for bare-ID resolution. Individual
-// model cards may narrow availability within a geography.
+// model cards may narrow availability within a geography:
+//   - https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-sonnet-4-6.html
+//   - https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-opus-4-7.html
+//   - https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-opus-4-8.html
+//   - https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-haiku-4-5.html
 func sourceRegionGeoPrefix(awsRegion string) string {
-	// Bedrock does not publish these Claude inference profiles in GovCloud.
+	// GovCloud profile availability is model-specific, so the default bare-ID
+	// resolver does not infer a profile there.
 	if strings.HasPrefix(awsRegion, "us-gov-") {
 		return ""
 	}

--- a/providers/bedrock/cross_region.go
+++ b/providers/bedrock/cross_region.go
@@ -16,6 +16,12 @@ package bedrock
 
 import "strings"
 
+const (
+	awsRegionCalgary   = "ca-west-1"
+	awsRegionMelbourne = "ap-southeast-4"
+	awsRegionSydney    = "ap-southeast-2"
+)
+
 // IsModelAllowedFromRegion reports whether invoking modelID from awsRegion
 // crosses a Bedrock inference-profile geography boundary.
 //
@@ -45,16 +51,20 @@ func IsModelAllowedFromRegion(modelID, awsRegion string) bool {
 
 	prefix, _, _ := strings.Cut(modelID, ".")
 
-	// The Sonnet 4.5 US profile is the only current Claude profile published
-	// for GovCloud in its source-region table. The Opus 4.8 card's summary
-	// claims GovCloud support but its source table omits both GovCloud regions,
-	// so use the stricter source-table interpretation. Global is unavailable.
+	// Sonnet 4.5 US is the only current catalog profile whose source-region
+	// table publishes GovCloud. The Opus 4.8 card's summary claims GovCloud
+	// support but its source table omits both regions, so use the stricter
+	// source-table interpretation. Global is unavailable.
 	if strings.HasPrefix(awsRegion, "us-gov-") {
 		return modelID == ModelClaudeSonnet45US
 	}
 
 	if strings.HasPrefix(awsRegion, "cn-") {
 		return false
+	}
+
+	if allowed, constrained := isNova2LiteSourceRegion(modelID, awsRegion); constrained {
+		return allowed
 	}
 
 	if prefix == "global" {
@@ -65,9 +75,10 @@ func IsModelAllowedFromRegion(modelID, awsRegion string) bool {
 	// Their model cards list New Zealand as global-only.
 	switch modelID {
 	case ModelClaudeOpus47AU, ModelClaudeOpus48AU:
-		return awsRegion == "ap-southeast-2" || awsRegion == "ap-southeast-4"
+		return awsRegion == awsRegionSydney || awsRegion == awsRegionMelbourne
 	case ModelClaudeHaiku45US, ModelClaudeOpus45US, ModelClaudeSonnet45US:
-		return awsRegion != "ca-west-1" && prefix == sourceRegionGeoPrefix(awsRegion)
+		// These cards mark Calgary Geo unsupported and omit it from Geo: US.
+		return awsRegion != awsRegionCalgary && prefix == sourceRegionGeoPrefix(awsRegion)
 	}
 
 	return prefix == sourceRegionGeoPrefix(awsRegion)
@@ -86,16 +97,17 @@ func IsModelAllowedFromRegion(modelID, awsRegion string) bool {
 //   - https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-haiku-4-5.html
 //   - https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-sonnet-4-5.html
 //   - https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-opus-4-5.html
+//   - https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-amazon-nova-2-lite.html
 func sourceRegionGeoPrefix(awsRegion string) string {
 	// Regions where the geo doesn't match the AWS region prefix —
 	// Canada is part of the US Geo, ap-northeast-* maps to JP, and a
 	// subset of ap-southeast-* maps to AU.
 	switch awsRegion {
-	case "ca-central-1", "ca-west-1":
+	case "ca-central-1", awsRegionCalgary:
 		return "us"
 	case "ap-northeast-1", "ap-northeast-3":
 		return "jp"
-	case "ap-southeast-2", "ap-southeast-4", "ap-southeast-6":
+	case awsRegionSydney, awsRegionMelbourne, "ap-southeast-6":
 		return "au"
 	}
 
@@ -115,4 +127,36 @@ func sourceRegionGeoPrefix(awsRegion string) string {
 
 	// Unknown region.
 	return ""
+}
+
+// isNova2LiteSourceRegion applies Nova 2 Lite's narrower published source
+// tables. It returns constrained=false for every other model.
+func isNova2LiteSourceRegion(modelID, awsRegion string) (bool, bool) {
+	switch modelID {
+	case ModelNova2LiteEU:
+		switch awsRegion {
+		case "eu-central-1", "eu-north-1", "eu-south-1", "eu-south-2", "eu-west-1", "eu-west-3":
+			return true, true
+		default:
+			return false, true
+		}
+	case ModelNova2LiteJP:
+		return awsRegion == "ap-northeast-1", true
+	case ModelNova2LiteGlobal:
+		switch awsRegion {
+		case "us-east-1", "us-east-2", "us-west-1", "us-west-2",
+			"ca-central-1", awsRegionCalgary,
+			"eu-central-1", "eu-north-1", "eu-south-1", "eu-south-2",
+			"eu-west-1", "eu-west-2", "eu-west-3",
+			"il-central-1", "me-central-1",
+			"ap-east-2", "ap-northeast-1", "ap-northeast-2", "ap-south-1",
+			"ap-southeast-1", awsRegionSydney, "ap-southeast-3",
+			awsRegionMelbourne, "ap-southeast-5", "ap-southeast-6", "ap-southeast-7":
+			return true, true
+		default:
+			return false, true
+		}
+	default:
+		return false, false
+	}
 }

--- a/providers/bedrock/cross_region.go
+++ b/providers/bedrock/cross_region.go
@@ -46,9 +46,15 @@ func IsModelAllowedFromRegion(modelID, awsRegion string) bool {
 	prefix, _, _ := strings.Cut(modelID, ".")
 
 	// The Sonnet 4.5 US profile is the only current Claude profile published
-	// for GovCloud source regions. Global routing is not available there.
+	// for GovCloud in its source-region table. The Opus 4.8 card's summary
+	// claims GovCloud support but its source table omits both GovCloud regions,
+	// so use the stricter source-table interpretation. Global is unavailable.
 	if strings.HasPrefix(awsRegion, "us-gov-") {
 		return modelID == ModelClaudeSonnet45US
+	}
+
+	if strings.HasPrefix(awsRegion, "cn-") {
+		return false
 	}
 
 	if prefix == "global" {
@@ -60,7 +66,7 @@ func IsModelAllowedFromRegion(modelID, awsRegion string) bool {
 	switch modelID {
 	case ModelClaudeOpus47AU, ModelClaudeOpus48AU:
 		return awsRegion == "ap-southeast-2" || awsRegion == "ap-southeast-4"
-	case ModelClaudeHaiku45US, ModelClaudeOpus45US:
+	case ModelClaudeHaiku45US, ModelClaudeOpus45US, ModelClaudeSonnet45US:
 		return awsRegion != "ca-west-1" && prefix == sourceRegionGeoPrefix(awsRegion)
 	}
 

--- a/providers/bedrock/cross_region.go
+++ b/providers/bedrock/cross_region.go
@@ -26,14 +26,15 @@ const (
 // crosses a Bedrock inference-profile geography boundary.
 //
 // Bedrock geo inference profiles (us./eu./au./jp.) accept only the source
-// regions listed on each model card. The "global." profile is unrestricted
-// outside GovCloud and China, and bare model IDs (no profile prefix) defer to AWS
-// in-region availability.
+// regions listed on each model card. Global profiles are generally broad, but
+// a model card may narrow their source regions too. Bare model IDs (no profile
+// prefix) defer to AWS in-region availability.
 //
 // Unknown regions and regions that AWS lists as global-only (no Geo profile at
-// all, e.g. me-central-1, sa-east-1) reject geo-prefixed calls but permit
-// "global.". China rejects every profile because Bedrock does not publish
-// Claude there. The SDK errs on the side of failing before an AWS API call.
+// all, e.g. me-central-1, sa-east-1) reject geo-prefixed calls. A published
+// global profile is allowed unless its model card narrows the source table.
+// China rejects every profile because Bedrock does not publish Claude there.
+// The SDK errs on the side of failing before an AWS API call.
 //
 // Examples:
 //

--- a/providers/bedrock/cross_region.go
+++ b/providers/bedrock/cross_region.go
@@ -60,6 +60,11 @@ func IsModelAllowedFromRegion(modelID, awsRegion string) bool {
 // This is the default profile family used for bare-ID resolution. Individual
 // model cards may narrow availability within a geography.
 func sourceRegionGeoPrefix(awsRegion string) string {
+	// Bedrock does not publish these Claude inference profiles in GovCloud.
+	if strings.HasPrefix(awsRegion, "us-gov-") {
+		return ""
+	}
+
 	// Regions where the geo doesn't match the AWS region prefix —
 	// Canada is part of the US Geo, ap-northeast-* maps to JP, and a
 	// subset of ap-southeast-* maps to AU.
@@ -72,7 +77,7 @@ func sourceRegionGeoPrefix(awsRegion string) string {
 		return "au"
 	}
 
-	// us-* (incl. us-gov-*) and eu-* line up with their region prefix.
+	// Commercial us-* and eu-* regions line up with their region prefix.
 	idx := strings.IndexByte(awsRegion, '-')
 	if idx <= 0 {
 		return ""

--- a/providers/bedrock/cross_region_test.go
+++ b/providers/bedrock/cross_region_test.go
@@ -50,6 +50,8 @@ func TestIsModelAllowedFromRegion(t *testing.T) {
 		{"us from us-west-2", ModelClaudeSonnet46US, "us-west-2", true},
 		{"us from ca-central-1 (Canada is US Geo)", ModelClaudeSonnet46US, "ca-central-1", true},
 		{"us from ca-west-1 (Calgary is US Geo)", ModelClaudeOpus46US, "ca-west-1", true},
+		{"Haiku 4.5 US from Calgary", ModelClaudeHaiku45US, "ca-west-1", false},
+		{"Opus 4.5 US from Calgary", ModelClaudeOpus45US, "ca-west-1", false},
 		{"eu from eu-west-1", ModelClaudeSonnet46EU, "eu-west-1", true},
 		{"eu from eu-central-2", ModelClaudeSonnet46EU, "eu-central-2", true},
 		{"jp from ap-northeast-1 (Tokyo)", ModelClaudeSonnet45JP, "ap-northeast-1", true},
@@ -93,7 +95,9 @@ func TestIsModelAllowedFromRegion(t *testing.T) {
 		// Unknown region — any geo prefix is rejected (we don't know what
 		// AWS would do, so fail fast).
 		{"us from unknown region", ModelClaudeSonnet46US, "xx-fake-1", false},
-		{"us from GovCloud", ModelClaudeSonnet45US, "us-gov-east-1", false},
+		{"Sonnet 4.5 US from GovCloud", ModelClaudeSonnet45US, "us-gov-east-1", true},
+		{"Opus 4.8 US from GovCloud", ModelClaudeOpus48US, "us-gov-east-1", false},
+		{"global from GovCloud", ModelClaudeSonnet45Global, "us-gov-east-1", false},
 		{"global from unknown region", ModelClaudeSonnet46Global, "xx-fake-1", true},
 		{"bare from unknown region (allowed)", ModelClaudeSonnet45, "xx-fake-1", true},
 

--- a/providers/bedrock/cross_region_test.go
+++ b/providers/bedrock/cross_region_test.go
@@ -48,7 +48,6 @@ func TestIsModelAllowedFromRegion(t *testing.T) {
 		// Matching geo — allowed.
 		{"us from us-east-1", ModelClaudeSonnet46US, "us-east-1", true},
 		{"us from us-west-2", ModelClaudeSonnet46US, "us-west-2", true},
-		{"us from us-gov-east-1", ModelClaudeSonnet45US, "us-gov-east-1", true},
 		{"us from ca-central-1 (Canada is US Geo)", ModelClaudeSonnet46US, "ca-central-1", true},
 		{"us from ca-west-1 (Calgary is US Geo)", ModelClaudeOpus46US, "ca-west-1", true},
 		{"eu from eu-west-1", ModelClaudeSonnet46EU, "eu-west-1", true},
@@ -92,6 +91,7 @@ func TestIsModelAllowedFromRegion(t *testing.T) {
 		// Unknown region — any geo prefix is rejected (we don't know what
 		// AWS would do, so fail fast).
 		{"us from unknown region", ModelClaudeSonnet46US, "xx-fake-1", false},
+		{"us from GovCloud", ModelClaudeSonnet45US, "us-gov-east-1", false},
 		{"global from unknown region", ModelClaudeSonnet46Global, "xx-fake-1", true},
 		{"bare from unknown region (allowed)", ModelClaudeSonnet45, "xx-fake-1", true},
 

--- a/providers/bedrock/cross_region_test.go
+++ b/providers/bedrock/cross_region_test.go
@@ -39,7 +39,7 @@ func TestIsModelAllowedFromRegion(t *testing.T) {
 		{"sonnet5 us from eu-west-1 (cross-geo)", ModelClaudeSonnet5US, "eu-west-1", false},
 		{"sonnet5 global from me-central-1", ModelClaudeSonnet5Global, "me-central-1", true},
 
-		// global.* is always allowed.
+		// Published global source regions are allowed.
 		{"global from us", ModelClaudeSonnet46Global, "us-east-1", true},
 		{"global from eu", ModelClaudeSonnet46Global, "eu-west-1", true},
 		{"global from me-central-1", ModelClaudeOpus46Global, "me-central-1", true},
@@ -69,7 +69,11 @@ func TestIsModelAllowedFromRegion(t *testing.T) {
 		{"nova2 bare from us", ModelNova2Lite, "us-east-1", true},
 		{"nova2 us from us-east-1", ModelNova2LiteUS, "us-east-1", true},
 		{"nova2 eu from eu-west-1", ModelNova2LiteEU, "eu-west-1", true},
+		{"nova2 eu from eu-west-2 (London)", ModelNova2LiteEU, "eu-west-2", false},
+		{"nova2 eu from eu-central-2 (Zurich)", ModelNova2LiteEU, "eu-central-2", false},
 		{"nova2 jp from ap-northeast-1 (Tokyo)", ModelNova2LiteJP, "ap-northeast-1", true},
+		{"nova2 jp from ap-northeast-3 (Osaka)", ModelNova2LiteJP, "ap-northeast-3", false},
+		{"nova2 global from ap-northeast-3 (Osaka)", ModelNova2LiteGlobal, "ap-northeast-3", false},
 		{"nova2 global from me-central-1", ModelNova2LiteGlobal, "me-central-1", true},
 		{"nova2 us from eu-west-1 (cross-geo)", ModelNova2LiteUS, "eu-west-1", false},
 		{"nova2 eu from us-east-1 (cross-geo)", ModelNova2LiteEU, "us-east-1", false},

--- a/providers/bedrock/cross_region_test.go
+++ b/providers/bedrock/cross_region_test.go
@@ -63,9 +63,8 @@ func TestIsModelAllowedFromRegion(t *testing.T) {
 		{"Opus 4.7 AU from New Zealand", ModelClaudeOpus47AU, "ap-southeast-6", false},
 		{"Opus 4.8 AU from New Zealand", ModelClaudeOpus48AU, "ap-southeast-6", false},
 
-		// Amazon Nova 2 Lite — same prefix-based routing as Claude (us/eu/jp
-		// geo profiles + global). Confirms the amazon. namespace routes like
-		// anthropic.
+		// Amazon Nova 2 Lite recognizes us/eu/jp/global prefixes, but its
+		// model card narrows the EU, JP, and global source-region tables.
 		{"nova2 bare from us", ModelNova2Lite, "us-east-1", true},
 		{"nova2 us from us-east-1", ModelNova2LiteUS, "us-east-1", true},
 		{"nova2 eu from eu-west-1", ModelNova2LiteEU, "eu-west-1", true},

--- a/providers/bedrock/cross_region_test.go
+++ b/providers/bedrock/cross_region_test.go
@@ -52,6 +52,7 @@ func TestIsModelAllowedFromRegion(t *testing.T) {
 		{"us from ca-west-1 (Calgary is US Geo)", ModelClaudeOpus46US, "ca-west-1", true},
 		{"Haiku 4.5 US from Calgary", ModelClaudeHaiku45US, "ca-west-1", false},
 		{"Opus 4.5 US from Calgary", ModelClaudeOpus45US, "ca-west-1", false},
+		{"Sonnet 4.5 US from Calgary", ModelClaudeSonnet45US, "ca-west-1", false},
 		{"eu from eu-west-1", ModelClaudeSonnet46EU, "eu-west-1", true},
 		{"eu from eu-central-2", ModelClaudeSonnet46EU, "eu-central-2", true},
 		{"jp from ap-northeast-1 (Tokyo)", ModelClaudeSonnet45JP, "ap-northeast-1", true},
@@ -98,6 +99,7 @@ func TestIsModelAllowedFromRegion(t *testing.T) {
 		{"Sonnet 4.5 US from GovCloud", ModelClaudeSonnet45US, "us-gov-east-1", true},
 		{"Opus 4.8 US from GovCloud", ModelClaudeOpus48US, "us-gov-east-1", false},
 		{"global from GovCloud", ModelClaudeSonnet45Global, "us-gov-east-1", false},
+		{"global from China", ModelClaudeSonnet46Global, "cn-north-1", false},
 		{"global from unknown region", ModelClaudeSonnet46Global, "xx-fake-1", true},
 		{"bare from unknown region (allowed)", ModelClaudeSonnet45, "xx-fake-1", true},
 

--- a/providers/bedrock/cross_region_test.go
+++ b/providers/bedrock/cross_region_test.go
@@ -57,6 +57,8 @@ func TestIsModelAllowedFromRegion(t *testing.T) {
 		{"au from ap-southeast-2 (Sydney)", ModelClaudeHaiku45AU, "ap-southeast-2", true},
 		{"au from ap-southeast-4 (Melbourne)", ModelClaudeHaiku45AU, "ap-southeast-4", true},
 		{"au from ap-southeast-6 (New Zealand)", ModelClaudeOpus46AU, "ap-southeast-6", true},
+		{"Opus 4.7 AU from New Zealand", ModelClaudeOpus47AU, "ap-southeast-6", false},
+		{"Opus 4.8 AU from New Zealand", ModelClaudeOpus48AU, "ap-southeast-6", false},
 
 		// Amazon Nova 2 Lite — same prefix-based routing as Claude (us/eu/jp
 		// geo profiles + global). Confirms the amazon. namespace routes like

--- a/providers/bedrock/models.go
+++ b/providers/bedrock/models.go
@@ -236,6 +236,7 @@ func (d ModelDefinition) discoveryMetadata() map[string]string {
 //   - "au"   for Australia/NZ      (ap-southeast-2, ap-southeast-4, ap-southeast-6)
 //   - "jp"   for Japan             (ap-northeast-1, ap-northeast-3)
 //   - "global" for regions without a published Geo profile
+//   - "" for unknown regions and partitions where Bedrock does not publish Claude
 //
 // See https://docs.aws.amazon.com/bedrock/latest/userguide/cross-region-inference-support.html
 func InferenceProfileRegion(region string) string {
@@ -677,8 +678,8 @@ var supportedModels = map[string]ModelDefinition{
 	},
 
 	// ----------------------------------------------------------------
-	// Claude Sonnet 5 — inference-profile-only, no bare entry. AWS currently
-	// publishes only US and global profiles:
+	// Claude Sonnet 5 — inference-profile-only, no bare entry. Verified
+	// 2026-07-26: AWS Programmatic Access publishes only US and global profiles:
 	// https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-sonnet-5.html
 	// ----------------------------------------------------------------
 	ModelClaudeSonnet5Global: {

--- a/providers/bedrock/models.go
+++ b/providers/bedrock/models.go
@@ -236,7 +236,7 @@ func (d ModelDefinition) discoveryMetadata() map[string]string {
 //   - "au"   for Australia/NZ      (ap-southeast-2, ap-southeast-4, ap-southeast-6)
 //   - "jp"   for Japan             (ap-northeast-1, ap-northeast-3)
 //   - "global" for regions without a published Geo profile
-//   - "" for unknown regions and partitions where Bedrock does not publish Claude
+//   - "" for China and unrecognized regions
 //
 // See https://docs.aws.amazon.com/bedrock/latest/userguide/cross-region-inference-support.html
 func InferenceProfileRegion(region string) string {
@@ -678,8 +678,9 @@ var supportedModels = map[string]ModelDefinition{
 	},
 
 	// ----------------------------------------------------------------
-	// Claude Sonnet 5 — inference-profile-only, no bare entry. Verified
-	// 2026-07-26: AWS Programmatic Access publishes only US and global profiles:
+	// Claude Sonnet 5 — inference-profile-only, no bare entry. As rendered for
+	// SDK maintainers on 2026-07-26, AWS Programmatic Access showed only US
+	// and global profiles. Re-check with list-inference-profiles when available:
 	// https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-sonnet-5.html
 	// ----------------------------------------------------------------
 	ModelClaudeSonnet5Global: {

--- a/providers/bedrock/models.go
+++ b/providers/bedrock/models.go
@@ -48,7 +48,11 @@ const (
 	ModelClaudeFable5       = "anthropic.claude-fable-5"
 	ModelClaudeFable5Global = "global." + ModelClaudeFable5
 	ModelClaudeFable5US     = "us." + ModelClaudeFable5
-	ModelClaudeFable5EU     = "eu." + ModelClaudeFable5
+	// ModelClaudeFable5EU is retained for source compatibility, but AWS does
+	// not publish this profile and it is not registered in the catalog.
+	//
+	// Deprecated: use ModelClaudeFable5Global outside the US geography.
+	ModelClaudeFable5EU = "eu." + ModelClaudeFable5
 
 	// ModelClaudeSonnet5 is the bare Bedrock ID for Claude Sonnet 5
 	// (inference-profile-only — invoke via one of the prefixed variants).
@@ -67,6 +71,7 @@ const (
 	ModelClaudeSonnet46US     = "us." + ModelClaudeSonnet46
 	ModelClaudeSonnet46EU     = "eu." + ModelClaudeSonnet46
 	ModelClaudeSonnet46AU     = "au." + ModelClaudeSonnet46
+	ModelClaudeSonnet46JP     = "jp." + ModelClaudeSonnet46
 
 	// ModelClaudeSonnet45 is the bare Bedrock ID for Claude Sonnet 4.5
 	// (inference-profile-only — invoke via one of the prefixed variants).
@@ -84,6 +89,7 @@ const (
 	ModelClaudeHaiku45US     = "us." + ModelClaudeHaiku45
 	ModelClaudeHaiku45EU     = "eu." + ModelClaudeHaiku45
 	ModelClaudeHaiku45AU     = "au." + ModelClaudeHaiku45
+	ModelClaudeHaiku45JP     = "jp." + ModelClaudeHaiku45
 
 	// ModelClaudeOpus48 is the bare Bedrock ID for Claude Opus 4.8
 	// (inference-profile-only — invoke via one of the prefixed variants).
@@ -92,6 +98,7 @@ const (
 	ModelClaudeOpus48US     = "us." + ModelClaudeOpus48
 	ModelClaudeOpus48EU     = "eu." + ModelClaudeOpus48
 	ModelClaudeOpus48JP     = "jp." + ModelClaudeOpus48
+	ModelClaudeOpus48AU     = "au." + ModelClaudeOpus48
 
 	// ModelClaudeOpus47 is the bare Bedrock ID for Claude Opus 4.7
 	// (inference-profile-only — invoke via one of the prefixed variants).
@@ -100,6 +107,7 @@ const (
 	ModelClaudeOpus47US     = "us." + ModelClaudeOpus47
 	ModelClaudeOpus47EU     = "eu." + ModelClaudeOpus47
 	ModelClaudeOpus47JP     = "jp." + ModelClaudeOpus47
+	ModelClaudeOpus47AU     = "au." + ModelClaudeOpus47
 
 	// ModelClaudeOpus46 is the bare Bedrock ID for Claude Opus 4.6
 	// (inference-profile-only — invoke via one of the prefixed variants).
@@ -316,6 +324,13 @@ var (
 		SupportedParams: []string{"max_tokens", "stop"},
 	}
 
+	claudeContext1M64kConstraints = llm.ModelConstraints{
+		TemperatureRange: [2]float64{0.0, 1.0},
+		MaxInputTokens:   1000000,
+		MaxOutputTokens:  64000,
+		SupportedParams:  []string{"temperature", "top_p", "max_tokens", "stop"},
+	}
+
 	claudeContext200kConstraints = llm.ModelConstraints{
 		TemperatureRange: [2]float64{0.0, 1.0},
 		MaxInputTokens:   200000,
@@ -454,8 +469,9 @@ var (
 //     is exactly 10% cheaper than the geo rate for the same model.
 var supportedModels = map[string]ModelDefinition{
 	// ----------------------------------------------------------------
-	// Claude Fable 5 — inference-profile-only, no bare entry. Geo
-	// profiles cover us and eu (jp/au are not published).
+	// Claude Fable 5 — inference-profile-only, no bare entry. AWS publishes
+	// only global and US profiles:
+	// https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-fable-5.html
 	// ----------------------------------------------------------------
 	ModelClaudeFable5Global: {
 		Name:                        ModelClaudeFable5Global,
@@ -477,20 +493,10 @@ var supportedModels = map[string]ModelDefinition{
 			pricing.NewRates(11.00, 55.00, 1.10).WithCacheCreation(13.75, 22.00, 0),
 		),
 	},
-	ModelClaudeFable5EU: {
-		Name:                        ModelClaudeFable5EU,
-		Label:                       "Claude Fable 5 (EU)",
-		Capabilities:                claudeStandardCaps,
-		Constraints:                 claudeNoSampling1MConstraints,
-		RequiresProviderDataSharing: true,
-		Pricing: pricing.FlatInfoFromRates(
-			pricing.NewRates(11.00, 55.00, 1.10).WithCacheCreation(13.75, 22.00, 0),
-		),
-	},
-
 	// ----------------------------------------------------------------
-	// Claude Opus 4.8 — inference-profile-only, no bare entry. Geo
-	// profiles cover us, eu, jp (au is not published).
+	// Claude Opus 4.8 — inference-profile-only, no bare entry. AWS publishes
+	// global, US, EU, JP, and AU profiles:
+	// https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-opus-4-8.html
 	// ----------------------------------------------------------------
 	ModelClaudeOpus48Global: {
 		Name:         ModelClaudeOpus48Global,
@@ -528,10 +534,20 @@ var supportedModels = map[string]ModelDefinition{
 			pricing.NewRates(5.50, 27.50, 0.55).WithCacheCreation(6.875, 11.00, 0),
 		),
 	},
+	ModelClaudeOpus48AU: {
+		Name:         ModelClaudeOpus48AU,
+		Label:        "Claude Opus 4.8 (AU)",
+		Capabilities: claudeStandardCaps,
+		Constraints:  claudeNoSampling1MConstraints,
+		Pricing: pricing.FlatInfoFromRates(
+			pricing.NewRates(5.50, 27.50, 0.55).WithCacheCreation(6.875, 11.00, 0),
+		),
+	},
 
 	// ----------------------------------------------------------------
-	// Claude Opus 4.7 — inference-profile-only, no bare entry. Geo
-	// profiles cover us, eu, jp (au is not published).
+	// Claude Opus 4.7 — inference-profile-only, no bare entry. AWS publishes
+	// global, US, EU, JP, and AU profiles:
+	// https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-opus-4-7.html
 	// ----------------------------------------------------------------
 	ModelClaudeOpus47Global: {
 		Name:         ModelClaudeOpus47Global,
@@ -563,6 +579,15 @@ var supportedModels = map[string]ModelDefinition{
 	ModelClaudeOpus47JP: {
 		Name:         ModelClaudeOpus47JP,
 		Label:        "Claude Opus 4.7 (JP)",
+		Capabilities: claudeStandardCaps,
+		Constraints:  claudeNoSampling1MConstraints,
+		Pricing: pricing.FlatInfoFromRates(
+			pricing.NewRates(5.50, 27.50, 0.55).WithCacheCreation(6.875, 11.00, 0),
+		),
+	},
+	ModelClaudeOpus47AU: {
+		Name:         ModelClaudeOpus47AU,
+		Label:        "Claude Opus 4.7 (AU)",
 		Capabilities: claudeStandardCaps,
 		Constraints:  claudeNoSampling1MConstraints,
 		Pricing: pricing.FlatInfoFromRates(
@@ -665,13 +690,15 @@ var supportedModels = map[string]ModelDefinition{
 	},
 
 	// ----------------------------------------------------------------
-	// Claude Sonnet 4.6 — inference-profile-only, no bare entry.
+	// Claude Sonnet 4.6 — inference-profile-only, no bare entry. AWS publishes
+	// global, US, EU, AU, and JP profiles:
+	// https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-sonnet-4-6.html
 	// ----------------------------------------------------------------
 	ModelClaudeSonnet46Global: {
 		Name:         ModelClaudeSonnet46Global,
 		Label:        "Claude Sonnet 4.6 (Global)",
 		Capabilities: claudeStandardCaps,
-		Constraints:  claudeContext200kConstraints,
+		Constraints:  claudeContext1M64kConstraints,
 		Pricing: pricing.FlatInfoFromRates(
 			pricing.NewRates(3.00, 15.00, 0.30).WithCacheCreation(3.75, 6.00, 0),
 		),
@@ -680,7 +707,7 @@ var supportedModels = map[string]ModelDefinition{
 		Name:         ModelClaudeSonnet46US,
 		Label:        "Claude Sonnet 4.6 (US)",
 		Capabilities: claudeStandardCaps,
-		Constraints:  claudeContext200kConstraints,
+		Constraints:  claudeContext1M64kConstraints,
 		Pricing: pricing.FlatInfoFromRates(
 			pricing.NewRates(3.30, 16.50, 0.33).WithCacheCreation(4.125, 6.60, 0),
 		),
@@ -689,7 +716,7 @@ var supportedModels = map[string]ModelDefinition{
 		Name:         ModelClaudeSonnet46EU,
 		Label:        "Claude Sonnet 4.6 (EU)",
 		Capabilities: claudeStandardCaps,
-		Constraints:  claudeContext200kConstraints,
+		Constraints:  claudeContext1M64kConstraints,
 		Pricing: pricing.FlatInfoFromRates(
 			pricing.NewRates(3.30, 16.50, 0.33).WithCacheCreation(4.125, 6.60, 0),
 		),
@@ -698,7 +725,16 @@ var supportedModels = map[string]ModelDefinition{
 		Name:         ModelClaudeSonnet46AU,
 		Label:        "Claude Sonnet 4.6 (AU)",
 		Capabilities: claudeStandardCaps,
-		Constraints:  claudeContext200kConstraints,
+		Constraints:  claudeContext1M64kConstraints,
+		Pricing: pricing.FlatInfoFromRates(
+			pricing.NewRates(3.30, 16.50, 0.33).WithCacheCreation(4.125, 6.60, 0),
+		),
+	},
+	ModelClaudeSonnet46JP: {
+		Name:         ModelClaudeSonnet46JP,
+		Label:        "Claude Sonnet 4.6 (JP)",
+		Capabilities: claudeStandardCaps,
+		Constraints:  claudeContext1M64kConstraints,
 		Pricing: pricing.FlatInfoFromRates(
 			pricing.NewRates(3.30, 16.50, 0.33).WithCacheCreation(4.125, 6.60, 0),
 		),
@@ -754,7 +790,9 @@ var supportedModels = map[string]ModelDefinition{
 	},
 
 	// ----------------------------------------------------------------
-	// Claude Haiku 4.5 — inference-profile-only, no bare entry.
+	// Claude Haiku 4.5 — inference-profile-only, no bare entry. AWS publishes
+	// global, US, EU, AU, and JP profiles:
+	// https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-haiku-4-5.html
 	// ----------------------------------------------------------------
 	ModelClaudeHaiku45Global: {
 		Name:         ModelClaudeHaiku45Global,
@@ -786,6 +824,15 @@ var supportedModels = map[string]ModelDefinition{
 	ModelClaudeHaiku45AU: {
 		Name:         ModelClaudeHaiku45AU,
 		Label:        "Claude Haiku 4.5 (AU)",
+		Capabilities: claudeStandardCaps,
+		Constraints:  claudeContext200kConstraints,
+		Pricing: pricing.FlatInfoFromRates(
+			pricing.NewRates(1.10, 5.50, 0.11).WithCacheCreation(1.375, 2.20, 0),
+		),
+	},
+	ModelClaudeHaiku45JP: {
+		Name:         ModelClaudeHaiku45JP,
+		Label:        "Claude Haiku 4.5 (JP)",
 		Capabilities: claudeStandardCaps,
 		Constraints:  claudeContext200kConstraints,
 		Pricing: pricing.FlatInfoFromRates(

--- a/providers/bedrock/models.go
+++ b/providers/bedrock/models.go
@@ -235,8 +235,13 @@ func InferenceProfileRegion(region string) string {
 		return geo
 	}
 
-	// Keep the historical default for an unset or unrecognized region.
-	return "us"
+	// Keep the historical default when AWS config has no region. Unknown
+	// regions return empty so model construction fails before an API call.
+	if region == "" {
+		return "us"
+	}
+
+	return ""
 }
 
 // geoProfilePrefixes are the Bedrock cross-region and global inference-profile
@@ -306,17 +311,9 @@ var (
 	}
 
 	claudeNoSampling1MConstraints = llm.ModelConstraints{
-		TemperatureRange: [2]float64{0.0, 1.0},
-		MaxInputTokens:   1000000,
-		MaxOutputTokens:  128000,
-		SupportedParams:  []string{"max_tokens", "stop"},
-	}
-
-	claudeFable5Constraints = llm.ModelConstraints{
-		TemperatureRange: [2]float64{0.0, 1.0},
-		MaxInputTokens:   1000000,
-		MaxOutputTokens:  128000,
-		SupportedParams:  []string{"max_tokens", "stop"},
+		MaxInputTokens:  1000000,
+		MaxOutputTokens: 128000,
+		SupportedParams: []string{"max_tokens", "stop"},
 	}
 
 	claudeContext200kConstraints = llm.ModelConstraints{
@@ -464,7 +461,7 @@ var supportedModels = map[string]ModelDefinition{
 		Name:                        ModelClaudeFable5Global,
 		Label:                       "Claude Fable 5 (Global)",
 		Capabilities:                claudeStandardCaps,
-		Constraints:                 claudeFable5Constraints,
+		Constraints:                 claudeNoSampling1MConstraints,
 		RequiresProviderDataSharing: true,
 		Pricing: pricing.FlatInfoFromRates(
 			pricing.NewRates(10.00, 50.00, 1.00).WithCacheCreation(12.50, 20.00, 0),
@@ -474,7 +471,7 @@ var supportedModels = map[string]ModelDefinition{
 		Name:                        ModelClaudeFable5US,
 		Label:                       "Claude Fable 5 (US)",
 		Capabilities:                claudeStandardCaps,
-		Constraints:                 claudeFable5Constraints,
+		Constraints:                 claudeNoSampling1MConstraints,
 		RequiresProviderDataSharing: true,
 		Pricing: pricing.FlatInfoFromRates(
 			pricing.NewRates(11.00, 55.00, 1.10).WithCacheCreation(13.75, 22.00, 0),
@@ -484,7 +481,7 @@ var supportedModels = map[string]ModelDefinition{
 		Name:                        ModelClaudeFable5EU,
 		Label:                       "Claude Fable 5 (EU)",
 		Capabilities:                claudeStandardCaps,
-		Constraints:                 claudeFable5Constraints,
+		Constraints:                 claudeNoSampling1MConstraints,
 		RequiresProviderDataSharing: true,
 		Pricing: pricing.FlatInfoFromRates(
 			pricing.NewRates(11.00, 55.00, 1.10).WithCacheCreation(13.75, 22.00, 0),

--- a/providers/bedrock/models.go
+++ b/providers/bedrock/models.go
@@ -221,24 +221,22 @@ func (d ModelDefinition) discoveryMetadata() map[string]string {
 // InferenceProfileRegion maps an AWS region to the Bedrock cross-region
 // inference profile geographic prefix.
 //
-// AWS uses these prefixes:
+// AWS commonly uses these prefixes. Exact source-region availability remains
+// model-specific; this function selects the catalog's default profile family:
 //   - "us"   for US regions        (us-east-1, us-west-2, …)
 //   - "eu"   for European regions  (eu-west-1, eu-central-1, …)
-//   - "apac" for Asia Pacific      (ap-southeast-1, ap-northeast-1, …)
+//   - "au"   for Australia/NZ      (ap-southeast-2, ap-southeast-4, ap-southeast-6)
+//   - "jp"   for Japan             (ap-northeast-1, ap-northeast-3)
+//   - "global" for regions without a published Geo profile
 //
 // See https://docs.aws.amazon.com/bedrock/latest/userguide/cross-region-inference-support.html
 func InferenceProfileRegion(region string) string {
-	idx := strings.IndexByte(region, '-')
-	if idx <= 0 {
-		return "us"
+	if geo := sourceRegionGeoPrefix(region); geo != "" {
+		return geo
 	}
 
-	prefix := region[:idx]
-	if prefix == "ap" {
-		return "apac"
-	}
-
-	return prefix
+	// Keep the historical default for an unset or unrecognized region.
+	return "us"
 }
 
 // geoProfilePrefixes are the Bedrock cross-region and global inference-profile
@@ -305,6 +303,13 @@ var (
 		MaxInputTokens:   1000000,
 		MaxOutputTokens:  128000,
 		SupportedParams:  []string{"temperature", "top_p", "max_tokens", "stop"},
+	}
+
+	claudeNoSampling1MConstraints = llm.ModelConstraints{
+		TemperatureRange: [2]float64{0.0, 1.0},
+		MaxInputTokens:   1000000,
+		MaxOutputTokens:  128000,
+		SupportedParams:  []string{"max_tokens", "stop"},
 	}
 
 	claudeFable5Constraints = llm.ModelConstraints{
@@ -494,7 +499,7 @@ var supportedModels = map[string]ModelDefinition{
 		Name:         ModelClaudeOpus48Global,
 		Label:        "Claude Opus 4.8 (Global)",
 		Capabilities: claudeStandardCaps,
-		Constraints:  claudeContext1MConstraints,
+		Constraints:  claudeNoSampling1MConstraints,
 		Pricing: pricing.FlatInfoFromRates(
 			pricing.NewRates(5.00, 25.00, 0.50).WithCacheCreation(6.25, 10.00, 0),
 		),
@@ -503,7 +508,7 @@ var supportedModels = map[string]ModelDefinition{
 		Name:         ModelClaudeOpus48US,
 		Label:        "Claude Opus 4.8 (US)",
 		Capabilities: claudeStandardCaps,
-		Constraints:  claudeContext1MConstraints,
+		Constraints:  claudeNoSampling1MConstraints,
 		Pricing: pricing.FlatInfoFromRates(
 			pricing.NewRates(5.50, 27.50, 0.55).WithCacheCreation(6.875, 11.00, 0),
 		),
@@ -512,7 +517,7 @@ var supportedModels = map[string]ModelDefinition{
 		Name:         ModelClaudeOpus48EU,
 		Label:        "Claude Opus 4.8 (EU)",
 		Capabilities: claudeStandardCaps,
-		Constraints:  claudeContext1MConstraints,
+		Constraints:  claudeNoSampling1MConstraints,
 		Pricing: pricing.FlatInfoFromRates(
 			pricing.NewRates(5.50, 27.50, 0.55).WithCacheCreation(6.875, 11.00, 0),
 		),
@@ -521,7 +526,7 @@ var supportedModels = map[string]ModelDefinition{
 		Name:         ModelClaudeOpus48JP,
 		Label:        "Claude Opus 4.8 (JP)",
 		Capabilities: claudeStandardCaps,
-		Constraints:  claudeContext1MConstraints,
+		Constraints:  claudeNoSampling1MConstraints,
 		Pricing: pricing.FlatInfoFromRates(
 			pricing.NewRates(5.50, 27.50, 0.55).WithCacheCreation(6.875, 11.00, 0),
 		),
@@ -535,7 +540,7 @@ var supportedModels = map[string]ModelDefinition{
 		Name:         ModelClaudeOpus47Global,
 		Label:        "Claude Opus 4.7 (Global)",
 		Capabilities: claudeStandardCaps,
-		Constraints:  claudeContext1MConstraints,
+		Constraints:  claudeNoSampling1MConstraints,
 		Pricing: pricing.FlatInfoFromRates(
 			pricing.NewRates(5.00, 25.00, 0.50).WithCacheCreation(6.25, 10.00, 0),
 		),
@@ -544,7 +549,7 @@ var supportedModels = map[string]ModelDefinition{
 		Name:         ModelClaudeOpus47US,
 		Label:        "Claude Opus 4.7 (US)",
 		Capabilities: claudeStandardCaps,
-		Constraints:  claudeContext1MConstraints,
+		Constraints:  claudeNoSampling1MConstraints,
 		Pricing: pricing.FlatInfoFromRates(
 			pricing.NewRates(5.50, 27.50, 0.55).WithCacheCreation(6.875, 11.00, 0),
 		),
@@ -553,7 +558,7 @@ var supportedModels = map[string]ModelDefinition{
 		Name:         ModelClaudeOpus47EU,
 		Label:        "Claude Opus 4.7 (EU)",
 		Capabilities: claudeStandardCaps,
-		Constraints:  claudeContext1MConstraints,
+		Constraints:  claudeNoSampling1MConstraints,
 		Pricing: pricing.FlatInfoFromRates(
 			pricing.NewRates(5.50, 27.50, 0.55).WithCacheCreation(6.875, 11.00, 0),
 		),
@@ -562,7 +567,7 @@ var supportedModels = map[string]ModelDefinition{
 		Name:         ModelClaudeOpus47JP,
 		Label:        "Claude Opus 4.7 (JP)",
 		Capabilities: claudeStandardCaps,
-		Constraints:  claudeContext1MConstraints,
+		Constraints:  claudeNoSampling1MConstraints,
 		Pricing: pricing.FlatInfoFromRates(
 			pricing.NewRates(5.50, 27.50, 0.55).WithCacheCreation(6.875, 11.00, 0),
 		),
@@ -647,7 +652,7 @@ var supportedModels = map[string]ModelDefinition{
 		Name:         ModelClaudeSonnet5Global,
 		Label:        "Claude Sonnet 5 (Global)",
 		Capabilities: claudeStandardCaps,
-		Constraints:  claudeContext1MConstraints,
+		Constraints:  claudeNoSampling1MConstraints,
 		Pricing: pricing.FlatInfoFromRates(
 			pricing.NewRates(3.00, 15.00, 0.30).WithCacheCreation(3.75, 6.00, 0),
 		),
@@ -656,7 +661,7 @@ var supportedModels = map[string]ModelDefinition{
 		Name:         ModelClaudeSonnet5US,
 		Label:        "Claude Sonnet 5 (US)",
 		Capabilities: claudeStandardCaps,
-		Constraints:  claudeContext1MConstraints,
+		Constraints:  claudeNoSampling1MConstraints,
 		Pricing: pricing.FlatInfoFromRates(
 			pricing.NewRates(3.30, 16.50, 0.33).WithCacheCreation(4.125, 6.60, 0),
 		),

--- a/providers/bedrock/models.go
+++ b/providers/bedrock/models.go
@@ -257,8 +257,9 @@ func InferenceProfileRegion(region string) string {
 // "us.anthropic.claude-sonnet-4-6" or the "global" in
 // "global.anthropic.claude-opus-4-6-v1".
 var geoProfilePrefixes = map[string]bool{
-	"us":     true,
-	"eu":     true,
+	"us": true,
+	"eu": true,
+	// Retained so caller-supplied apac.* IDs are not double-prefixed.
 	"apac":   true,
 	"jp":     true,
 	"au":     true,
@@ -322,6 +323,15 @@ var (
 		MaxInputTokens:  1000000,
 		MaxOutputTokens: 128000,
 		SupportedParams: []string{"max_tokens", "stop"},
+	}
+
+	claudeFable5Constraints = llm.ModelConstraints{
+		TemperatureRange: [2]float64{1, 1},
+		TopPRange:        [2]float64{0.99, 1},
+		TopPMaxExclusive: true,
+		MaxInputTokens:   1000000,
+		MaxOutputTokens:  128000,
+		SupportedParams:  []string{"temperature", "top_p", "max_tokens", "stop"},
 	}
 
 	claudeContext1M64kConstraints = llm.ModelConstraints{
@@ -477,7 +487,7 @@ var supportedModels = map[string]ModelDefinition{
 		Name:                        ModelClaudeFable5Global,
 		Label:                       "Claude Fable 5 (Global)",
 		Capabilities:                claudeStandardCaps,
-		Constraints:                 claudeNoSampling1MConstraints,
+		Constraints:                 claudeFable5Constraints,
 		RequiresProviderDataSharing: true,
 		Pricing: pricing.FlatInfoFromRates(
 			pricing.NewRates(10.00, 50.00, 1.00).WithCacheCreation(12.50, 20.00, 0),
@@ -487,7 +497,7 @@ var supportedModels = map[string]ModelDefinition{
 		Name:                        ModelClaudeFable5US,
 		Label:                       "Claude Fable 5 (US)",
 		Capabilities:                claudeStandardCaps,
-		Constraints:                 claudeNoSampling1MConstraints,
+		Constraints:                 claudeFable5Constraints,
 		RequiresProviderDataSharing: true,
 		Pricing: pricing.FlatInfoFromRates(
 			pricing.NewRates(11.00, 55.00, 1.10).WithCacheCreation(13.75, 22.00, 0),
@@ -667,8 +677,9 @@ var supportedModels = map[string]ModelDefinition{
 	},
 
 	// ----------------------------------------------------------------
-	// Claude Sonnet 5 — inference-profile-only, no bare entry. Only us
-	// and global are published so far (see const block); 1M context.
+	// Claude Sonnet 5 — inference-profile-only, no bare entry. AWS currently
+	// publishes only US and global profiles:
+	// https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-sonnet-5.html
 	// ----------------------------------------------------------------
 	ModelClaudeSonnet5Global: {
 		Name:         ModelClaudeSonnet5Global,

--- a/providers/bedrock/options.go
+++ b/providers/bedrock/options.go
@@ -79,8 +79,8 @@ func WithTopP(topP float64) Option {
 			return fmt.Errorf("%s: %w", cfg.ModelName, err)
 		}
 
-		if topP < 0 || topP > 1 {
-			return fmt.Errorf("%s: top_p must be 0.0-1.0, got %f", cfg.ModelName, topP)
+		if err := cfg.Constraints.ValidateTopP(topP); err != nil {
+			return fmt.Errorf("%s: %w", cfg.ModelName, err)
 		}
 
 		cfg.setOptions["top_p"] = true

--- a/providers/bedrock/provider.go
+++ b/providers/bedrock/provider.go
@@ -218,7 +218,18 @@ func (p *Provider) NewModel(modelName string, opts ...Option) (llm.Model, error)
 	apiModelID := modelName
 
 	if _, registered := lookupModel(apiModelID); !registered && !hasRegionPrefix(apiModelID) {
-		apiModelID = InferenceProfileRegion(p.region) + "." + apiModelID
+		geo := InferenceProfileRegion(p.region)
+		if geo != "" {
+			geoModelID := geo + "." + apiModelID
+			if _, ok := lookupModel(geoModelID); ok {
+				apiModelID = geoModelID
+			} else {
+				globalModelID := "global." + apiModelID
+				if _, ok := lookupModel(globalModelID); ok {
+					apiModelID = globalModelID
+				}
+			}
+		}
 	}
 
 	// Look up by the prefixed ID — each inference profile variant is a

--- a/providers/bedrock/provider.go
+++ b/providers/bedrock/provider.go
@@ -210,9 +210,9 @@ func WithCachingDisabled() ProviderOption {
 // An unprefixed inference-profile model ID prefers the AWS source region's geo
 // profile. If that model has no profile for the geography, NewModel falls back
 // to its global profile, which has different data-residency semantics. Unknown,
-// China, and GovCloud regions fail instead of guessing; an unset region keeps
-// the historical US default. Already-prefixed IDs and exact catalog matches
-// are used as provided.
+// China, and unsupported GovCloud combinations fail instead of guessing; an
+// unset region keeps the historical US default. Already-prefixed IDs and exact
+// catalog matches are used as provided.
 func (p *Provider) NewModel(modelName string, opts ...Option) (llm.Model, error) {
 	// Build the API model ID. Most Bedrock models are cross-region inference
 	// profiles, so an un-prefixed name prefers the source region's geo profile
@@ -228,7 +228,8 @@ func (p *Provider) NewModel(modelName string, opts ...Option) (llm.Model, error)
 				apiModelID = geoModelID
 			} else {
 				globalModelID := "global." + apiModelID
-				if _, ok := lookupModel(globalModelID); ok {
+				if _, ok := lookupModel(globalModelID); ok &&
+					(p.region == "" || IsModelAllowedFromRegion(globalModelID, p.region)) {
 					apiModelID = globalModelID
 				}
 			}

--- a/providers/bedrock/provider.go
+++ b/providers/bedrock/provider.go
@@ -211,8 +211,8 @@ func WithCachingDisabled() ProviderOption {
 // profile. If that model has no profile for the geography, NewModel falls back
 // to its global profile, which has different data-residency semantics. Unknown,
 // China, and unsupported GovCloud combinations fail instead of guessing; an
-// unset region keeps the historical US default. Already-prefixed IDs and exact
-// catalog matches are used as provided.
+// unset region keeps the historical US default. Already-prefixed profile IDs
+// remain exact, but are validated against the configured source region.
 func (p *Provider) NewModel(modelName string, opts ...Option) (llm.Model, error) {
 	// Build the API model ID. Most Bedrock models are cross-region inference
 	// profiles, so an un-prefixed name prefers the source region's geo profile
@@ -246,6 +246,11 @@ func (p *Provider) NewModel(modelName string, opts ...Option) (llm.Model, error)
 		}
 
 		return nil, fmt.Errorf("unsupported Bedrock model: %s", modelName)
+	}
+
+	if p.region != "" && hasRegionPrefix(apiModelID) &&
+		!IsModelAllowedFromRegion(apiModelID, p.region) {
+		return nil, fmt.Errorf("unsupported Bedrock model: %s in region %s", modelName, p.region)
 	}
 
 	cfg := &Config{

--- a/providers/bedrock/provider.go
+++ b/providers/bedrock/provider.go
@@ -206,22 +206,25 @@ func WithCachingDisabled() ProviderOption {
 }
 
 // NewModel creates a new Bedrock model instance with the specified configuration.
+//
+// An unprefixed inference-profile model ID prefers the AWS source region's geo
+// profile. If that model has no profile for the geography, NewModel falls back
+// to its global profile, which has different data-residency semantics. Unknown,
+// China, and GovCloud regions fail instead of guessing; an unset region keeps
+// the historical US default. Already-prefixed IDs and exact catalog matches
+// are used as provided.
 func (p *Provider) NewModel(modelName string, opts ...Option) (llm.Model, error) {
 	// Build the API model ID. Most Bedrock models are cross-region inference
-	// profiles, so an un-prefixed name gets the source region's geo prefix
+	// profiles, so an un-prefixed name prefers the source region's geo profile
 	// (e.g. "anthropic.claude-sonnet-4-6" -> "us.anthropic.claude-sonnet-4-6").
-	// Two cases skip prefixing: a name that already carries a region prefix
-	// (e.g. "eu.anthropic.…"), and a name that is itself a catalog entry — a
-	// few third-party models (e.g. "mistral.mistral-large-3-675b-instruct") are
-	// on-demand / in-region and are invoked by their bare ID, so an exact
-	// catalog match is used as-is.
 	apiModelID := modelName
 
 	if _, registered := lookupModel(apiModelID); !registered && !hasRegionPrefix(apiModelID) {
 		geo := InferenceProfileRegion(p.region)
 		if geo != "" {
 			geoModelID := geo + "." + apiModelID
-			if _, ok := lookupModel(geoModelID); ok {
+			if _, ok := lookupModel(geoModelID); ok &&
+				(p.region == "" || IsModelAllowedFromRegion(geoModelID, p.region)) {
 				apiModelID = geoModelID
 			} else {
 				globalModelID := "global." + apiModelID
@@ -237,6 +240,10 @@ func (p *Provider) NewModel(modelName string, opts ...Option) (llm.Model, error)
 	// cross-region premium over the base/global rate).
 	modelDef, ok := lookupModel(apiModelID)
 	if !ok {
+		if p.region != "" {
+			return nil, fmt.Errorf("unsupported Bedrock model: %s in region %s", modelName, p.region)
+		}
+
 		return nil, fmt.Errorf("unsupported Bedrock model: %s", modelName)
 	}
 

--- a/providers/bedrock/provider_test.go
+++ b/providers/bedrock/provider_test.go
@@ -548,6 +548,9 @@ func TestNewModel_Nova2LiteSourceRouting(t *testing.T) {
 		{"eu-central-2", "", true},
 		{"ap-northeast-1", ModelNova2LiteJP, false},
 		{"ap-northeast-3", "", true},
+		{"ap-southeast-2", ModelNova2LiteGlobal, false},
+		{"ap-southeast-4", ModelNova2LiteGlobal, false},
+		{"ap-southeast-6", ModelNova2LiteGlobal, false},
 	} {
 		t.Run(tt.region, func(t *testing.T) {
 			t.Parallel()

--- a/providers/bedrock/provider_test.go
+++ b/providers/bedrock/provider_test.go
@@ -464,6 +464,24 @@ func TestNewModel_GeoProfileOrGlobalFallback(t *testing.T) {
 		{"ap-southeast-2", ModelClaudeOpus47, ModelClaudeOpus47AU},
 		{"ap-southeast-2", ModelClaudeOpus46, ModelClaudeOpus46AU},
 		{"ap-southeast-2", ModelClaudeOpus45, ModelClaudeOpus45Global},
+		{"eu-west-1", ModelClaudeFable5, ModelClaudeFable5Global},
+		{"eu-west-1", ModelClaudeSonnet5, ModelClaudeSonnet5Global},
+		{"eu-west-1", ModelClaudeSonnet46, ModelClaudeSonnet46EU},
+		{"eu-west-1", ModelClaudeSonnet45, ModelClaudeSonnet45EU},
+		{"eu-west-1", ModelClaudeHaiku45, ModelClaudeHaiku45EU},
+		{"eu-west-1", ModelClaudeOpus48, ModelClaudeOpus48EU},
+		{"eu-west-1", ModelClaudeOpus47, ModelClaudeOpus47EU},
+		{"eu-west-1", ModelClaudeOpus46, ModelClaudeOpus46EU},
+		{"eu-west-1", ModelClaudeOpus45, ModelClaudeOpus45EU},
+		{"ap-southeast-4", ModelClaudeFable5, ModelClaudeFable5Global},
+		{"ap-southeast-4", ModelClaudeSonnet5, ModelClaudeSonnet5Global},
+		{"ap-southeast-4", ModelClaudeSonnet46, ModelClaudeSonnet46AU},
+		{"ap-southeast-4", ModelClaudeSonnet45, ModelClaudeSonnet45AU},
+		{"ap-southeast-4", ModelClaudeHaiku45, ModelClaudeHaiku45AU},
+		{"ap-southeast-4", ModelClaudeOpus48, ModelClaudeOpus48AU},
+		{"ap-southeast-4", ModelClaudeOpus47, ModelClaudeOpus47AU},
+		{"ap-southeast-4", ModelClaudeOpus46, ModelClaudeOpus46AU},
+		{"ap-southeast-4", ModelClaudeOpus45, ModelClaudeOpus45Global},
 	}
 
 	for _, tt := range tests {
@@ -477,6 +495,36 @@ func TestNewModel_GeoProfileOrGlobalFallback(t *testing.T) {
 			m, ok := model.(*Model)
 			require.True(t, ok)
 			assert.Equal(t, tt.wantID, m.config.APIModelID)
+		})
+	}
+}
+
+func TestNewModel_PrefixedProfileRegionValidation(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name    string
+		region  string
+		modelID string
+		wantErr bool
+	}{
+		{"global from China", "cn-north-1", ModelClaudeSonnet46Global, true},
+		{"EU from US", "us-east-1", ModelClaudeSonnet46EU, true},
+		{"global from unknown region", "unknown", ModelClaudeSonnet46Global, false},
+		{"Sonnet 4.5 US from GovCloud", "us-gov-east-1", ModelClaudeSonnet45US, false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			p := &Provider{client: nil, region: tt.region}
+
+			_, err := p.NewModel(tt.modelID)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
 		})
 	}
 }

--- a/providers/bedrock/provider_test.go
+++ b/providers/bedrock/provider_test.go
@@ -53,7 +53,7 @@ func TestInferenceProfileRegion(t *testing.T) {
 		{"", "us"},
 		{"unknown", ""},
 		{"cn-north-1", ""},
-		{"us-gov-west-1", ""},
+		{"us-gov-west-1", "us"},
 	}
 
 	for _, tt := range tests {
@@ -484,7 +484,7 @@ func TestNewModel_GeoProfileOrGlobalFallback(t *testing.T) {
 func TestNewModel_UnknownRegionFailsAtConstruction(t *testing.T) {
 	t.Parallel()
 
-	for _, region := range []string{"cn-north-1", "us-gov-west-1", "unknown"} {
+	for _, region := range []string{"cn-north-1", "unknown"} {
 		t.Run(region, func(t *testing.T) {
 			t.Parallel()
 
@@ -493,6 +493,43 @@ func TestNewModel_UnknownRegionFailsAtConstruction(t *testing.T) {
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), "unsupported Bedrock model")
 			assert.Contains(t, err.Error(), region)
+		})
+	}
+}
+
+func TestNewModel_ModelSpecificUSRouting(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name    string
+		region  string
+		modelID string
+		wantID  string
+		wantErr bool
+	}{
+		{"Sonnet 4.5 from GovCloud", "us-gov-west-1", ModelClaudeSonnet45, ModelClaudeSonnet45US, false},
+		{"Opus 4.8 from GovCloud", "us-gov-west-1", ModelClaudeOpus48, "", true},
+		{"Haiku 4.5 from Calgary", "ca-west-1", ModelClaudeHaiku45, ModelClaudeHaiku45Global, false},
+		{"Opus 4.5 from Calgary", "ca-west-1", ModelClaudeOpus45, ModelClaudeOpus45Global, false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			p := &Provider{client: nil, region: tt.region}
+
+			model, err := p.NewModel(tt.modelID)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.region)
+
+				return
+			}
+
+			require.NoError(t, err)
+
+			m, ok := model.(*Model)
+			require.True(t, ok)
+			assert.Equal(t, tt.wantID, m.config.APIModelID)
 		})
 	}
 }
@@ -615,7 +652,6 @@ func TestNewModel_RestrictedClaudeSamplingParametersRejected(t *testing.T) {
 	}
 
 	for _, model := range []string{
-		ModelClaudeFable5,
 		ModelClaudeOpus47US,
 		ModelClaudeOpus48US,
 		ModelClaudeSonnet5US,
@@ -632,6 +668,36 @@ func TestNewModel_RestrictedClaudeSamplingParametersRejected(t *testing.T) {
 					assert.Contains(t, err.Error(), tt.want)
 				})
 			}
+		})
+	}
+}
+
+func TestNewModel_Fable5SamplingParameters(t *testing.T) {
+	t.Parallel()
+
+	p := &Provider{client: nil, region: "us-east-1"}
+
+	for _, tt := range []struct {
+		name    string
+		opt     Option
+		wantErr bool
+	}{
+		{"default temperature", WithTemperature(1), false},
+		{"non-default temperature", WithTemperature(0.5), true},
+		{"minimum top_p", WithTopP(0.99), false},
+		{"top_p below minimum", WithTopP(0.98), true},
+		{"top_p maximum is exclusive", WithTopP(1), true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := p.NewModel(ModelClaudeFable5, tt.opt)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
 		})
 	}
 }
@@ -1302,7 +1368,7 @@ func TestWithTopP_OutOfRange(t *testing.T) {
 
 	_, err := p.NewModel(ModelClaudeSonnet46, WithTopP(1.5))
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "top_p must be 0.0-1.0")
+	assert.Contains(t, err.Error(), "top_p")
 }
 
 func TestWithMaxTokens_Negative(t *testing.T) {

--- a/providers/bedrock/provider_test.go
+++ b/providers/bedrock/provider_test.go
@@ -511,6 +511,7 @@ func TestNewModel_ModelSpecificUSRouting(t *testing.T) {
 		{"Opus 4.8 from GovCloud", "us-gov-west-1", ModelClaudeOpus48, "", true},
 		{"Haiku 4.5 from Calgary", "ca-west-1", ModelClaudeHaiku45, ModelClaudeHaiku45Global, false},
 		{"Opus 4.5 from Calgary", "ca-west-1", ModelClaudeOpus45, ModelClaudeOpus45Global, false},
+		{"Sonnet 4.5 from Calgary", "ca-west-1", ModelClaudeSonnet45, ModelClaudeSonnet45Global, false},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()

--- a/providers/bedrock/provider_test.go
+++ b/providers/bedrock/provider_test.go
@@ -166,10 +166,9 @@ func TestLookupModel(t *testing.T) {
 			wantDef: ModelClaudeFable5US,
 		},
 		{
-			name:    "Fable 5 EU profile is its own entry",
-			input:   ModelClaudeFable5EU,
-			wantOK:  true,
-			wantDef: ModelClaudeFable5EU,
+			name:   "Fable 5 EU profile is not published",
+			input:  ModelClaudeFable5EU,
+			wantOK: false,
 		},
 		{
 			name:    "Fable 5 global profile is its own entry",
@@ -408,7 +407,6 @@ func TestNewModel_SupportedModels(t *testing.T) {
 		{"with region prefix", "eu." + ModelClaudeSonnet46},
 		{"opus with region", "global." + ModelClaudeOpus46},
 		{"haiku with region", "eu." + ModelClaudeHaiku45},
-		{"Fable 5 with region prefix", ModelClaudeFable5EU},
 	}
 
 	for _, tt := range tests {
@@ -443,46 +441,43 @@ func TestNewModel_GlobalOnlyRegionSelectsGlobalProfile(t *testing.T) {
 func TestNewModel_GeoProfileOrGlobalFallback(t *testing.T) {
 	t.Parallel()
 
-	models := []string{
-		ModelClaudeFable5,
-		ModelClaudeSonnet5,
-		ModelClaudeSonnet46,
-		ModelClaudeSonnet45,
-		ModelClaudeHaiku45,
-		ModelClaudeOpus48,
-		ModelClaudeOpus47,
-		ModelClaudeOpus46,
-		ModelClaudeOpus45,
-	}
-	regions := []struct {
-		region string
-		geo    string
+	tests := []struct {
+		region  string
+		modelID string
+		wantID  string
 	}{
-		{"ap-northeast-1", "jp"},
-		{"ap-southeast-2", "au"},
+		{"ap-northeast-1", ModelClaudeFable5, ModelClaudeFable5Global},
+		{"ap-northeast-1", ModelClaudeSonnet5, ModelClaudeSonnet5Global},
+		{"ap-northeast-1", ModelClaudeSonnet46, ModelClaudeSonnet46JP},
+		{"ap-northeast-1", ModelClaudeSonnet45, ModelClaudeSonnet45JP},
+		{"ap-northeast-1", ModelClaudeHaiku45, ModelClaudeHaiku45JP},
+		{"ap-northeast-1", ModelClaudeOpus48, ModelClaudeOpus48JP},
+		{"ap-northeast-1", ModelClaudeOpus47, ModelClaudeOpus47JP},
+		{"ap-northeast-1", ModelClaudeOpus46, ModelClaudeOpus46Global},
+		{"ap-northeast-1", ModelClaudeOpus45, ModelClaudeOpus45Global},
+		{"ap-southeast-2", ModelClaudeFable5, ModelClaudeFable5Global},
+		{"ap-southeast-2", ModelClaudeSonnet5, ModelClaudeSonnet5Global},
+		{"ap-southeast-2", ModelClaudeSonnet46, ModelClaudeSonnet46AU},
+		{"ap-southeast-2", ModelClaudeSonnet45, ModelClaudeSonnet45AU},
+		{"ap-southeast-2", ModelClaudeHaiku45, ModelClaudeHaiku45AU},
+		{"ap-southeast-2", ModelClaudeOpus48, ModelClaudeOpus48AU},
+		{"ap-southeast-2", ModelClaudeOpus47, ModelClaudeOpus47AU},
+		{"ap-southeast-2", ModelClaudeOpus46, ModelClaudeOpus46AU},
+		{"ap-southeast-2", ModelClaudeOpus45, ModelClaudeOpus45Global},
 	}
 
-	for _, region := range regions {
-		for _, modelID := range models {
-			t.Run(region.region+"/"+modelID, func(t *testing.T) {
-				t.Parallel()
+	for _, tt := range tests {
+		t.Run(tt.region+"/"+tt.modelID, func(t *testing.T) {
+			t.Parallel()
 
-				wantID := region.geo + "." + modelID
-				if _, ok := lookupModel(wantID); !ok {
-					wantID = "global." + modelID
-					_, globalRegistered := lookupModel(wantID)
-					require.True(t, globalRegistered, "missing both %s and global profile", region.geo)
-				}
+			p := &Provider{client: nil, region: tt.region}
+			model, err := p.NewModel(tt.modelID)
+			require.NoError(t, err)
 
-				p := &Provider{client: nil, region: region.region}
-				model, err := p.NewModel(modelID)
-				require.NoError(t, err)
-
-				m, ok := model.(*Model)
-				require.True(t, ok)
-				assert.Equal(t, wantID, m.config.APIModelID)
-			})
-		}
+			m, ok := model.(*Model)
+			require.True(t, ok)
+			assert.Equal(t, tt.wantID, m.config.APIModelID)
+		})
 	}
 }
 
@@ -497,6 +492,53 @@ func TestNewModel_UnknownRegionFailsAtConstruction(t *testing.T) {
 			_, err := p.NewModel(ModelClaudeSonnet46)
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), "unsupported Bedrock model")
+			assert.Contains(t, err.Error(), region)
+		})
+	}
+}
+
+func TestNewModel_NZFallsBackWhenAUProfileExcludesRegion(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		modelID string
+		wantID  string
+	}{
+		{ModelClaudeOpus47, ModelClaudeOpus47Global},
+		{ModelClaudeOpus48, ModelClaudeOpus48Global},
+		{ModelClaudeOpus46, ModelClaudeOpus46AU},
+	} {
+		t.Run(tt.modelID, func(t *testing.T) {
+			t.Parallel()
+
+			p := &Provider{client: nil, region: "ap-southeast-6"}
+			model, err := p.NewModel(tt.modelID)
+			require.NoError(t, err)
+
+			m, ok := model.(*Model)
+			require.True(t, ok)
+			assert.Equal(t, tt.wantID, m.config.APIModelID)
+		})
+	}
+}
+
+func TestSonnet46ContextLimits(t *testing.T) {
+	t.Parallel()
+
+	for _, id := range []string{
+		ModelClaudeSonnet46Global,
+		ModelClaudeSonnet46US,
+		ModelClaudeSonnet46EU,
+		ModelClaudeSonnet46AU,
+		ModelClaudeSonnet46JP,
+	} {
+		t.Run(id, func(t *testing.T) {
+			t.Parallel()
+
+			def, ok := supportedModels[id]
+			require.True(t, ok)
+			assert.Equal(t, 1_000_000, def.Constraints.MaxInputTokens)
+			assert.Equal(t, 64_000, def.Constraints.MaxOutputTokens)
 		})
 	}
 }
@@ -1224,7 +1266,7 @@ func TestModelsDiscovery_ProviderDataSharingMetadata(t *testing.T) {
 		metadataByName[m.Name] = m.Metadata
 	}
 
-	for _, name := range []string{ModelClaudeFable5Global, ModelClaudeFable5US, ModelClaudeFable5EU} {
+	for _, name := range []string{ModelClaudeFable5Global, ModelClaudeFable5US} {
 		assert.Equal(t, "true", metadataByName[name][ModelMetadataRequiresProviderDataSharing])
 	}
 

--- a/providers/bedrock/provider_test.go
+++ b/providers/bedrock/provider_test.go
@@ -39,11 +39,17 @@ func TestInferenceProfileRegion(t *testing.T) {
 	}{
 		{"us-east-1", "us"},
 		{"us-west-2", "us"},
+		{"ca-central-1", "us"},
+		{"ca-west-1", "us"},
 		{"eu-west-1", "eu"},
 		{"eu-central-1", "eu"},
-		{"ap-southeast-1", "apac"},
-		{"ap-northeast-1", "apac"},
-		{"ap-south-1", "apac"},
+		{"ap-southeast-1", "global"},
+		{"ap-southeast-2", "au"},
+		{"ap-southeast-4", "au"},
+		{"ap-southeast-6", "au"},
+		{"ap-northeast-1", "jp"},
+		{"ap-northeast-3", "jp"},
+		{"ap-south-1", "global"},
 		{"", "us"},
 		{"unknown", "us"},
 	}
@@ -416,20 +422,20 @@ func TestNewModel_SupportedModels(t *testing.T) {
 	}
 }
 
-func TestNewModel_APACRegionPrefixHasNoMatchingModel(t *testing.T) {
+func TestNewModel_GlobalOnlyRegionSelectsGlobalProfile(t *testing.T) {
 	t.Parallel()
 
 	// AWS does not publish an "apac." inference profile for any current
 	// Anthropic Claude model — Sonnet 4.5 has "jp." for Japan, and other
-	// Asia-Pacific regions have to use "global." instead. A provider in
-	// ap-southeast-1 calling NewModel with a bare Claude ID therefore fails
-	// at lookup; that's the correct behavior, exposed here as a regression
-	// guard so anyone re-introducing apac. needs to confirm AWS publishes it.
+	// Asia-Pacific regions use "global." instead.
 	p := &Provider{client: nil, region: "ap-southeast-1"}
 
-	_, err := p.NewModel(ModelClaudeHaiku45)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "unsupported Bedrock model")
+	model, err := p.NewModel(ModelClaudeHaiku45)
+	require.NoError(t, err)
+
+	m, ok := model.(*Model)
+	require.True(t, ok)
+	assert.Equal(t, ModelClaudeHaiku45Global, m.config.APIModelID)
 }
 
 func TestNewModel_USRegionPrefix(t *testing.T) {
@@ -489,12 +495,12 @@ func TestNewModel_Fable5RegionPrefix(t *testing.T) {
 	assert.Equal(t, ModelClaudeFable5US, m.config.APIModelID)
 }
 
-func TestNewModel_Fable5SamplingParametersRejected(t *testing.T) {
+func TestNewModel_RestrictedClaudeSamplingParametersRejected(t *testing.T) {
 	t.Parallel()
 
 	p := &Provider{client: nil, region: "us-east-1"}
 
-	tests := []struct {
+	options := []struct {
 		name string
 		opt  Option
 		want string
@@ -503,13 +509,20 @@ func TestNewModel_Fable5SamplingParametersRejected(t *testing.T) {
 		{name: "top_p", opt: WithTopP(0.9), want: "top_p"},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+	for _, model := range []string{
+		ModelClaudeFable5,
+		ModelClaudeOpus47US,
+		ModelClaudeOpus48US,
+		ModelClaudeSonnet5US,
+	} {
+		t.Run(model, func(t *testing.T) {
 			t.Parallel()
 
-			_, err := p.NewModel(ModelClaudeFable5, tt.opt)
-			require.Error(t, err)
-			assert.Contains(t, err.Error(), tt.want)
+			for _, tt := range options {
+				_, err := p.NewModel(model, tt.opt)
+				require.Error(t, err, tt.name)
+				assert.Contains(t, err.Error(), tt.want, tt.name)
+			}
 		})
 	}
 }

--- a/providers/bedrock/provider_test.go
+++ b/providers/bedrock/provider_test.go
@@ -51,7 +51,9 @@ func TestInferenceProfileRegion(t *testing.T) {
 		{"ap-northeast-3", "jp"},
 		{"ap-south-1", "global"},
 		{"", "us"},
-		{"unknown", "us"},
+		{"unknown", ""},
+		{"cn-north-1", ""},
+		{"us-gov-west-1", ""},
 	}
 
 	for _, tt := range tests {
@@ -438,6 +440,67 @@ func TestNewModel_GlobalOnlyRegionSelectsGlobalProfile(t *testing.T) {
 	assert.Equal(t, ModelClaudeHaiku45Global, m.config.APIModelID)
 }
 
+func TestNewModel_GeoProfileOrGlobalFallback(t *testing.T) {
+	t.Parallel()
+
+	models := []string{
+		ModelClaudeFable5,
+		ModelClaudeSonnet5,
+		ModelClaudeSonnet46,
+		ModelClaudeSonnet45,
+		ModelClaudeHaiku45,
+		ModelClaudeOpus48,
+		ModelClaudeOpus47,
+		ModelClaudeOpus46,
+		ModelClaudeOpus45,
+	}
+	regions := []struct {
+		region string
+		geo    string
+	}{
+		{"ap-northeast-1", "jp"},
+		{"ap-southeast-2", "au"},
+	}
+
+	for _, region := range regions {
+		for _, modelID := range models {
+			t.Run(region.region+"/"+modelID, func(t *testing.T) {
+				t.Parallel()
+
+				wantID := region.geo + "." + modelID
+				if _, ok := lookupModel(wantID); !ok {
+					wantID = "global." + modelID
+					_, globalRegistered := lookupModel(wantID)
+					require.True(t, globalRegistered, "missing both %s and global profile", region.geo)
+				}
+
+				p := &Provider{client: nil, region: region.region}
+				model, err := p.NewModel(modelID)
+				require.NoError(t, err)
+
+				m, ok := model.(*Model)
+				require.True(t, ok)
+				assert.Equal(t, wantID, m.config.APIModelID)
+			})
+		}
+	}
+}
+
+func TestNewModel_UnknownRegionFailsAtConstruction(t *testing.T) {
+	t.Parallel()
+
+	for _, region := range []string{"cn-north-1", "us-gov-west-1", "unknown"} {
+		t.Run(region, func(t *testing.T) {
+			t.Parallel()
+
+			p := &Provider{client: nil, region: region}
+			_, err := p.NewModel(ModelClaudeSonnet46)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "unsupported Bedrock model")
+		})
+	}
+}
+
 func TestNewModel_USRegionPrefix(t *testing.T) {
 	t.Parallel()
 
@@ -519,9 +582,13 @@ func TestNewModel_RestrictedClaudeSamplingParametersRejected(t *testing.T) {
 			t.Parallel()
 
 			for _, tt := range options {
-				_, err := p.NewModel(model, tt.opt)
-				require.Error(t, err, tt.name)
-				assert.Contains(t, err.Error(), tt.want, tt.name)
+				t.Run(tt.name, func(t *testing.T) {
+					t.Parallel()
+
+					_, err := p.NewModel(model, tt.opt)
+					require.Error(t, err)
+					assert.Contains(t, err.Error(), tt.want)
+				})
 			}
 		})
 	}

--- a/providers/bedrock/provider_test.go
+++ b/providers/bedrock/provider_test.go
@@ -510,6 +510,10 @@ func TestNewModel_PrefixedProfileRegionValidation(t *testing.T) {
 	}{
 		{"global from China", "cn-north-1", ModelClaudeSonnet46Global, true},
 		{"EU from US", "us-east-1", ModelClaudeSonnet46EU, true},
+		{"Opus 4.8 AU from New Zealand", "ap-southeast-6", ModelClaudeOpus48AU, true},
+		{"Haiku 4.5 US from Calgary", "ca-west-1", ModelClaudeHaiku45US, true},
+		{"Nova EU from London", "eu-west-2", ModelNova2LiteEU, true},
+		{"Nova JP from Osaka", "ap-northeast-3", ModelNova2LiteJP, true},
 		{"global from unknown region", "unknown", ModelClaudeSonnet46Global, false},
 		{"Sonnet 4.5 US from GovCloud", "us-gov-east-1", ModelClaudeSonnet45US, false},
 	} {
@@ -521,10 +525,46 @@ func TestNewModel_PrefixedProfileRegionValidation(t *testing.T) {
 			_, err := p.NewModel(tt.modelID)
 			if tt.wantErr {
 				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.region)
+
 				return
 			}
 
 			require.NoError(t, err)
+		})
+	}
+}
+
+func TestNewModel_Nova2LiteSourceRouting(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		region  string
+		wantID  string
+		wantErr bool
+	}{
+		{"eu-west-1", ModelNova2LiteEU, false},
+		{"eu-west-2", ModelNova2LiteGlobal, false},
+		{"eu-central-2", "", true},
+		{"ap-northeast-1", ModelNova2LiteJP, false},
+		{"ap-northeast-3", "", true},
+	} {
+		t.Run(tt.region, func(t *testing.T) {
+			t.Parallel()
+
+			p := &Provider{client: nil, region: tt.region}
+
+			model, err := p.NewModel(ModelNova2Lite)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+
+			m, ok := model.(*Model)
+			require.True(t, ok)
+			assert.Equal(t, tt.wantID, m.config.APIModelID)
 		})
 	}
 }

--- a/providers/google/options.go
+++ b/providers/google/options.go
@@ -87,8 +87,8 @@ func WithTopP(topP float64) Option {
 			return fmt.Errorf("%s: %w", cfg.ModelName, err)
 		}
 
-		if topP < 0 || topP > 1 {
-			return fmt.Errorf("%s: top_p must be 0.0-1.0, got %f", cfg.ModelName, topP)
+		if err = cfg.Constraints.ValidateTopP(topP); err != nil {
+			return fmt.Errorf("%s: %w", cfg.ModelName, err)
 		}
 
 		cfg.setOptions["top_p"] = true

--- a/providers/openai/options.go
+++ b/providers/openai/options.go
@@ -85,8 +85,8 @@ func WithTopP(topP float64) Option {
 			return fmt.Errorf("%s: %w", cfg.ModelName, err)
 		}
 
-		if topP < 0 || topP > 1 {
-			return fmt.Errorf("%s: top_p must be 0.0-1.0, got %f", cfg.ModelName, topP)
+		if err = cfg.Constraints.ValidateTopP(topP); err != nil {
+			return fmt.Errorf("%s: %w", cfg.ModelName, err)
 		}
 
 		cfg.setOptions["top_p"] = true

--- a/providers/openaicompat/options.go
+++ b/providers/openaicompat/options.go
@@ -104,8 +104,8 @@ func WithTopP(topP float64) Option {
 			return fmt.Errorf("%s: %w", cfg.ModelName, err)
 		}
 
-		if topP < 0 || topP > 1 {
-			return fmt.Errorf("%s: top_p must be 0.0-1.0, got %f", cfg.ModelName, topP)
+		if err = cfg.Constraints.ValidateTopP(topP); err != nil {
+			return fmt.Errorf("%s: %w", cfg.ModelName, err)
 		}
 
 		cfg.setOptions["top_p"] = true


### PR DESCRIPTION
## Summary

- remove legacy `>200K` pricing brackets from native 1M Anthropic models
- reject unsupported sampling parameters on Opus 4.7+, Sonnet 5, and matching Bedrock profiles
- keep standard speed valid on Opus 4.6/4.7 while rejecting unsupported fast mode
- correct Sonnet 4.6 discovery limits to 1M/128K on the native API and 1M/64K on Bedrock
- correct current Bedrock profiles: add missing JP/AU variants and remove the unpublished Fable 5 EU entry
- align Bedrock bare-ID routing with US/Canada, EU, JP, AU/NZ, and global profile families
- fall back to `global.` when a preferred geo profile is unpublished or disallowed for the source region
- preserve model-specific New Zealand/Calgary behavior and Sonnet 4.5 GovCloud routing
- honor Nova 2 Lite's narrower EU, JP, and global source-region tables
- accept only the narrow backwards-compatible sampling values Fable 5 still permits
- fail early instead of guessing in unknown, China, and unsupported GovCloud combinations

## Compatibility

- `WithTemperature`, `WithTopP`, and `WithTopK` now fail validation for models that reject non-default sampling parameters
- out-of-range `WithTopP` errors now use the shared constraint format across Anthropic, Bedrock, Google, OpenAI, and OpenAI-compatible providers
- `WithSpeed(SpeedFast)` now fails validation for Opus 4.6 and 4.7; `SpeedStandard` remains valid
- already-prefixed Bedrock inference profiles now fail construction when the configured source region is outside that profile's supported geography
- the deprecated `ModelClaudeFable5EU` constant remains source-compatible, but `NewModel` rejects it because AWS does not publish that profile
- `InferenceProfileRegion` no longer returns `apac`; unknown non-empty regions return an empty prefix, while GovCloud maps to the model-validated US family

## Test plan

- `task lint:new`
- `task test:unit`
- `task license:check`

## Sources

- [Anthropic pricing](https://platform.claude.com/docs/en/about-claude/pricing)
- [Anthropic model migration guide](https://platform.claude.com/docs/en/about-claude/models/migration-guide)
- [Anthropic fast mode](https://platform.claude.com/docs/en/build-with-claude/fast-mode)
- [AWS Bedrock cross-region inference](https://docs.aws.amazon.com/bedrock/latest/userguide/cross-region-inference-support.html)
- [AWS Sonnet 4.6 model card](https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-sonnet-4-6.html)
- [AWS Opus 4.7 model card](https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-opus-4-7.html)
- [AWS Opus 4.8 model card](https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-opus-4-8.html)
- [AWS Haiku 4.5 model card](https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-haiku-4-5.html)
- [AWS Sonnet 4.5 model card](https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-sonnet-4-5.html)
- [AWS Opus 4.5 model card](https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-opus-4-5.html)
- [AWS Fable 5 model card](https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-fable-5.html)

## Review notes

- backend-only catalog and validation fixes; no screenshots
- split from #182 so the Opus 5 feature remains independently reviewable
