### PR TITLE
feat(google): add latest Gemini Flash models

### DIFF
--- a/providers/google/google_conformance_test.go
+++ b/providers/google/google_conformance_test.go
@@ -112,6 +112,8 @@ func TestGoogleConformance_Integration(t *testing.T) {
 	t.Parallel()
 
 	modelsToTest := []string{
+		google.ModelGemini36Flash,       // gemini-3.6-flash
+		google.ModelGemini35FlashLite,   // gemini-3.5-flash-lite
 		google.ModelGemini35Flash,       // gemini-3.5-flash
 		google.ModelGemini31ProPreview,  // gemini-3.1-pro-preview
 		google.ModelGemini3FlashPreview, // gemini-3-flash-preview

--- a/providers/google/google_test.go
+++ b/providers/google/google_test.go
@@ -66,6 +66,8 @@ func TestProviderModels(t *testing.T) {
 
 	// Verify expected models are present
 	expectedModels := []string{
+		"gemini-3.6-flash",
+		"gemini-3.5-flash-lite",
 		"gemini-3-pro-preview",
 		"gemini-3-flash-preview",
 		"gemini-2.5-pro",
@@ -74,6 +76,58 @@ func TestProviderModels(t *testing.T) {
 	}
 	for _, expected := range expectedModels {
 		assert.Contains(t, modelNames, expected, "Should include %s", expected)
+	}
+}
+
+func TestLatestGeminiModels(t *testing.T) {
+	t.Parallel()
+
+	provider, err := NewProvider(context.Background(), "test-api-key")
+	require.NoError(t, err)
+
+	tests := []struct {
+		name                  string
+		inputMicrocents       int64
+		outputMicrocents      int64
+		cachedInputMicrocents int64
+		maxInputTokens        int
+		maxOutputTokens       int
+	}{
+		{
+			name:                  "gemini-3.6-flash",
+			inputMicrocents:       150_000_000,
+			outputMicrocents:      750_000_000,
+			cachedInputMicrocents: 15_000_000,
+			maxInputTokens:        1_048_576,
+			maxOutputTokens:       65_536,
+		},
+		{
+			name:                  "gemini-3.5-flash-lite",
+			inputMicrocents:       30_000_000,
+			outputMicrocents:      250_000_000,
+			cachedInputMicrocents: 3_000_000,
+			maxInputTokens:        1_048_576,
+			maxOutputTokens:       65_536,
+		},
+	}
+
+	prices := ModelPricing()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			model, err := provider.NewModel(tt.name)
+			require.NoError(t, err)
+			assert.Equal(t, tt.maxInputTokens, model.Constraints().MaxInputTokens)
+			assert.Equal(t, tt.maxOutputTokens, model.Constraints().MaxOutputTokens)
+
+			price, ok := prices[tt.name]
+			require.True(t, ok)
+			assert.Equal(t, tt.inputMicrocents, price.Default.Base.InputPerMillion)
+			assert.Equal(t, tt.outputMicrocents, price.Default.Base.OutputPerMillion)
+			assert.Equal(t, tt.cachedInputMicrocents, price.Default.Base.CachedInputPerMillion)
+		})
 	}
 }
 

--- a/providers/google/googletest/constants.go
+++ b/providers/google/googletest/constants.go
@@ -16,7 +16,7 @@ package googletest
 
 const (
 	// TestModelName is the model to use for integration tests.
-	TestModelName = "gemini-3.5-flash"
+	TestModelName = "gemini-3.6-flash"
 	// TestReasoningModelName is the model for reasoning tests.
 	TestReasoningModelName = "gemini-3.1-pro-preview"
 )

--- a/providers/google/models.go
+++ b/providers/google/models.go
@@ -23,6 +23,8 @@ import (
 
 // Model ID constants for Google Gemini models.
 const (
+	ModelGemini36Flash       = "gemini-3.6-flash"
+	ModelGemini35FlashLite   = "gemini-3.5-flash-lite"
 	ModelGemini35Flash       = "gemini-3.5-flash"
 	ModelGemini31ProPreview  = "gemini-3.1-pro-preview"
 	ModelGemini3ProPreview   = "gemini-3-pro-preview"
@@ -68,6 +70,50 @@ func resolveModelFamily(model string) string {
 // supportedModels defines all Gemini models with their capabilities and constraints.
 // Based on https://ai.google.dev/gemini-api/docs/models
 var supportedModels = map[string]ModelDefinition{
+	ModelGemini36Flash: {
+		Name:  ModelGemini36Flash,
+		Label: "Gemini 3.6 Flash",
+		Capabilities: llm.ModelCapabilities{
+			Streaming:        true,
+			Tools:            true,
+			JSONMode:         true,
+			StructuredOutput: true,
+			Vision:           true,
+			MultiTurn:        true,
+			SystemPrompts:    true,
+			Reasoning:        true,
+		},
+		Constraints: llm.ModelConstraints{
+			TemperatureRange:  [2]float64{0.0, 2.0},
+			MaxInputTokens:    1048576,
+			MaxOutputTokens:   65536,
+			SupportedParams:   []string{"temperature", "top_p", "top_k", "max_tokens", "stop", "presence_penalty", "frequency_penalty"},
+			MutuallyExclusive: [][]string{},
+		},
+		Pricing: pricing.FlatInfo(1.50, 7.50, 0.15),
+	},
+	ModelGemini35FlashLite: {
+		Name:  ModelGemini35FlashLite,
+		Label: "Gemini 3.5 Flash-Lite",
+		Capabilities: llm.ModelCapabilities{
+			Streaming:        true,
+			Tools:            true,
+			JSONMode:         true,
+			StructuredOutput: true,
+			Vision:           true,
+			MultiTurn:        true,
+			SystemPrompts:    true,
+			Reasoning:        true,
+		},
+		Constraints: llm.ModelConstraints{
+			TemperatureRange:  [2]float64{0.0, 2.0},
+			MaxInputTokens:    1048576,
+			MaxOutputTokens:   65536,
+			SupportedParams:   []string{"temperature", "top_p", "top_k", "max_tokens", "stop", "presence_penalty", "frequency_penalty"},
+			MutuallyExclusive: [][]string{},
+		},
+		Pricing: pricing.FlatInfo(0.30, 2.50, 0.03),
+	},
 	ModelGemini35Flash: {
 		Name:  ModelGemini35Flash,
 		Label: "Gemini 3.5 Flash",

--- a/providers/google/pricing.go
+++ b/providers/google/pricing.go
@@ -17,7 +17,7 @@ package google
 import "github.com/redpanda-data/ai-sdk-go/pricing"
 
 // ModelPricing returns a model ID → pricing map for all supported Google models.
-// Source: https://ai.google.dev/gemini-api/docs/pricing (as of 2026-04).
+// Source: https://ai.google.dev/gemini-api/docs/pricing (as of 2026-07).
 func ModelPricing() map[string]pricing.Info {
 	m := make(map[string]pricing.Info, len(supportedModels))
 	for id, def := range supportedModels {


### PR DESCRIPTION
## Summary

- add `gemini-3.6-flash` and `gemini-3.5-flash-lite` to the Google model catalog
- register Google-published 1M input / 64K output limits and standard pricing
- run both models through Google conformance coverage and use Gemini 3.6 Flash as the default integration model

## Scope

This PR is additive model support only. Handling Google's deprecated `temperature`, `top_p`, and `top_k` behavior is intentionally split into [AI-1693](https://redpandadata.atlassian.net/browse/AI-1693).

## Sources

- [Latest Gemini models](https://ai.google.dev/gemini-api/docs/latest-model)
- [Gemini 3.6 Flash](https://ai.google.dev/gemini-api/docs/models/gemini-3.6-flash)
- [Gemini 3.5 Flash-Lite](https://ai.google.dev/gemini-api/docs/models/gemini-3.5-flash-lite)
- [Gemini API pricing](https://ai.google.dev/gemini-api/docs/pricing)

## Testing

- `go test ./providers/google -short -count=1`
- `task test:unit`
- `golangci-lint run --new --timeout 10m ./providers/google/...`
- `task license:check`
- `git diff --check`

Full-repo `task lint` also ran, but remains blocked by 33 pre-existing findings outside this change. Changed-code lint reports zero issues.

Visual recap skipped: data-only provider catalog change with no customer-facing UI.


[AI-1693]: https://redpandadata.atlassian.net/browse/AI-1693?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ