### PR TITLE
feat(agenttool): map sub-agent terminal states (truncation, overflow, errors)

### DIFF
--- a/tool/agenttool/agenttool.go
+++ b/tool/agenttool/agenttool.go
@@ -34,6 +34,7 @@ package agenttool
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 
 	"github.com/rs/xid"
@@ -153,11 +154,12 @@ func (at *AgentTool) Execute(ctx context.Context, args json.RawMessage) (json.Ra
 	// before its own tool calls.
 	ctx = agent.ContextWithConversationID(ctx, session.ConversationID(sess))
 
-	// Run agent, collecting the last assistant message as the result and the
-	// finish reason so a truncated turn can be flagged to the parent.
+	// Run agent, collecting the last assistant message, the terminal finish
+	// reason, and any fatal cause carried in an ErrorEvent.
 	var (
 		result       string
 		finishReason agent.FinishReason
+		runErr       error
 	)
 
 	for evt, err := range at.agent.Run(ctx, inv) {
@@ -169,6 +171,10 @@ func (at *AgentTool) Execute(ctx context.Context, args json.RawMessage) (json.Ra
 		case agent.MessageEvent:
 			// Capture last assistant message as result.
 			result = e.Response.Message.TextContent()
+		case agent.ErrorEvent:
+			// Non-terminal at the runtime layer: llmagent carries the fatal cause
+			// here and reports FinishReasonError on the terminal event.
+			runErr = e.Err
 		case agent.InvocationEndEvent:
 			finishReason = e.FinishReason
 		}
@@ -178,12 +184,36 @@ func (at *AgentTool) Execute(ctx context.Context, args json.RawMessage) (json.Ra
 		result = "Task completed with no text output."
 	}
 
-	// Output truncation is non-fatal: the sub-agent stopped at its output-token
-	// cap with a partial answer. Deliver the partial content but mark it so the
-	// parent does not mistake it for a complete result.
+	// Map the sub-agent's terminal finish reason to a tool outcome, mirroring the
+	// A2A executor so both composition surfaces agree on success vs failure.
+	// llmagent signals most fatal conditions through the finish reason (yielded
+	// with a nil iterator error), so they must be handled here rather than by the
+	// error check above.
 	var metadata map[string]any
-	if finishReason == agent.FinishReasonLength {
+
+	switch finishReason {
+	case agent.FinishReasonStop, agent.FinishReasonTransfer, "":
+		// Natural completion — plain success.
+	case agent.FinishReasonLength:
+		// Output truncation is non-fatal: deliver the partial answer, but mark it
+		// so the parent does not mistake it for a complete result.
 		metadata = map[string]any{markerTruncated: true}
+	case agent.FinishReasonContextOverflow:
+		return nil, errors.New("agent execution failed: the conversation exceeds the model's context window")
+	case agent.FinishReasonMaxTurns:
+		return nil, errors.New("agent execution failed: maximum iterations reached")
+	case agent.FinishReasonInputRequired:
+		return nil, errors.New("agent execution failed: sub-agent requires external input, which agent-as-tool cannot provide")
+	case agent.FinishReasonInterrupted:
+		return nil, fmt.Errorf("agent execution failed: %w", context.Canceled)
+	case agent.FinishReasonError:
+		if runErr != nil {
+			return nil, fmt.Errorf("agent execution failed: %w", runErr)
+		}
+
+		return nil, errors.New("agent execution failed: sub-agent stopped with an error")
+	default:
+		return nil, fmt.Errorf("agent execution failed: unexpected finish reason %q", finishReason)
 	}
 
 	output := Result{

--- a/tool/agenttool/agenttool.go
+++ b/tool/agenttool/agenttool.go
@@ -81,6 +81,12 @@ func (at *AgentTool) Definition() llm.ToolDefinition {
 // Result represents the output from an agent tool execution.
 type Result struct {
 	Result string `json:"result"`
+	// Truncated is true when the sub-agent's turn stopped at its output-token
+	// limit (agent.FinishReasonLength) rather than finishing naturally. The
+	// result then holds only the partial content produced before the cut, so the
+	// parent can tell an incomplete answer apart from a complete one — the
+	// agent-as-tool analogue of the A2A executor's `truncated` marker.
+	Truncated bool `json:"truncated,omitempty"`
 }
 
 // Execute implements tool.Tool by running the agent with a fresh session.
@@ -140,17 +146,24 @@ func (at *AgentTool) Execute(ctx context.Context, args json.RawMessage) (json.Ra
 	// before its own tool calls.
 	ctx = agent.ContextWithConversationID(ctx, session.ConversationID(sess))
 
-	// Run agent and collect the last assistant message as the result.
-	var result string
+	// Run agent, collecting the last assistant message as the result and the
+	// finish reason so a truncated turn can be flagged to the parent.
+	var (
+		result       string
+		finishReason agent.FinishReason
+	)
 
 	for evt, err := range at.agent.Run(ctx, inv) {
 		if err != nil {
 			return nil, fmt.Errorf("agent execution failed: %w", err)
 		}
 
-		// Capture last assistant message as result
-		if msgEvt, ok := evt.(agent.MessageEvent); ok {
-			result = msgEvt.Response.Message.TextContent()
+		switch e := evt.(type) {
+		case agent.MessageEvent:
+			// Capture last assistant message as result.
+			result = e.Response.Message.TextContent()
+		case agent.InvocationEndEvent:
+			finishReason = e.FinishReason
 		}
 	}
 
@@ -158,8 +171,14 @@ func (at *AgentTool) Execute(ctx context.Context, args json.RawMessage) (json.Ra
 		result = "Task completed with no text output."
 	}
 
+	// Output truncation is non-fatal: the sub-agent stopped at its output-token
+	// cap with a partial answer. Deliver the partial content but flag it so the
+	// parent does not mistake it for a complete result.
+	truncated := finishReason == agent.FinishReasonLength
+
 	output := Result{
-		Result: result,
+		Result:    result,
+		Truncated: truncated,
 	}
 
 	return json.Marshal(output)

--- a/tool/agenttool/agenttool.go
+++ b/tool/agenttool/agenttool.go
@@ -81,13 +81,20 @@ func (at *AgentTool) Definition() llm.ToolDefinition {
 // Result represents the output from an agent tool execution.
 type Result struct {
 	Result string `json:"result"`
-	// Truncated is true when the sub-agent's turn stopped at its output-token
-	// limit (agent.FinishReasonLength) rather than finishing naturally. The
-	// result then holds only the partial content produced before the cut, so the
-	// parent can tell an incomplete answer apart from a complete one — the
-	// agent-as-tool analogue of the A2A executor's `truncated` marker.
-	Truncated bool `json:"truncated,omitempty"`
+	// Metadata carries out-of-band markers about the run, keyed the same way as
+	// the A2A executor's status-message metadata so both surfaces share one
+	// vocabulary. Omitted when there is nothing to report. Known keys:
+	//   - "truncated" (bool): the sub-agent stopped at its output-token limit
+	//     (agent.FinishReasonLength) and Result holds only the partial content
+	//     produced before the cut, so the parent can tell an incomplete answer
+	//     apart from a complete one.
+	// The map is the extension point for further markers (e.g. usage).
+	Metadata map[string]any `json:"metadata,omitempty"`
 }
+
+// markerTruncated flags a partial result produced when the sub-agent hit its
+// output-token cap. Matches the A2A executor's metadata key.
+const markerTruncated = "truncated"
 
 // Execute implements tool.Tool by running the agent with a fresh session.
 //
@@ -172,13 +179,16 @@ func (at *AgentTool) Execute(ctx context.Context, args json.RawMessage) (json.Ra
 	}
 
 	// Output truncation is non-fatal: the sub-agent stopped at its output-token
-	// cap with a partial answer. Deliver the partial content but flag it so the
+	// cap with a partial answer. Deliver the partial content but mark it so the
 	// parent does not mistake it for a complete result.
-	truncated := finishReason == agent.FinishReasonLength
+	var metadata map[string]any
+	if finishReason == agent.FinishReasonLength {
+		metadata = map[string]any{markerTruncated: true}
+	}
 
 	output := Result{
-		Result:    result,
-		Truncated: truncated,
+		Result:   result,
+		Metadata: metadata,
 	}
 
 	return json.Marshal(output)

--- a/tool/agenttool/agenttool.go
+++ b/tool/agenttool/agenttool.go
@@ -205,7 +205,16 @@ func (at *AgentTool) Execute(ctx context.Context, args json.RawMessage) (json.Ra
 	case agent.FinishReasonInputRequired:
 		return nil, errors.New("agent execution failed: sub-agent requires external input, which agent-as-tool cannot provide")
 	case agent.FinishReasonInterrupted:
-		return nil, fmt.Errorf("agent execution failed: %w", context.Canceled)
+		// llmagent reports this for any ctx.Err() (a deadline as well as a cancel),
+		// so report the actual cause: a parent testing for a sub-agent timeout with
+		// errors.Is(err, context.DeadlineExceeded) must see it.
+		cause := ctx.Err()
+		if cause == nil {
+			// No context error: the consumer stopped listening mid-run.
+			cause = context.Canceled
+		}
+
+		return nil, fmt.Errorf("agent execution failed: %w", cause)
 	case agent.FinishReasonError:
 		if runErr != nil {
 			return nil, fmt.Errorf("agent execution failed: %w", runErr)

--- a/tool/agenttool/agenttool_integration_test.go
+++ b/tool/agenttool/agenttool_integration_test.go
@@ -66,10 +66,10 @@ func TestExecute_TruncationFlag_Integration(t *testing.T) {
 	var output agenttool.Result
 	require.NoError(t, json.Unmarshal(raw, &output))
 
-	assert.True(t, output.Truncated,
+	assert.Equal(t, true, output.Metadata["truncated"],
 		"a 16-token cap on a long-essay prompt must surface as a truncated sub-agent result")
 	assert.NotEmpty(t, output.Result,
 		"the partial content the sub-agent produced before the cut must still be delivered")
 
-	t.Logf("truncated=%v result=%q", output.Truncated, output.Result)
+	t.Logf("metadata=%v result=%q", output.Metadata, output.Result)
 }

--- a/tool/agenttool/agenttool_integration_test.go
+++ b/tool/agenttool/agenttool_integration_test.go
@@ -1,0 +1,75 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agenttool_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/redpanda-data/ai-sdk-go/agent/llmagent"
+	"github.com/redpanda-data/ai-sdk-go/providers/anthropic"
+	"github.com/redpanda-data/ai-sdk-go/providers/anthropic/anthropictest"
+	"github.com/redpanda-data/ai-sdk-go/tool/agenttool"
+)
+
+// TestExecute_TruncationFlag_Integration proves end to end, against the real
+// Anthropic API, that a genuinely truncated sub-agent turn surfaces as
+// Result.Truncated. A real llmagent runs behind the agent-as-tool, and a tiny
+// per-model output budget forces the model to stop at the output-token cap —
+// exercising the full model → llmagent → agenttool finish-reason path that the
+// mock-based unit tests cannot.
+func TestExecute_TruncationFlag_Integration(t *testing.T) {
+	t.Parallel()
+
+	apiKey := anthropictest.GetAPIKeyOrSkipTest(t)
+
+	provider, err := anthropic.NewProvider(apiKey)
+	require.NoError(t, err)
+
+	// A tiny output budget guarantees the long-essay prompt truncates.
+	model, err := provider.NewModel(anthropictest.TestModelName, anthropic.WithMaxTokens(16))
+	require.NoError(t, err)
+
+	subAgent, err := llmagent.New("essayist", "You are a helpful assistant.", model)
+	require.NoError(t, err)
+
+	at := agenttool.New(subAgent)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	args, err := json.Marshal(map[string]string{
+		"query": "Write a detailed 1000-word essay about the history of computing.",
+	})
+	require.NoError(t, err)
+
+	raw, err := at.Execute(ctx, args)
+	require.NoError(t, err)
+
+	var output agenttool.Result
+	require.NoError(t, json.Unmarshal(raw, &output))
+
+	assert.True(t, output.Truncated,
+		"a 16-token cap on a long-essay prompt must surface as a truncated sub-agent result")
+	assert.NotEmpty(t, output.Result,
+		"the partial content the sub-agent produced before the cut must still be delivered")
+
+	t.Logf("truncated=%v result=%q", output.Truncated, output.Result)
+}

--- a/tool/agenttool/agenttool_test.go
+++ b/tool/agenttool/agenttool_test.go
@@ -320,6 +320,49 @@ func TestExecute(t *testing.T) {
 			"the sub-agent's underlying error must reach the parent, not be swallowed")
 	})
 
+	// An interruption must name the cause that actually stopped the run:
+	// llmagent reports FinishReasonInterrupted for any ctx.Err() (a deadline as
+	// well as a cancel), and also when the consumer stopped listening, where
+	// there is no context error at all.
+	interruptions := []struct {
+		name       string
+		expiredCtx bool
+		wantCause  error
+	}{
+		{"a deadline that already passed", true, context.DeadlineExceeded},
+		{"a consumer that stopped listening", false, context.Canceled},
+	}
+
+	for _, tt := range interruptions {
+		t.Run("interrupted reports "+tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			mockAgent := &mockAgent{
+				name:         "sub-agent",
+				response:     "some partial content",
+				finishReason: agent.FinishReasonInterrupted,
+			}
+
+			agentTool := agenttool.New(mockAgent)
+
+			ctx := context.Background()
+
+			if tt.expiredCtx {
+				var cancel context.CancelFunc
+
+				ctx, cancel = context.WithDeadline(ctx, time.Now().Add(-time.Minute))
+
+				defer cancel()
+			}
+
+			_, err := agentTool.Execute(ctx, json.RawMessage("{}"))
+
+			require.Error(t, err)
+			assert.ErrorIs(t, err, tt.wantCause,
+				"the interruption must report the cause that stopped the sub-agent")
+		})
+	}
+
 	t.Run("agent error propagation", func(t *testing.T) {
 		t.Parallel()
 

--- a/tool/agenttool/agenttool_test.go
+++ b/tool/agenttool/agenttool_test.go
@@ -33,11 +33,12 @@ import (
 
 // mockAgent is a simple test agent that returns a predefined response.
 type mockAgent struct {
-	name        string
-	description string
-	inputSchema map[string]any
-	response    string
-	shouldError bool
+	name         string
+	description  string
+	inputSchema  map[string]any
+	response     string
+	shouldError  bool
+	finishReason agent.FinishReason
 }
 
 func (m *mockAgent) Info() agent.Info {
@@ -66,11 +67,18 @@ func (m *mockAgent) Run(_ context.Context, _ *agent.InvocationMetadata) iter.Seq
 			},
 		}
 
-		yield(evt, nil)
+		if !yield(evt, nil) {
+			return
+		}
 
-		// Emit end event
+		// Emit end event. Default to a natural stop unless the test overrides it.
+		finishReason := m.finishReason
+		if finishReason == "" {
+			finishReason = agent.FinishReasonStop
+		}
+
 		endEvt := agent.InvocationEndEvent{
-			FinishReason: agent.FinishReasonStop,
+			FinishReason: finishReason,
 		}
 		yield(endEvt, nil)
 	}
@@ -206,6 +214,50 @@ func TestExecute(t *testing.T) {
 		err = json.Unmarshal(result, &output)
 		require.NoError(t, err)
 		assert.Equal(t, "Response without input", output.Result)
+	})
+
+	t.Run("truncated sub-agent turn is flagged", func(t *testing.T) {
+		t.Parallel()
+
+		mockAgent := &mockAgent{
+			name:         "verbose-agent",
+			response:     "partial answer that got cut off",
+			finishReason: agent.FinishReasonLength,
+		}
+
+		agentTool := agenttool.New(mockAgent)
+
+		result, err := agentTool.Execute(context.Background(), json.RawMessage("{}"))
+		require.NoError(t, err)
+
+		var output agenttool.Result
+		require.NoError(t, json.Unmarshal(result, &output))
+
+		assert.True(t, output.Truncated,
+			"a sub-agent turn that stopped at the output-token cap must be flagged truncated")
+		assert.Contains(t, output.Result, "partial answer that got cut off",
+			"the partial content the sub-agent produced must still be delivered")
+	})
+
+	t.Run("completed sub-agent turn is not flagged", func(t *testing.T) {
+		t.Parallel()
+
+		mockAgent := &mockAgent{
+			name:     "test-agent",
+			response: "complete answer",
+			// finishReason defaults to FinishReasonStop
+		}
+
+		agentTool := agenttool.New(mockAgent)
+
+		result, err := agentTool.Execute(context.Background(), json.RawMessage("{}"))
+		require.NoError(t, err)
+
+		var output agenttool.Result
+		require.NoError(t, json.Unmarshal(result, &output))
+
+		assert.False(t, output.Truncated, "a naturally completed turn must not be flagged truncated")
+		assert.Equal(t, "complete answer", output.Result)
 	})
 
 	t.Run("agent error propagation", func(t *testing.T) {

--- a/tool/agenttool/agenttool_test.go
+++ b/tool/agenttool/agenttool_test.go
@@ -233,7 +233,7 @@ func TestExecute(t *testing.T) {
 		var output agenttool.Result
 		require.NoError(t, json.Unmarshal(result, &output))
 
-		assert.True(t, output.Truncated,
+		assert.Equal(t, true, output.Metadata["truncated"],
 			"a sub-agent turn that stopped at the output-token cap must be flagged truncated")
 		assert.Contains(t, output.Result, "partial answer that got cut off",
 			"the partial content the sub-agent produced must still be delivered")
@@ -256,7 +256,7 @@ func TestExecute(t *testing.T) {
 		var output agenttool.Result
 		require.NoError(t, json.Unmarshal(result, &output))
 
-		assert.False(t, output.Truncated, "a naturally completed turn must not be flagged truncated")
+		assert.Nil(t, output.Metadata, "a naturally completed turn must carry no markers")
 		assert.Equal(t, "complete answer", output.Result)
 	})
 

--- a/tool/agenttool/agenttool_test.go
+++ b/tool/agenttool/agenttool_test.go
@@ -33,12 +33,13 @@ import (
 
 // mockAgent is a simple test agent that returns a predefined response.
 type mockAgent struct {
-	name         string
-	description  string
-	inputSchema  map[string]any
-	response     string
-	shouldError  bool
-	finishReason agent.FinishReason
+	name          string
+	description   string
+	inputSchema   map[string]any
+	response      string
+	shouldError   bool
+	finishReason  agent.FinishReason
+	errorEventErr error // if set, emit a (non-terminal) ErrorEvent before the end event
 }
 
 func (m *mockAgent) Info() agent.Info {
@@ -69,6 +70,15 @@ func (m *mockAgent) Run(_ context.Context, _ *agent.InvocationMetadata) iter.Seq
 
 		if !yield(evt, nil) {
 			return
+		}
+
+		// llmagent carries a fatal cause in a non-terminal ErrorEvent and reports
+		// the terminal condition via the finish reason (both yielded with a nil
+		// iterator error) — mirror that here when the test asks for it.
+		if m.errorEventErr != nil {
+			if !yield(agent.ErrorEvent{Err: m.errorEventErr, Message: m.errorEventErr.Error()}, nil) {
+				return
+			}
 		}
 
 		// Emit end event. Default to a natural stop unless the test overrides it.
@@ -258,6 +268,56 @@ func TestExecute(t *testing.T) {
 
 		assert.Nil(t, output.Metadata, "a naturally completed turn must carry no markers")
 		assert.Equal(t, "complete answer", output.Result)
+	})
+
+	// Terminal states other than output truncation must fail the tool call rather
+	// than return a silent success, mirroring the A2A executor's mapping.
+	terminalFailures := []struct {
+		name         string
+		finishReason agent.FinishReason
+		wantContains string
+	}{
+		{"context overflow", agent.FinishReasonContextOverflow, "context window"},
+		{"max turns", agent.FinishReasonMaxTurns, "maximum iterations"},
+		{"input required", agent.FinishReasonInputRequired, "external input"},
+	}
+
+	for _, tt := range terminalFailures {
+		t.Run(tt.name+" is a tool error", func(t *testing.T) {
+			t.Parallel()
+
+			mockAgent := &mockAgent{
+				name:         "sub-agent",
+				response:     "some partial content",
+				finishReason: tt.finishReason,
+			}
+
+			agentTool := agenttool.New(mockAgent)
+
+			_, err := agentTool.Execute(context.Background(), json.RawMessage("{}"))
+
+			require.Error(t, err, "a %s sub-agent turn must not be returned as a success", tt.name)
+			assert.Contains(t, err.Error(), tt.wantContains)
+		})
+	}
+
+	t.Run("terminal error surfaces the underlying cause", func(t *testing.T) {
+		t.Parallel()
+
+		mockAgent := &mockAgent{
+			name:          "sub-agent",
+			response:      "some partial content",
+			finishReason:  agent.FinishReasonError,
+			errorEventErr: llm.ErrContentPolicyViolation,
+		}
+
+		agentTool := agenttool.New(mockAgent)
+
+		_, err := agentTool.Execute(context.Background(), json.RawMessage("{}"))
+
+		require.Error(t, err)
+		assert.ErrorIs(t, err, llm.ErrContentPolicyViolation,
+			"the sub-agent's underlying error must reach the parent, not be swallowed")
 	})
 
 	t.Run("agent error propagation", func(t *testing.T) {


### PR DESCRIPTION
## What

When an agent is used as a tool (`tool/agenttool`), `Execute` captured the sub-agent's last message text but ignored its finish reason — so **every** terminal state (truncation, context overflow, content-filter/unknown errors, max-turns, input-required) came back as an indistinguishable success with whatever partial text existed.

This branches on the sub-agent's terminal finish reason (and surfaces a fatal `ErrorEvent` cause), mirroring the A2A executor so both composition surfaces agree on success vs failure:

| Sub-agent finish reason | agent-as-tool outcome |
|---|---|
| Stop / Transfer | success (`{"result": "..."}`) |
| **Length** (output truncation) | success + `{"metadata": {"truncated": true}}`, partial content delivered |
| ContextOverflow | tool error ("conversation exceeds the model's context window") |
| Error (content filter / unknown) | tool error, surfacing the underlying `ErrorEvent.Err` |
| MaxTurns | tool error ("maximum iterations reached") |
| InputRequired | tool error (a tool can't pause for external input) |

`metadata` is keyed the same way as the A2A executor's status-message metadata, so both surfaces share one vocabulary; it's the extension point for further markers (e.g. `usage`).

Genuine generation/transport errors (incl. the pre-generation context-window 400) already arrive via the iterator error channel and are propagated as a tool error — unchanged.

## Why

`llmagent` signals most fatal conditions through the **finish reason** / a non-terminal `ErrorEvent` (both yielded with a nil iterator error), not through `yield(nil, err)`. `agenttool` previously only checked the iterator error + last message, so those slipped through as successes. The A2A executor already detects fatality from the finish reason; this brings agent-as-tool to parity.

## Testing

- Unit (`TestExecute`): truncation → `metadata.truncated` + partial; natural stop → no metadata; context-overflow / max-turns / input-required → tool error; terminal error surfaces the underlying cause (`ErrContentPolicyViolation`).
- E2E integration: real `llmagent` on the live Anthropic model with a 16-token cap genuinely truncates → `metadata.truncated=true`. Key-gated.
- Built TDD (red → green).

## Notes

Absorbs the follow-up that was filed as AI-1711 (agent-as-tool swallowing overflow/error terminal states) — handled here rather than deferred.