### PR TITLE
feat(bedrock): give Claude models a bounded default max_tokens

### DIFF
--- a/providers/bedrock/default_max_tokens_integration_test.go
+++ b/providers/bedrock/default_max_tokens_integration_test.go
@@ -1,0 +1,137 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bedrock
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/redpanda-data/ai-sdk-go/llm"
+	"github.com/redpanda-data/ai-sdk-go/providers/bedrock/bedrocktest"
+)
+
+// TestBedrockOmittedMaxTokensDefault_Integration is the live boundary check that
+// establishes the fact the Claude default max_tokens injection depends on: that
+// Converse, given no maxTokens for a Claude model, applies a small implicit
+// output cap far below the model's advertised MaxOutputTokens — rather than the
+// model maximum the published InferenceConfiguration reference describes. Unit
+// tests cannot settle this: they assert config state after the injection, not
+// what AWS does on the wire when the field is absent. This one requires
+// authorized Bedrock credentials and is skipped without them.
+//
+// It runs the same long-output prompt twice against the same catalog Claude
+// model and compares the observed output-token counts:
+//
+//   - Omitted: maxTokens forced back to nil so the request carries no maxTokens
+//     (NewModel injects the default for Claude, so it is cleared here to observe
+//     the raw provider behavior the default is meant to correct).
+//   - Explicit: maxTokens set to the injected default so its ceiling is visible.
+//
+// The prompt asks for far more output than any cap allows, so a run that hits a
+// ceiling stops with FinishReasonLength at roughly that ceiling. If the omitted
+// run truncates below the explicit 16K run, the implicit default is the low cap
+// the injection is meant to lift. If instead it runs to the model maximum, the
+// injection lowers the effective ceiling and must be dropped — the assertions
+// fail loudly and say so.
+func TestBedrockOmittedMaxTokensDefault_Integration(t *testing.T) {
+	t.Parallel()
+
+	bedrocktest.SkipUnlessAWSCredentials(t)
+
+	region := bedrocktest.TestRegion
+
+	provider, err := NewProvider(context.Background(), WithRegion(region))
+	require.NoError(t, err)
+
+	// A prompt that demands far more output than any per-turn cap allows, so the
+	// turn is cut off by the budget (FinishReasonLength) rather than finishing on
+	// its own. That cutoff point is the effective max_tokens we want to observe.
+	longOutputPrompt := "Write an extremely long, continuous fictional story of at " +
+		"least 100,000 words. Do not summarize, do not stop early, do not ask " +
+		"questions, and never wrap up — keep writing prose until you are cut off."
+
+	// Omitted run: build via NewModel (which injects the Claude default), then
+	// clear MaxTokens so the request carries no maxTokens at all. The request
+	// mapper reads this same Config pointer at send time, so nil-ing it here is
+	// what puts the field-absent case on the wire.
+	omitted, err := provider.NewModel(bedrocktest.TestModelName)
+	require.NoError(t, err)
+
+	om, ok := omitted.(*Model)
+	require.True(t, ok)
+	require.NotNil(t, om.config.MaxTokens, "NewModel should inject the Claude default before we clear it")
+	om.config.MaxTokens = nil
+
+	outputCap := om.definition.Constraints.MaxOutputTokens
+	require.Positive(t, outputCap, "catalog model must advertise an output cap for this check to be meaningful")
+
+	omittedOut, omittedFinish := generateAndMeasure(t, omitted, longOutputPrompt)
+	t.Logf("omitted maxTokens: output_tokens=%d finish=%q (model cap=%d, SDK default=%d)",
+		omittedOut, omittedFinish, outputCap, defaultMaxTokens)
+
+	// Explicit run: the injected default made visible, so we can compare ceilings.
+	explicit, err := provider.NewModel(bedrocktest.TestModelName, WithMaxTokens(defaultMaxTokens))
+	require.NoError(t, err)
+
+	explicitOut, explicitFinish := generateAndMeasure(t, explicit, longOutputPrompt)
+	t.Logf("explicit maxTokens=%d: output_tokens=%d finish=%q", defaultMaxTokens, explicitOut, explicitFinish)
+
+	// Both runs must have been cut off by their budget; otherwise the prompt
+	// finished on its own and neither number reflects a cap.
+	require.Equal(t, llm.FinishReasonLength, omittedFinish,
+		"prompt did not exhaust the omitted-maxTokens budget; cannot characterize the implicit default")
+	require.Equal(t, llm.FinishReasonLength, explicitFinish,
+		"prompt did not exhaust the explicit %d budget; cannot compare ceilings", defaultMaxTokens)
+
+	// The explicit default should cap output near 16K — proof the SDK value
+	// reaches the wire and is the operative ceiling when set.
+	assert.Greater(t, explicitOut, 12000,
+		"explicit maxTokens=%d should produce output near that ceiling; got %d", defaultMaxTokens, explicitOut)
+
+	// The premise: omitting maxTokens truncates BELOW the injected default, so
+	// the injection raises the ceiling rather than lowering it. If the implicit
+	// default were the model maximum (as the published reference states), this
+	// run would produce far more than 16K and the assertion fails — the signal
+	// that the injection is harmful and PR must be reconsidered.
+	assert.Less(t, omittedOut, defaultMaxTokens,
+		"PREMISE CHECK: omitting maxTokens should truncate below the injected %d default; "+
+			"got %d output tokens. If this meets or exceeds %d, Bedrock's implicit default is "+
+			"the model maximum (%d), not a low cap — the injected default LOWERS the effective "+
+			"ceiling and must be removed.", defaultMaxTokens, omittedOut, defaultMaxTokens, outputCap)
+}
+
+// generateAndMeasure runs one generation and returns the visible output-token
+// count and finish reason.
+func generateAndMeasure(t *testing.T, model llm.Model, prompt string) (int, llm.FinishReason) {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Minute)
+	defer cancel()
+
+	resp, err := model.Generate(ctx, &llm.Request{
+		Messages: []llm.Message{
+			llm.NewMessage(llm.RoleUser, llm.NewTextPart(prompt)),
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.NotNil(t, resp.Usage, "provider must report token usage for this check")
+
+	return resp.Usage.OutputTokens, resp.FinishReason
+}

--- a/providers/bedrock/models.go
+++ b/providers/bedrock/models.go
@@ -313,7 +313,7 @@ func profileRegionResolverFor(modelID string) (func(string) (string, bool), bool
 // Claude-only behavior (like the default output budget) away from the other
 // Bedrock families, whose output caps and defaults differ.
 func isAnthropicModel(modelID string) bool {
-	return strings.Contains(modelID, "anthropic.")
+	return strings.HasPrefix(modelID, "anthropic.") || strings.Contains(modelID, ".anthropic.")
 }
 
 // lookupModel finds a ModelDefinition by exact model ID. Each inference

--- a/providers/bedrock/models.go
+++ b/providers/bedrock/models.go
@@ -307,6 +307,15 @@ func profileRegionResolverFor(modelID string) (func(string) (string, bool), bool
 	return resolver, ok
 }
 
+// isAnthropicModel reports whether a resolved Bedrock model ID belongs to the
+// Anthropic (Claude) family — e.g. "anthropic.claude-sonnet-5",
+// "us.anthropic.claude-opus-4-8", "global.anthropic.…". Used to scope
+// Claude-only behavior (like the default output budget) away from the other
+// Bedrock families, whose output caps and defaults differ.
+func isAnthropicModel(modelID string) bool {
+	return strings.Contains(modelID, "anthropic.")
+}
+
 // lookupModel finds a ModelDefinition by exact model ID. Each inference
 // profile variant is registered as its own entry (with its own pricing), so
 // callers must pass the full prefixed ID to get the correct rate card.

--- a/providers/bedrock/provider.go
+++ b/providers/bedrock/provider.go
@@ -205,7 +205,6 @@ func WithCachingDisabled() ProviderOption {
 	}
 }
 
-// NewModel creates a new Bedrock model instance with the specified configuration.
 // defaultMaxTokens is a bounded fallback output budget for Claude models on
 // Bedrock. Bedrock sends no max_tokens unless one is set, so AWS applies its own
 // default — 4096 for Claude — which truncates ordinary agent turns. This gives
@@ -217,6 +216,7 @@ func WithCachingDisabled() ProviderOption {
 // conversations.
 const defaultMaxTokens = 16384
 
+// NewModel creates a new Bedrock model instance with the specified configuration.
 func (p *Provider) NewModel(modelName string, opts ...Option) (llm.Model, error) {
 	// Build the API model ID. Most Bedrock models are cross-region inference
 	// profiles, so an un-prefixed name gets the source region's geo prefix
@@ -275,7 +275,12 @@ func (p *Provider) NewModel(modelName string, opts ...Option) (llm.Model, error)
 	// Give Claude models a bounded default output budget when the caller set none,
 	// so they are not left at AWS's 4096. Scoped to Claude; clamped to the model's
 	// output cap so it can never exceed the limit. An explicit WithMaxTokens wins.
-	if cfg.MaxTokens == nil && isAnthropicModel(apiModelID) {
+	//
+	// The MaxOutputTokens > 0 guard keeps the budget >= 1 (a catalog entry with an
+	// unset cap would otherwise put max_tokens: 0 on the wire). setOptions is left
+	// untouched on purpose: this is an SDK-injected default, not a caller-set
+	// option, so it must not trip caller-facing conditional rules in Validate.
+	if cfg.MaxTokens == nil && isAnthropicModel(apiModelID) && modelDef.Constraints.MaxOutputTokens > 0 {
 		budget := int32(min(defaultMaxTokens, modelDef.Constraints.MaxOutputTokens)) //nolint:gosec // bounded: 1 <= budget <= MaxOutputTokens
 		cfg.MaxTokens = &budget
 	}

--- a/providers/bedrock/provider.go
+++ b/providers/bedrock/provider.go
@@ -206,6 +206,17 @@ func WithCachingDisabled() ProviderOption {
 }
 
 // NewModel creates a new Bedrock model instance with the specified configuration.
+// defaultMaxTokens is a bounded fallback output budget for Claude models on
+// Bedrock. Bedrock sends no max_tokens unless one is set, so AWS applies its own
+// default — 4096 for Claude — which truncates ordinary agent turns. This gives
+// Claude a safe out-of-the-box budget matching the native Anthropic provider; an
+// explicit WithMaxTokens still wins. It is scoped to Claude because the other
+// Bedrock families have different output caps and their AWS defaults are not the
+// same footgun. It is bounded rather than the model max because max_tokens
+// reserves context-window space, so defaulting to the max would 400 long
+// conversations.
+const defaultMaxTokens = 16384
+
 func (p *Provider) NewModel(modelName string, opts ...Option) (llm.Model, error) {
 	// Build the API model ID. Most Bedrock models are cross-region inference
 	// profiles, so an un-prefixed name gets the source region's geo prefix
@@ -259,6 +270,14 @@ func (p *Provider) NewModel(modelName string, opts ...Option) (llm.Model, error)
 		if err := opt(cfg); err != nil {
 			return nil, fmt.Errorf("invalid option for %s: %w", modelName, err)
 		}
+	}
+
+	// Give Claude models a bounded default output budget when the caller set none,
+	// so they are not left at AWS's 4096. Scoped to Claude; clamped to the model's
+	// output cap so it can never exceed the limit. An explicit WithMaxTokens wins.
+	if cfg.MaxTokens == nil && isAnthropicModel(apiModelID) {
+		budget := int32(min(defaultMaxTokens, modelDef.Constraints.MaxOutputTokens)) //nolint:gosec // bounded: 1 <= budget <= MaxOutputTokens
+		cfg.MaxTokens = &budget
 	}
 
 	if err := cfg.Validate(); err != nil {

--- a/providers/bedrock/provider_test.go
+++ b/providers/bedrock/provider_test.go
@@ -510,6 +510,63 @@ func TestNewModel_BareInRegionModelNotPrefixed(t *testing.T) {
 	assert.Equal(t, ModelMistralLarge3, m.config.APIModelID)
 }
 
+// TestNewModel_ClaudeDefaultMaxTokens verifies that a Claude model on Bedrock
+// gets a bounded default output budget when the caller sets none — otherwise
+// Bedrock sends no max_tokens and AWS applies its own 4096, which truncates
+// ordinary agent turns.
+func TestNewModel_ClaudeDefaultMaxTokens(t *testing.T) {
+	t.Parallel()
+
+	p := &Provider{client: nil, region: "us-east-1"}
+
+	model, err := p.NewModel(ModelClaudeSonnet46)
+	require.NoError(t, err)
+
+	m, ok := model.(*Model)
+	require.True(t, ok)
+
+	require.NotNil(t, m.config.MaxTokens,
+		"a Claude model must get a bounded default rather than be left at AWS's 4096")
+	assert.Equal(t, int32(defaultMaxTokens), *m.config.MaxTokens)
+	assert.LessOrEqual(t, int(*m.config.MaxTokens), m.config.Constraints.MaxOutputTokens,
+		"the default must never exceed the model's output cap")
+}
+
+// TestNewModel_ExplicitMaxTokensOverridesClaudeDefault verifies an explicit
+// WithMaxTokens wins over the injected default.
+func TestNewModel_ExplicitMaxTokensOverridesClaudeDefault(t *testing.T) {
+	t.Parallel()
+
+	p := &Provider{client: nil, region: "us-east-1"}
+
+	model, err := p.NewModel(ModelClaudeSonnet46, WithMaxTokens(4096))
+	require.NoError(t, err)
+
+	m, ok := model.(*Model)
+	require.True(t, ok)
+
+	require.NotNil(t, m.config.MaxTokens)
+	assert.Equal(t, int32(4096), *m.config.MaxTokens, "an explicit budget must win over the default")
+}
+
+// TestNewModel_NonClaudeModelHasNoDefaultMaxTokens verifies the default is scoped
+// to Claude: other Bedrock families keep AWS's own default, since their output
+// caps and windows differ and their defaults are not the same footgun.
+func TestNewModel_NonClaudeModelHasNoDefaultMaxTokens(t *testing.T) {
+	t.Parallel()
+
+	p := &Provider{client: nil, region: "us-east-1"}
+
+	model, err := p.NewModel(ModelMistralLarge3)
+	require.NoError(t, err)
+
+	m, ok := model.(*Model)
+	require.True(t, ok)
+
+	assert.Nil(t, m.config.MaxTokens,
+		"non-Claude Bedrock models must not get an SDK-imposed max_tokens default")
+}
+
 func TestNewModel_Fable5RegionPrefix(t *testing.T) {
 	t.Parallel()
 

--- a/providers/bedrock/provider_test.go
+++ b/providers/bedrock/provider_test.go
@@ -580,6 +580,31 @@ func TestNewModel_ClaudeDefaultReachesConverseInput(t *testing.T) {
 	assert.Equal(t, int32(defaultMaxTokens), *input.InferenceConfig.MaxTokens)
 }
 
+// TestSupportedModels_ClaudeHaveOutputCap guards the invariant the Claude default
+// output budget relies on. NewModel only injects the default when
+// MaxOutputTokens > 0 (and clamps to it), so a Claude entry that forgot to set a
+// cap would silently revert to AWS's 4096 — the exact footgun this default
+// closes, with no signal. Make that mis-specification a build failure instead.
+func TestSupportedModels_ClaudeHaveOutputCap(t *testing.T) {
+	t.Parallel()
+
+	var checked int
+
+	for id, def := range supportedModels {
+		if isAnthropicModel(id) {
+			checked++
+
+			assert.Positive(t, def.Constraints.MaxOutputTokens,
+				"Claude model %q must set MaxOutputTokens so the default output budget applies", id)
+		}
+	}
+
+	// Guard against a vacuous pass: if isAnthropicModel ever stops matching the
+	// catalog keys, the loop above would assert nothing and still "pass".
+	require.Positive(t, checked, "expected Claude models in the catalog; the filter matched none")
+	t.Logf("checked %d Claude models", checked)
+}
+
 func TestNewModel_Fable5RegionPrefix(t *testing.T) {
 	t.Parallel()
 

--- a/providers/bedrock/provider_test.go
+++ b/providers/bedrock/provider_test.go
@@ -510,11 +510,56 @@ func TestNewModel_BareInRegionModelNotPrefixed(t *testing.T) {
 	assert.Equal(t, ModelMistralLarge3, m.config.APIModelID)
 }
 
-// TestNewModel_ClaudeDefaultMaxTokens verifies that a Claude model on Bedrock
-// gets a bounded default output budget when the caller sets none — otherwise
-// Bedrock sends no max_tokens and AWS applies its own 4096, which truncates
-// ordinary agent turns.
-func TestNewModel_ClaudeDefaultMaxTokens(t *testing.T) {
+// TestNewModel_DefaultMaxTokens verifies the Claude-scoped default output budget:
+// a Claude model with no budget set gets a bounded default (otherwise Bedrock
+// sends no max_tokens and AWS applies its own 4096, truncating ordinary turns),
+// an explicit WithMaxTokens wins, and non-Claude families are left untouched
+// (their output caps and defaults differ).
+func TestNewModel_DefaultMaxTokens(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		modelName string
+		opts      []Option
+		wantSet   bool
+		want      int32
+	}{
+		{"claude gets bounded default", ModelClaudeSonnet46, nil, true, defaultMaxTokens},
+		{"explicit budget wins", ModelClaudeSonnet46, []Option{WithMaxTokens(4096)}, true, 4096},
+		{"non-claude family untouched", ModelMistralLarge3, nil, false, 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			p := &Provider{client: nil, region: "us-east-1"}
+
+			model, err := p.NewModel(tt.modelName, tt.opts...)
+			require.NoError(t, err)
+
+			m, ok := model.(*Model)
+			require.True(t, ok)
+
+			if !tt.wantSet {
+				assert.Nil(t, m.config.MaxTokens, "no SDK-imposed default expected")
+
+				return
+			}
+
+			require.NotNil(t, m.config.MaxTokens)
+			assert.Equal(t, tt.want, *m.config.MaxTokens)
+			assert.LessOrEqual(t, int(*m.config.MaxTokens), m.config.Constraints.MaxOutputTokens,
+				"the default must never exceed the model's output cap")
+		})
+	}
+}
+
+// TestNewModel_ClaudeDefaultReachesConverseInput proves the injected default
+// actually reaches the wire (InferenceConfig.MaxTokens on the Converse input) —
+// the mechanism the fix depends on — not merely that it lands on the config.
+func TestNewModel_ClaudeDefaultReachesConverseInput(t *testing.T) {
 	t.Parallel()
 
 	p := &Provider{client: nil, region: "us-east-1"}
@@ -525,46 +570,14 @@ func TestNewModel_ClaudeDefaultMaxTokens(t *testing.T) {
 	m, ok := model.(*Model)
 	require.True(t, ok)
 
-	require.NotNil(t, m.config.MaxTokens,
-		"a Claude model must get a bounded default rather than be left at AWS's 4096")
-	assert.Equal(t, int32(defaultMaxTokens), *m.config.MaxTokens)
-	assert.LessOrEqual(t, int(*m.config.MaxTokens), m.config.Constraints.MaxOutputTokens,
-		"the default must never exceed the model's output cap")
-}
-
-// TestNewModel_ExplicitMaxTokensOverridesClaudeDefault verifies an explicit
-// WithMaxTokens wins over the injected default.
-func TestNewModel_ExplicitMaxTokensOverridesClaudeDefault(t *testing.T) {
-	t.Parallel()
-
-	p := &Provider{client: nil, region: "us-east-1"}
-
-	model, err := p.NewModel(ModelClaudeSonnet46, WithMaxTokens(4096))
+	input, err := NewRequestMapper(m.config).ToConverseInput(&llm.Request{
+		Messages: []llm.Message{llm.NewMessage(llm.RoleUser, llm.NewTextPart("Hi"))},
+	})
 	require.NoError(t, err)
 
-	m, ok := model.(*Model)
-	require.True(t, ok)
-
-	require.NotNil(t, m.config.MaxTokens)
-	assert.Equal(t, int32(4096), *m.config.MaxTokens, "an explicit budget must win over the default")
-}
-
-// TestNewModel_NonClaudeModelHasNoDefaultMaxTokens verifies the default is scoped
-// to Claude: other Bedrock families keep AWS's own default, since their output
-// caps and windows differ and their defaults are not the same footgun.
-func TestNewModel_NonClaudeModelHasNoDefaultMaxTokens(t *testing.T) {
-	t.Parallel()
-
-	p := &Provider{client: nil, region: "us-east-1"}
-
-	model, err := p.NewModel(ModelMistralLarge3)
-	require.NoError(t, err)
-
-	m, ok := model.(*Model)
-	require.True(t, ok)
-
-	assert.Nil(t, m.config.MaxTokens,
-		"non-Claude Bedrock models must not get an SDK-imposed max_tokens default")
+	require.NotNil(t, input.InferenceConfig)
+	require.NotNil(t, input.InferenceConfig.MaxTokens)
+	assert.Equal(t, int32(defaultMaxTokens), *input.InferenceConfig.MaxTokens)
 }
 
 func TestNewModel_Fable5RegionPrefix(t *testing.T) {

--- a/providers/bedrock/provider_test.go
+++ b/providers/bedrock/provider_test.go
@@ -526,7 +526,7 @@ func TestNewModel_DefaultMaxTokens(t *testing.T) {
 		want      int32
 	}{
 		{"claude gets bounded default", ModelClaudeSonnet46, nil, true, defaultMaxTokens},
-		{"explicit budget wins", ModelClaudeSonnet46, []Option{WithMaxTokens(4096)}, true, 4096},
+		{"explicit budget wins", ModelClaudeSonnet46, []Option{WithMaxTokens(8192)}, true, 8192},
 		{"non-claude family untouched", ModelMistralLarge3, nil, false, 0},
 	}
 


### PR DESCRIPTION
## What

On the Bedrock path, `Config.MaxTokens` defaults to `nil`, and the request mapper only sends `max_tokens` when it's non-nil — so AWS applies its own default, **4096 for Claude**, which truncates ordinary agent turns (sometimes to empty output when reasoning consumes the whole budget).

This gives **Claude models on Bedrock** a bounded default output budget (16K) when the caller sets none — the same safe out-of-the-box fallback the native Anthropic provider already has (#179), so Claude behaves consistently on either path.

```go
if cfg.MaxTokens == nil && isAnthropicModel(apiModelID) {
    budget := int32(min(defaultMaxTokens, modelDef.Constraints.MaxOutputTokens))
    cfg.MaxTokens = &budget
}
```

- **Scoped to the Claude family.** Other Bedrock families (Nova, Llama, Mistral, Gemma, gpt, …) have different output caps and context windows, and their AWS defaults aren't the same footgun — a blanket default risks 400s. So the default is applied only to `anthropic.*` model IDs.
- **Clamped** to the model's `MaxOutputTokens` so it can never exceed the cap.
- **Explicit `WithMaxTokens` still wins** — the default only fills when unset. Precedence: `WithMaxTokens` > default (mirrors the anthropic provider).

## Why

Surfaced via AI-1708 (a Bedrock-Claude agent hitting the 4096 cap). #179 raised the default and made truncation non-fatal, but the default bump was anthropic-provider-only; this closes the same footgun on the Bedrock path so a Bedrock-Claude agent isn't silently left at 4096 when no harness sets a budget.

## Testing

- `TestNewModel_ClaudeDefaultMaxTokens`: a Claude model with no options → 16K, never above the output cap.
- `TestNewModel_ExplicitMaxTokensOverridesClaudeDefault`: `WithMaxTokens(4096)` wins over the default.
- `TestNewModel_NonClaudeModelHasNoDefaultMaxTokens`: a non-Claude model (Mistral) keeps `nil` — guards the Claude-only scoping.
- Built TDD (red → green). No Bedrock e2e: the send-path mechanism is already proven by the anthropic e2e; this change is the default value + scoping, fully unit-testable.

## Scope

Default value + Claude scoping only. A per-request `max_tokens` override on Bedrock (matching the anthropic `RequestOptions`) is possible future work, not included here.