### PR TITLE
feat(openaicompat): add DeepSeek V4 presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,8 +88,10 @@ Works with DeepSeek, local models, or any OpenAI-compatible API.
 import "github.com/redpanda-data/ai-sdk-go/providers/openaicompat"
 
 provider, err := openaicompat.NewProvider(apiKey, openaicompat.WithBaseURL("https://api.deepseek.com"))
-model, err := provider.NewModel("deepseek-chat")
+model, err := provider.NewModel("deepseek-v4-flash", openaicompat.WithThinking(false))
 ```
+
+Use `deepseek-v4-pro` with `WithReasoning()` and `WithThinking(true)` for maximum capability.
 
 ## Streaming
 

--- a/providers/openaicompat/deepseek_conformance_test.go
+++ b/providers/openaicompat/deepseek_conformance_test.go
@@ -18,6 +18,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/redpanda-data/ai-sdk-go/internal/testsuite"
 	"github.com/redpanda-data/ai-sdk-go/llm"
 	"github.com/redpanda-data/ai-sdk-go/plugins/retry"
@@ -29,9 +32,9 @@ import (
 // DeepSeekFixture implements the conformance.Fixture interface for DeepSeek API.
 // This tests the openaicompat provider against DeepSeek's reasoning models.
 type DeepSeekFixture struct {
-	provider      *openaicompat.Provider
-	standardCaps  llm.ModelCapabilities
-	reasoningCaps llm.ModelCapabilities
+	provider     *openaicompat.Provider
+	capabilities llm.ModelCapabilities
+	constraints  llm.ModelConstraints
 }
 
 // NewDeepSeekFixture creates a new DeepSeek test fixture.
@@ -51,27 +54,27 @@ func NewDeepSeekFixture(t *testing.T) *DeepSeekFixture {
 		t.Fatalf("Failed to create DeepSeek provider: %v", err)
 	}
 
-	// DeepSeek-specific capabilities
-	// DeepSeek supports JSON mode (json_object) but not Structured Outputs (json_schema)
-	deepseekCaps := llm.ModelCapabilities{
-		Streaming:        true,
-		Tools:            true,
-		JSONMode:         true,  // Supports json_object
-		StructuredOutput: false, // Does NOT support json_schema
-		Vision:           true,
-		Audio:            false,
-		MultiTurn:        true,
-		SystemPrompts:    true,
-		Reasoning:        false, // Set per-model below
-	}
+	return newDeepSeekFixture(provider)
+}
 
-	reasoningCaps := deepseekCaps
-	reasoningCaps.Reasoning = true
-
+func newDeepSeekFixture(provider *openaicompat.Provider) *DeepSeekFixture {
 	return &DeepSeekFixture{
-		provider:      provider,
-		standardCaps:  deepseekCaps,
-		reasoningCaps: reasoningCaps,
+		provider: provider,
+		capabilities: llm.ModelCapabilities{
+			Streaming:     true,
+			Tools:         true,
+			JSONMode:      true,
+			MultiTurn:     true,
+			SystemPrompts: true,
+			Reasoning:     true,
+		},
+		constraints: llm.ModelConstraints{
+			TemperatureRange:  [2]float64{0.0, 2.0},
+			MaxInputTokens:    1_000_000,
+			MaxOutputTokens:   384_000,
+			SupportedParams:   []string{"temperature", "top_p", "max_tokens", "logprobs", "stop"},
+			MutuallyExclusive: [][]string{{"temperature", "top_p"}},
+		},
 	}
 }
 
@@ -82,9 +85,9 @@ func (f *DeepSeekFixture) Name() string {
 func (f *DeepSeekFixture) NewStandardModel(t *testing.T) llm.Model {
 	t.Helper()
 
-	model, err := f.provider.NewModel(
+	model, err := f.newModel(
 		openaicompattest.DeepSeekDefaultStandardModel,
-		openaicompat.WithCapabilities(f.standardCaps),
+		openaicompat.WithThinking(false),
 	)
 	if err != nil {
 		t.Fatalf("Failed to create standard model: %v", err)
@@ -96,9 +99,9 @@ func (f *DeepSeekFixture) NewStandardModel(t *testing.T) llm.Model {
 func (f *DeepSeekFixture) NewReasoningModel(t *testing.T) llm.Model {
 	t.Helper()
 
-	model, err := f.provider.NewModel(
+	model, err := f.newModel(
 		openaicompattest.DeepSeekDefaultReasoningModel,
-		openaicompat.WithCapabilities(f.reasoningCaps),
+		openaicompat.WithThinking(true),
 	)
 	if err != nil {
 		t.Fatalf("Failed to create reasoning model: %v", err)
@@ -108,11 +111,36 @@ func (f *DeepSeekFixture) NewReasoningModel(t *testing.T) llm.Model {
 }
 
 func (f *DeepSeekFixture) Models() []llm.ModelDiscoveryInfo {
-	return f.provider.Models()
+	return []llm.ModelDiscoveryInfo{
+		{
+			Name:         openaicompattest.DeepSeekDefaultStandardModel,
+			Label:        "DeepSeek V4 Flash",
+			Capabilities: f.capabilities,
+			Constraints:  f.constraints,
+		},
+		{
+			Name:         openaicompattest.DeepSeekDefaultReasoningModel,
+			Label:        "DeepSeek V4 Pro",
+			Capabilities: f.capabilities,
+			Constraints:  f.constraints,
+		},
+	}
 }
 
 func (f *DeepSeekFixture) NewModel(modelName string) (llm.Model, error) {
-	return f.provider.NewModel(modelName)
+	return f.newModel(modelName)
+}
+
+func (f *DeepSeekFixture) newModel(modelName string, opts ...openaicompat.Option) (llm.Model, error) {
+	opts = append([]openaicompat.Option{
+		openaicompat.WithConstraints(f.constraints),
+		openaicompat.WithCapabilities(f.capabilities),
+	}, opts...)
+
+	return f.provider.NewModel(
+		modelName,
+		opts...,
+	)
 }
 
 // TestDeepSeekConformance_Integration runs the generic conformance test suite against DeepSeek API.
@@ -129,4 +157,48 @@ func TestDeepSeekConformance_Integration(t *testing.T) {
 
 	fixture := NewDeepSeekFixture(t)
 	testsuite.Run(t, conformance.NewSuite(fixture))
+}
+
+func TestDeepSeekV4ConformancePresets(t *testing.T) {
+	t.Parallel()
+
+	provider, err := openaicompat.NewProvider(
+		"sk-test-key",
+		openaicompat.WithBaseURL(openaicompattest.DeepSeekDefaultBaseURL),
+	)
+	require.NoError(t, err)
+
+	fixture := newDeepSeekFixture(provider)
+	wantConstraints := llm.ModelConstraints{
+		TemperatureRange:  [2]float64{0.0, 2.0},
+		MaxInputTokens:    1_000_000,
+		MaxOutputTokens:   384_000,
+		SupportedParams:   []string{"temperature", "top_p", "max_tokens", "logprobs", "stop"},
+		MutuallyExclusive: [][]string{{"temperature", "top_p"}},
+	}
+	wantCapabilities := llm.ModelCapabilities{
+		Streaming:     true,
+		Tools:         true,
+		JSONMode:      true,
+		MultiTurn:     true,
+		SystemPrompts: true,
+		Reasoning:     true,
+	}
+
+	models := fixture.Models()
+	require.Len(t, models, 2)
+	require.Equal(t, []string{"deepseek-v4-flash", "deepseek-v4-pro"}, []string{models[0].Name, models[1].Name})
+
+	for _, info := range models {
+		assert.Equal(t, wantConstraints, info.Constraints)
+		assert.Equal(t, wantCapabilities, info.Capabilities)
+
+		model, err := fixture.NewModel(info.Name)
+		require.NoError(t, err)
+		assert.Equal(t, info.Constraints, model.Constraints())
+		assert.Equal(t, info.Capabilities, model.Capabilities())
+	}
+
+	assert.Equal(t, "deepseek-v4-flash", fixture.NewStandardModel(t).Name())
+	assert.Equal(t, "deepseek-v4-pro", fixture.NewReasoningModel(t).Name())
 }

--- a/providers/openaicompat/deepseek_integration_test.go
+++ b/providers/openaicompat/deepseek_integration_test.go
@@ -37,7 +37,7 @@ import (
 // Optional environment variables:
 //
 //	DEEPSEEK_BASE_URL - API base URL (default: https://api.deepseek.com)
-//	DEEPSEEK_MODEL - Model name (default: deepseek-reasoner)
+//	DEEPSEEK_MODEL - Model name (default: deepseek-v4-pro)
 func TestDeepSeekMultiTurnReasoning(t *testing.T) {
 	t.Parallel()
 
@@ -54,7 +54,7 @@ func TestDeepSeekMultiTurnReasoning(t *testing.T) {
 	require.NoError(t, err, "Failed to create provider")
 
 	// Create reasoning model
-	model, err := provider.NewModel(modelName, openaicompat.WithReasoning())
+	model, err := provider.NewModel(modelName, openaicompat.WithReasoning(), openaicompat.WithThinking(true))
 	require.NoError(t, err, "Failed to create model")
 
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)

--- a/providers/openaicompat/model.go
+++ b/providers/openaicompat/model.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/option"
 
 	"github.com/redpanda-data/ai-sdk-go/llm"
 )
@@ -67,7 +68,7 @@ func (m *Model) Generate(ctx context.Context, req *llm.Request) (*llm.Response, 
 	}
 
 	// Make the API call using Chat Completion API
-	response, err := m.client.Chat.Completions.New(ctx, apiReq)
+	response, err := m.client.Chat.Completions.New(ctx, apiReq, m.requestOptions()...)
 	if err != nil {
 		// Double-wrap: see anthropic/model.go Generate for rationale.
 		return nil, fmt.Errorf("%w: %w", llm.ErrAPICall, classifyError(err))
@@ -94,7 +95,7 @@ func (m *Model) GenerateEvents(ctx context.Context, req *llm.Request) iter.Seq2[
 		}
 
 		// Create streaming request using Chat Completion API
-		stream := m.client.Chat.Completions.NewStreaming(ctx, apiReq)
+		stream := m.client.Chat.Completions.NewStreaming(ctx, apiReq, m.requestOptions()...)
 		defer stream.Close() // Automatic cleanup, even on early break
 
 		var (
@@ -236,6 +237,19 @@ func (m *Model) GenerateEvents(ctx context.Context, req *llm.Request) iter.Seq2[
 			yield(nil, fmt.Errorf("%w: stream ended without finish reason", llm.ErrResponseMapping))
 		}
 	}
+}
+
+func (m *Model) requestOptions() []option.RequestOption {
+	if m.config.Thinking == nil {
+		return nil
+	}
+
+	thinkingType := "disabled"
+	if *m.config.Thinking {
+		thinkingType = "enabled"
+	}
+
+	return []option.RequestOption{option.WithJSONSet("thinking.type", thinkingType)}
 }
 
 // buildStreamEndResponse constructs the final unified response for StreamEndEvent

--- a/providers/openaicompat/openaicompat_test.go
+++ b/providers/openaicompat/openaicompat_test.go
@@ -16,6 +16,9 @@ package openaicompat
 
 import (
 	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -138,6 +141,74 @@ func TestModelConstraints(t *testing.T) {
 	_, err = provider.NewModel("any-model", WithTemperature(3.0))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "out of range")
+}
+
+func TestWithConstraints(t *testing.T) {
+	t.Parallel()
+
+	provider, err := NewProvider("sk-test-key")
+	require.NoError(t, err)
+
+	constraints := llm.ModelConstraints{
+		TemperatureRange: [2]float64{0.0, 1.0},
+		MaxInputTokens:   1_000_000,
+		MaxOutputTokens:  384_000,
+		SupportedParams:  []string{"max_tokens"},
+	}
+
+	model, err := provider.NewModel("custom-model", WithConstraints(constraints))
+	require.NoError(t, err)
+	assert.Equal(t, constraints, model.Constraints())
+
+	_, err = provider.NewModel("custom-model", WithConstraints(constraints), WithTemperature(0.5))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "temperature is not supported")
+
+	_, err = provider.NewModel("custom-model", WithConstraints(constraints), WithMaxTokens(384_001))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "max_tokens 384001 exceeds limit 384000")
+}
+
+func TestWithThinking(t *testing.T) {
+	t.Parallel()
+
+	requestBodies := make(chan map[string]any, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+
+		err := json.NewDecoder(r.Body).Decode(&body)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		requestBodies <- body
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{
+			"id":"chatcmpl-test",
+			"object":"chat.completion",
+			"created":1,
+			"model":"deepseek-v4-flash",
+			"choices":[{"index":0,"message":{"role":"assistant","content":"OK"},"finish_reason":"stop"}],
+			"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}
+		}`)
+	}))
+	t.Cleanup(server.Close)
+
+	provider, err := NewProvider("sk-test-key", WithBaseURL(server.URL))
+	require.NoError(t, err)
+	model, err := provider.NewModel("deepseek-v4-flash", WithThinking(false))
+	require.NoError(t, err)
+
+	_, err = model.Generate(t.Context(), &llm.Request{Messages: []llm.Message{{
+		Role:    llm.RoleUser,
+		Content: []llm.Part{llm.NewTextPart("Say OK")},
+	}}})
+	require.NoError(t, err)
+
+	body := <-requestBodies
+	assert.Equal(t, map[string]any{"type": "disabled"}, body["thinking"])
 }
 
 func TestModelCapabilities(t *testing.T) {

--- a/providers/openaicompat/openaicompattest/constants.go
+++ b/providers/openaicompat/openaicompattest/constants.go
@@ -21,11 +21,11 @@ const (
 	TestReasoningModelName = "o1"
 
 	// DeepSeekDefaultBaseURL is the default API base URL for DeepSeek.
-	DeepSeekDefaultBaseURL = "https://api.deepseek.com/v1"
-	// DeepSeekDefaultStandardModel is the default standard chat model.
-	DeepSeekDefaultStandardModel = "deepseek-chat"
-	// DeepSeekDefaultReasoningModel is the default reasoning model.
-	DeepSeekDefaultReasoningModel = "deepseek-reasoner"
+	DeepSeekDefaultBaseURL = "https://api.deepseek.com"
+	// DeepSeekDefaultStandardModel is the default fast model.
+	DeepSeekDefaultStandardModel = "deepseek-v4-flash"
+	// DeepSeekDefaultReasoningModel is the default high-capability model.
+	DeepSeekDefaultReasoningModel = "deepseek-v4-pro"
 
 	// AnthropicDefaultBaseURL is the Anthropic OpenAI-compatible endpoint.
 	AnthropicDefaultBaseURL = "https://api.anthropic.com/v1"

--- a/providers/openaicompat/options.go
+++ b/providers/openaicompat/options.go
@@ -32,6 +32,7 @@ type Config struct {
 	// Capability flags
 	SupportsReasoning  bool
 	CustomCapabilities *llm.ModelCapabilities // Override default capabilities if set
+	Thinking           *bool
 
 	// OpenAI-specific parameters
 	Temperature      *float64
@@ -45,6 +46,16 @@ type Config struct {
 
 	// Track which options have been set for conflict detection with model constraints
 	setOptions map[string]bool
+}
+
+// WithConstraints overrides the permissive constraints used for dynamic models.
+// Use this when the target OpenAI-compatible service publishes model-specific
+// token limits or parameter support.
+func WithConstraints(constraints llm.ModelConstraints) Option {
+	return func(cfg *Config) error {
+		cfg.Constraints = constraints
+		return nil
+	}
 }
 
 // WithCapabilities overrides the default model capabilities.
@@ -62,6 +73,15 @@ func WithCapabilities(caps llm.ModelCapabilities) Option {
 func WithReasoning() Option {
 	return func(cfg *Config) error {
 		cfg.SupportsReasoning = true
+		return nil
+	}
+}
+
+// WithThinking toggles thinking mode for compatible APIs such as DeepSeek.
+// The setting is sent as the OpenAI-compatible `thinking.type` extension.
+func WithThinking(enabled bool) Option {
+	return func(cfg *Config) error {
+		cfg.Thinking = &enabled
 		return nil
 	}
 }
@@ -134,8 +154,8 @@ func WithMaxTokens(tokens int) Option {
 			return fmt.Errorf("%s: max_tokens must be positive, got %d", cfg.ModelName, tokens)
 		}
 
-		if tokens > cfg.Constraints.MaxInputTokens {
-			return fmt.Errorf("%s: max_tokens %d exceeds limit %d", cfg.ModelName, tokens, cfg.Constraints.MaxInputTokens)
+		if tokens > cfg.Constraints.MaxOutputTokens {
+			return fmt.Errorf("%s: max_tokens %d exceeds limit %d", cfg.ModelName, tokens, cfg.Constraints.MaxOutputTokens)
 		}
 
 		cfg.MaxTokens = &tokens

--- a/providers/openaicompat/reasoning_parsing_test.go
+++ b/providers/openaicompat/reasoning_parsing_test.go
@@ -35,12 +35,12 @@ func TestReasoningContentParsing(t *testing.T) {
 		t.Parallel()
 
 		// Simulate a response with reasoning_content in extra fields
-		// This is what DeepSeek-R1 or vLLM with reasoning parser returns
+		// This is what DeepSeek V4 or vLLM with a reasoning parser returns.
 		rawJSON := `{
 			"id": "test-123",
 			"object": "chat.completion",
 			"created": 1234567890,
-			"model": "deepseek-reasoner",
+			"model": "deepseek-v4-pro",
 			"choices": [{
 				"index": 0,
 				"message": {

--- a/providers/openaicompat/reasoning_test.go
+++ b/providers/openaicompat/reasoning_test.go
@@ -16,7 +16,6 @@ package openaicompat_test
 
 import (
 	"context"
-	"os"
 	"strings"
 	"testing"
 	"time"
@@ -26,6 +25,7 @@ import (
 
 	"github.com/redpanda-data/ai-sdk-go/llm"
 	"github.com/redpanda-data/ai-sdk-go/providers/openaicompat"
+	"github.com/redpanda-data/ai-sdk-go/providers/openaicompat/openaicompattest"
 )
 
 // TestDeepSeekReasoningContent_Integration tests that reasoning_content is correctly extracted
@@ -33,21 +33,22 @@ import (
 func TestDeepSeekReasoningContent_Integration(t *testing.T) {
 	t.Parallel()
 
-	apiKey := os.Getenv("DEEPSEEK_API_KEY")
-	if apiKey == "" {
-		t.Skip("DEEPSEEK_API_KEY not set, skipping integration test")
-	}
+	apiKey := openaicompattest.GetDeepSeekAPIKeyOrSkipTest(t)
 
 	// Create provider pointing to DeepSeek's API
 	provider, err := openaicompat.NewProvider(
 		apiKey,
-		openaicompat.WithBaseURL("https://api.deepseek.com"),
+		openaicompat.WithBaseURL(openaicompattest.GetDeepSeekBaseURL()),
 		openaicompat.WithTimeout(2*time.Minute),
 	)
 	require.NoError(t, err)
 
 	// Create a reasoning model
-	model, err := provider.NewModel("deepseek-reasoner", openaicompat.WithReasoning())
+	model, err := provider.NewModel(
+		openaicompattest.DeepSeekDefaultReasoningModel,
+		openaicompat.WithReasoning(),
+		openaicompat.WithThinking(true),
+	)
 	require.NoError(t, err)
 
 	ctx := context.Background()


### PR DESCRIPTION
## Summary
- replace retired `deepseek-chat` and `deepseek-reasoner` presets with `deepseek-v4-flash` and `deepseek-v4-pro`
- apply DeepSeek's published 1M context / 384K output constraints and add explicit thinking-mode request support
- cover both V4 models in DeepSeek conformance discovery and update README/integration fixtures

## Why
DeepSeek retired the legacy model aliases on July 24, 2026. The OpenAI-compatible provider needs current presets plus an explicit non-thinking mode so standard tool-call conformance remains valid while V4 defaults to thinking.

Live DeepSeek verification is out of scope for this environment because `DEEPSEEK_API_KEY` is unavailable; the real integration and conformance tests remain credential-gated.

## Sources
- [DeepSeek changelog](https://api-docs.deepseek.com/updates/)
- [DeepSeek V4 release](https://api-docs.deepseek.com/news/news260424/)
- [Models and pricing](https://api-docs.deepseek.com/quick_start/pricing/)
- [Thinking mode](https://api-docs.deepseek.com/guides/thinking_mode/)

## Commits
- `0992302` feat(openaicompat): add deepseek v4 presets

## Reviewer guide
Start with `providers/openaicompat/options.go` and `model.go` for constraint/thinking behavior, then `deepseek_conformance_test.go` for the V4 contract and coverage, then the remaining fixture/docs migrations.

## Dogfood evidence
- Verdict: PASS
- Entrypoint: standalone temporary Go consumer via `.build/go1.26.5/bin/go run .context/deepseek-dogfood.go`
- Actions and break attempts: constructed Flash/non-thinking and Pro/thinking models, generated through an OpenAI-compatible test server, inspected outgoing JSON, then requested 384,001 output tokens
- Observations: emitted `thinking.type=disabled` for Flash and `enabled` for Pro; both exposed a 384,000-token output limit; oversized output was rejected
- Repairs and replay: no dogfood defects; final replay passed
- Limits: endpoint was simulated because no DeepSeek API credential is available

## Test plan
- [x] `go test ./providers/openaicompat -short -count=1`
- [x] `task test:unit`
- [x] `task lint:new`
- [x] `task license:check`
- [x] `git diff --check`
- [x] retired identifier scan with `rg 'deepseek-(chat|reasoner)'`

🤖 Generated with Codex