### PR TITLE
chore(anthropic): remove retired claude-opus-4-1 model

### DIFF
--- a/providers/anthropic/alias_test.go
+++ b/providers/anthropic/alias_test.go
@@ -114,16 +114,6 @@ func TestModelResolution(t *testing.T) {
 			modelKey:      "claude-opus-4-5-20251101",
 			expectedModel: "claude-opus-4-5-20251101",
 		},
-		{
-			name:          "claude-opus-4-1 family name resolves",
-			modelKey:      "claude-opus-4-1",
-			expectedModel: "claude-opus-4-1",
-		},
-		{
-			name:          "claude-opus-4-1 arbitrary timestamp resolves",
-			modelKey:      "claude-opus-4-1-20240101",
-			expectedModel: "claude-opus-4-1-20240101",
-		},
 	}
 
 	for _, tt := range tests {
@@ -151,8 +141,8 @@ func TestCustomModelName(t *testing.T) {
 	require.NoError(t, err)
 
 	model, err := provider.NewModel(
-		"claude-opus-4-1",
-		WithCustomModelName("claude-opus-4-2-beta"),
+		"claude-opus-4-5",
+		WithCustomModelName("claude-opus-4-9-beta"),
 	)
 	require.NoError(t, err)
 	require.NotNil(t, model)
@@ -160,8 +150,8 @@ func TestCustomModelName(t *testing.T) {
 	m, ok := model.(*Model)
 	require.True(t, ok)
 
-	assert.Equal(t, "claude-opus-4-1", m.config.ModelName)
-	assert.Equal(t, "claude-opus-4-2-beta", m.config.CustomModelName)
+	assert.Equal(t, "claude-opus-4-5", m.config.ModelName)
+	assert.Equal(t, "claude-opus-4-9-beta", m.config.CustomModelName)
 	assert.Equal(t, int(200000), m.config.Constraints.MaxInputTokens)
 }
 
@@ -183,7 +173,7 @@ func TestCustomModelNameValidation(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = provider.NewModel(
-		"claude-opus-4-1",
+		"claude-opus-4-5",
 		WithCustomModelName(""),
 	)
 	require.Error(t, err)

--- a/providers/anthropic/models.go
+++ b/providers/anthropic/models.go
@@ -35,7 +35,6 @@ const (
 	ModelClaudeOpus47   = "claude-opus-4-7"
 	ModelClaudeOpus46   = "claude-opus-4-6"
 	ModelClaudeOpus45   = "claude-opus-4-5"
-	ModelClaudeOpus41   = "claude-opus-4-1"
 )
 
 // Effort controls the output effort level for supported models.
@@ -402,31 +401,6 @@ var supportedModels = map[string]ModelDefinition{
 					Rates:            pricing.NewRates(60.00, 225.00, 6.00).WithCacheCreation(75.00, 120.00, 0),
 				}},
 			},
-		),
-	},
-	ModelClaudeOpus41: {
-		Name:  ModelClaudeOpus41,
-		Label: "Claude Opus 4.1",
-		Capabilities: llm.ModelCapabilities{
-			Streaming:        true,
-			Tools:            true,
-			JSONMode:         false, // Anthropic doesn't have native JSON mode
-			StructuredOutput: false, // Use tool calling for structured output instead
-			Vision:           true,
-			MultiTurn:        true,
-			SystemPrompts:    true,
-			Reasoning:        true, // Extended thinking support
-		},
-		Constraints: llm.ModelConstraints{
-			TemperatureRange:  [2]float64{0.0, 1.0},
-			MaxInputTokens:    200000, // 200K context window
-			MaxOutputTokens:   32000,  // 32K output tokens
-			SupportedParams:   []string{"temperature", "top_p", "top_k", "max_tokens"},
-			MutuallyExclusive: [][]string{},
-		},
-		Pricing: pricing.FlatInfoFromRates(
-			pricing.NewRates(15.00, 75.00, 1.50).
-				WithCacheCreation(18.75, 30.00, 0),
 		),
 	},
 	ModelClaudeOpus45: {

--- a/providers/anthropic/options.go
+++ b/providers/anthropic/options.go
@@ -240,7 +240,7 @@ func WithSpeed(speed Speed) Option {
 
 // WithCustomModelName allows overriding the model name sent to the API while
 // inheriting the base model's capabilities and constraints. This is useful for:
-//   - Using newly released models before SDK updates (e.g., "claude-opus-4-2" using claude-opus-4-1 constraints)
+//   - Using newly released models before SDK updates (e.g., "claude-opus-4-9" using claude-opus-4-8 constraints)
 //   - Testing beta/experimental model variants
 //   - Using timestamped versions not yet in the SDK
 //
@@ -249,7 +249,7 @@ func WithSpeed(speed Speed) Option {
 //
 // Example:
 //
-//	provider.NewModel("claude-opus-4-1", WithCustomModelName("claude-opus-4-2-beta"))
+//	provider.NewModel("claude-opus-4-8", WithCustomModelName("claude-opus-4-9-beta"))
 func WithCustomModelName(customName string) Option {
 	return func(cfg *Config) error {
 		if customName == "" {


### PR DESCRIPTION
`claude-opus-4-1` has been retired upstream by Anthropic, but it is still in the anthropic catalog. The live conformance test fails against it and reds the **Test** check on every PR in the repo, regardless of that PR's own changes.

```
--- FAIL: TestAnthropicConformance_Integration/TestAllSupportedModels/
      basic_generation_works_for_all_supported_models/model_claude-opus-4-1

POST https://api.anthropic.com/v1/messages?beta=true
404 Not Found
{"type":"error","error":{"type":"not_found_error","message":"model: claude-opus-4-1"}}
```

### Not a regression

`main`'s last Test run passed on 2026-08-04 ([run 30891056535](https://github.com/redpanda-data/ai-sdk-go/actions/runs/30891056535)); the model 404s as of 2026-08-10. `main` would fail this identically today — it just hasn't run CI since the 4th. Surfaced on [#180](https://github.com/redpanda-data/ai-sdk-go/pull/180) ([run 31370738255](https://github.com/redpanda-data/ai-sdk-go/actions/runs/31370738255)), which is otherwise green and approved.

### What changed

Following the same pattern as `1eea507` (gemini-2.0-flash) and `8940552` (Grok 4.3) — remove from supported models, tests and references, with no changes to the test suite:

| File | Change |
|---|---|
| `models.go` | Drop the `ModelClaudeOpus41` constant and its `supportedModels` entry |
| `alias_test.go` | Drop the two model-resolution cases; repoint the two custom-model-name tests at `claude-opus-4-5` |
| `options.go` | Refresh the two `WithCustomModelName` doc examples that named it |

Two notes on the test changes:

- The dropped resolution cases are redundant — every other model already covers both the family-name and timestamped patterns.
- `TestCustomModelName` and `TestCustomModelNameValidation` exercise custom model naming rather than 4.1 specifically, and only need a valid base model. `claude-opus-4-5` shares the same 200K input / 32K output constraints, so the existing assertions hold unchanged. Deleting those tests would have lost real coverage.

### Why not teach the suite to skip

`isModelAccessGate` deliberately covers models that exist but aren't reachable by the test account — Fable 5 without Mythos access, or a Bedrock model without an AWS Marketplace subscription. A retired model doesn't exist for anyone, which is a different condition, and widening the matcher would make the suite quieter about genuinely-wrong model IDs. Retirement is handled by removing the entry.

### Verification

`gofmt`, `go build ./...` and `go vet` clean. `llm`, all five provider packages and the `plugins/*` packages pass. No `claude-opus-4-1` references remain anywhere in the repo.

Out of scope: sweeping the catalogs for other models that may also have been retired. If another has been, CI will red again the same way — worth a follow-up.

AI-1779
