### PR TITLE
chore(openai): remove retired gpt-5.2-chat-latest and gpt-5.3-chat-latest

### DIFF
--- a/providers/openai/constants.go
+++ b/providers/openai/constants.go
@@ -35,13 +35,8 @@ const (
 
 	// ModelGPT5_2 is the GPT-5.2 Thinking model (default variant).
 	ModelGPT5_2 = shared.ChatModelGPT5_2
-	// ModelGPT5_2Instant is the GPT-5.2 Instant model (speed-optimized variant).
-	ModelGPT5_2Instant = shared.ChatModelGPT5_2ChatLatest
 	// ModelGPT5_2Pro is the GPT-5.2 Pro model (maximum accuracy variant).
 	ModelGPT5_2Pro = shared.ChatModelGPT5_2Pro
-
-	// ModelGPT5_3ChatLatest is the GPT-5.3 Chat Latest model (speed-optimized, medium-only reasoning).
-	ModelGPT5_3ChatLatest = shared.ChatModelGPT5_3ChatLatest
 
 	// ModelGPT5_6Luna is the cost-optimized GPT-5.6 model.
 	ModelGPT5_6Luna = shared.ChatModelGPT5_6Luna

--- a/providers/openai/models.go
+++ b/providers/openai/models.go
@@ -198,30 +198,6 @@ var supportedModels = map[string]ModelDefinition{
 		SupportedReasoningEfforts: []ReasoningEffort{ReasoningEffortNone, ReasoningEffortLow, ReasoningEffortMedium, ReasoningEffortHigh, ReasoningEffortXHigh},
 		Pricing:                   pricing.FlatInfo(0.875, 7.00, 0.175),
 	},
-	ModelGPT5_2Instant: {
-		Name:  ModelGPT5_2Instant,
-		Label: "OpenAI GPT-5.2 Instant",
-		Capabilities: llm.ModelCapabilities{
-			Streaming:        true,
-			Tools:            true,
-			JSONMode:         true,
-			StructuredOutput: true,
-			Vision:           true,
-			Audio:            true,
-			MultiTurn:        true,
-			SystemPrompts:    true,
-			Reasoning:        true,
-		},
-		Constraints: llm.ModelConstraints{
-			TemperatureRange:  [2]float64{0.0, 2.0},
-			MaxInputTokens:    400000, // 400K context window
-			MaxOutputTokens:   128000, // 128K output tokens
-			SupportedParams:   []string{"temperature", "top_p", "max_tokens", "frequency_penalty", "presence_penalty", "seed", "reasoning_effort", "reasoning_summary"},
-			MutuallyExclusive: [][]string{{"temperature", "top_p"}},
-		},
-		SupportedReasoningEfforts: []ReasoningEffort{ReasoningEffortMedium}, // Instant variant only supports medium
-		Pricing:                   pricing.FlatInfo(0.875, 7.00, 0.175),
-	},
 	ModelGPT5_2Pro: {
 		Name:  ModelGPT5_2Pro,
 		Label: "OpenAI GPT-5.2 Pro",
@@ -245,32 +221,6 @@ var supportedModels = map[string]ModelDefinition{
 		},
 		SupportedReasoningEfforts: []ReasoningEffort{ReasoningEffortMedium, ReasoningEffortHigh, ReasoningEffortXHigh}, // Pro variant starts at medium
 		Pricing:                   pricing.FlatInfo(10.50, 84.00, 0),
-	},
-
-	// GPT-5.3 Series
-	ModelGPT5_3ChatLatest: {
-		Name:  ModelGPT5_3ChatLatest,
-		Label: "OpenAI GPT-5.3 Chat Latest",
-		Capabilities: llm.ModelCapabilities{
-			Streaming:        true,
-			Tools:            true,
-			JSONMode:         true,
-			StructuredOutput: true,
-			Vision:           true,
-			Audio:            true,
-			MultiTurn:        true,
-			SystemPrompts:    true,
-			Reasoning:        true,
-		},
-		Constraints: llm.ModelConstraints{
-			TemperatureRange:  [2]float64{0.0, 2.0},
-			MaxInputTokens:    400000, // 400K context window
-			MaxOutputTokens:   128000, // 128K output tokens
-			SupportedParams:   []string{"temperature", "top_p", "max_tokens", "frequency_penalty", "presence_penalty", "seed", "reasoning_effort", "reasoning_summary"},
-			MutuallyExclusive: [][]string{{"temperature", "top_p"}},
-		},
-		SupportedReasoningEfforts: []ReasoningEffort{ReasoningEffortMedium}, // Chat-latest only supports medium
-		Pricing:                   pricing.FlatInfo(1.75, 14.00, 0.175),
 	},
 
 	// GPT-5.6 Series

--- a/providers/openai/openai_integration_test.go
+++ b/providers/openai/openai_integration_test.go
@@ -167,9 +167,7 @@ func TestAllModelsReasoningEffortsIntegration(t *testing.T) {
 		ModelGPT5Mini,
 		ModelGPT5_1,
 		ModelGPT5_2,
-		ModelGPT5_2Instant,
 		ModelGPT5_2Pro,
-		ModelGPT5_3ChatLatest,
 		ModelGPT5_4,
 		ModelGPT5_4Mini,
 		ModelO3,
@@ -307,34 +305,10 @@ func TestUnsupportedReasoningEffortsIntegration(t *testing.T) {
 			reason:       "GPT-5.2-pro doesn't support 'low'",
 		},
 		{
-			model:        ModelGPT5_2Instant,
-			effort:       ReasoningEffortNone,
-			shouldReject: true,
-			reason:       "GPT-5.2-instant only supports 'medium'",
-		},
-		{
-			model:        ModelGPT5_2Instant,
-			effort:       ReasoningEffortLow,
-			shouldReject: true,
-			reason:       "GPT-5.2-instant only supports 'medium'",
-		},
-		{
 			model:        ModelGPT5_4,
 			effort:       ReasoningEffortMinimal,
 			shouldReject: true,
 			reason:       "GPT-5.4 doesn't support 'minimal'",
-		},
-		{
-			model:        ModelGPT5_3ChatLatest,
-			effort:       ReasoningEffortNone,
-			shouldReject: true,
-			reason:       "GPT-5.3-chat-latest only supports 'medium'",
-		},
-		{
-			model:        ModelGPT5_3ChatLatest,
-			effort:       ReasoningEffortHigh,
-			shouldReject: true,
-			reason:       "GPT-5.3-chat-latest only supports 'medium'",
 		},
 	}
 
@@ -397,13 +371,6 @@ func TestSupportedReasoningEfforts(t *testing.T) {
 			model:         ModelGPT5_4,
 			expectedFirst: ReasoningEffortNone,
 			expectNone:    true,
-			expectMinimal: false,
-		},
-		{
-			name:          "gpt-5.3-chat-latest should only have 'medium'",
-			model:         ModelGPT5_3ChatLatest,
-			expectedFirst: ReasoningEffortMedium,
-			expectNone:    false,
 			expectMinimal: false,
 		},
 		{

--- a/providers/openai/openai_test.go
+++ b/providers/openai/openai_test.go
@@ -110,7 +110,7 @@ func TestProviderModels(t *testing.T) {
 	}
 
 	// Verify expected models are present
-	expectedModels := []string{"gpt-4o", "gpt-4o-mini", "o3", "gpt-5", "gpt-5.2", "gpt-5.3-chat-latest", "gpt-5.4", "gpt-5.4-mini", "gpt-5.4-nano"}
+	expectedModels := []string{"gpt-4o", "gpt-4o-mini", "o3", "gpt-5", "gpt-5.2", "gpt-5.4", "gpt-5.4-mini", "gpt-5.4-nano"}
 	for _, expected := range expectedModels {
 		assert.Contains(t, modelNames, expected, "Should include %s", expected)
 	}
@@ -948,19 +948,6 @@ func TestReasoningEffort(t *testing.T) {
 			reasoningOpts: []Option{WithReasoningEffort(ReasoningEffortMinimal)},
 			wantErr:       true,
 			errContains:   "does not support reasoning effort 'minimal'",
-		},
-		{
-			name:          "gpt-5.3-chat-latest with ReasoningEffortMedium (supported)",
-			model:         ModelGPT5_3ChatLatest,
-			reasoningOpts: []Option{WithReasoningEffort(ReasoningEffortMedium)},
-			wantErr:       false,
-		},
-		{
-			name:          "gpt-5.3-chat-latest with ReasoningEffortHigh (unsupported)",
-			model:         ModelGPT5_3ChatLatest,
-			reasoningOpts: []Option{WithReasoningEffort(ReasoningEffortHigh)},
-			wantErr:       true,
-			errContains:   "does not support reasoning effort 'high'",
 		},
 		{
 			name:          "o3 with ReasoningEffortLow (supported)",


### PR DESCRIPTION
OpenAI pulled both models — the API now returns `Model not found`, failing `TestOpenAIConformance_Integration/TestAllSupportedModels` and `TestAllModelsReasoningEffortsIntegration` on every PR. `main` was green at de1a67d earlier the same day, so they went away today.

Removes the catalog entries, the `ModelGPT5_2Instant` / `ModelGPT5_3ChatLatest` constants, and the test cases pinning their reasoning-effort sets — same approach as fd3cac7 for claude-opus-4-1.

Needs to land before #193 / #194 can go green.