### PR TITLE
fix(otel): gate remaining content behind the recording opt-ins

### DIFF
--- a/plugins/otel/interceptor.go
+++ b/plugins/otel/interceptor.go
@@ -174,9 +174,10 @@ func (t *TracingInterceptor) startInvocationSpan(
 
 	agentSnap := inv.Agent()
 
-	// Add system instructions from agent snapshot (not from session messages)
-	// Per OTel spec, system_instructions should be for separately-provided instructions
-	if agentSnap.SystemPrompt != "" {
+	// Add system instructions from agent snapshot (not from session messages).
+	// Per OTel spec, system_instructions carries separately-provided instruction
+	// content and is Opt-In — recorded only when input recording is enabled.
+	if t.cfg.recordInputs && agentSnap.SystemPrompt != "" {
 		// Transform to OTel format (array of parts)
 		systemPart := genai.Part{
 			Type:    genai.PartTypeText,

--- a/plugins/otel/otel_test.go
+++ b/plugins/otel/otel_test.go
@@ -595,6 +595,60 @@ func TestTracingInterceptor_InterceptToolExecution_ToolErrorResponse(t *testing.
 	}
 }
 
+func TestTracingInterceptor_InterceptToolExecution_ToolErrorPayloadGatedByRecordOutputs(t *testing.T) {
+	t.Parallel()
+
+	exporter, tp := setupTracer()
+	defer tp.Shutdown(t.Context()) //nolint:errcheck // Test cleanup
+
+	// No WithRecordOutputs: the error payload is content and must stay out of the span.
+	interceptor := pluginotel.New(
+		pluginotel.WithTracerProvider(tp),
+	)
+
+	inv := agent.NewInvocationMetadata(&session.State{ID: "sess-123"}, agent.Info{
+		Name: "test-agent",
+	})
+	ctx := t.Context()
+
+	_, _ = interceptor.InterceptTurn(ctx, &agent.TurnInfo{Inv: inv}, func(ctx context.Context, _ *agent.TurnInfo) (agent.FinishReason, error) {
+		req := &llm.ToolRequestPart{Name: "query_logs", ID: "tool-call-abc", Arguments: json.RawMessage(`{"query":"errors"}`)}
+
+		toolInfo := &agent.ToolCallInfo{Inv: inv, Req: req}
+		resp, err := interceptor.InterceptToolExecution(ctx, toolInfo,
+			func(_ context.Context, _ *agent.ToolCallInfo) (*llm.ToolResponsePart, error) {
+				return &llm.ToolResponsePart{
+					ID:      "tool-call-abc",
+					Name:    "query_logs",
+					IsError: true, Result: json.RawMessage(`{"error":"query failed: secret record 42"}`),
+				}, nil
+			})
+		require.NoError(t, err)
+		assert.NotNil(t, resp)
+
+		return agent.FinishReasonStop, nil
+	})
+
+	spans := exporter.GetSpans()
+	var toolSpan *tracetest.SpanStub
+
+	for i := range spans {
+		if strings.HasPrefix(spans[i].Name, "execute_tool") {
+			toolSpan = &spans[i]
+			break
+		}
+	}
+
+	require.NotNil(t, toolSpan, "Expected execute_tool span")
+
+	// The span still reports the error, but with a generic description.
+	assert.Equal(t, codes.Error, toolSpan.Status.Code)
+	assert.NotContains(t, toolSpan.Status.Description, "secret record 42")
+	assert.Equal(t, "tool returned an error", toolSpan.Status.Description)
+	assertHasAttribute(t, toolSpan.Attributes, "error.type", "tool_error")
+	assertMissingAttribute(t, toolSpan.Attributes, "gen_ai.tool.call.result")
+}
+
 func TestTracingInterceptor_SpanHierarchy(t *testing.T) {
 	t.Parallel()
 
@@ -1421,6 +1475,7 @@ func TestTracingInterceptor_SystemInstructions_Emitted(t *testing.T) {
 
 	interceptor := pluginotel.New(
 		pluginotel.WithTracerProvider(tp),
+		pluginotel.WithRecordInputs(true), // system instructions are content: recorded only with inputs opt-in
 	)
 
 	inv := agent.NewInvocationMetadata(&session.State{ID: "sess-123"}, agent.Info{
@@ -1448,6 +1503,33 @@ func TestTracingInterceptor_SystemInstructions_Emitted(t *testing.T) {
 	}
 
 	assert.True(t, found, "Expected gen_ai.system_instructions attribute")
+}
+
+func TestTracingInterceptor_SystemInstructions_NotEmittedWithoutRecordInputs(t *testing.T) {
+	t.Parallel()
+
+	exporter, tp := setupTracer()
+	defer tp.Shutdown(t.Context()) //nolint:errcheck // Test cleanup
+
+	interceptor := pluginotel.New(
+		pluginotel.WithTracerProvider(tp),
+	)
+
+	inv := agent.NewInvocationMetadata(&session.State{ID: "sess-123"}, agent.Info{
+		Name:         "test-agent",
+		SystemPrompt: "You are a helpful assistant.",
+	})
+	ctx := t.Context()
+
+	_, _ = interceptor.InterceptTurn(ctx, &agent.TurnInfo{Inv: inv}, func(_ context.Context, _ *agent.TurnInfo) (agent.FinishReason, error) {
+		return agent.FinishReasonStop, nil
+	})
+
+	spans := exporter.GetSpans()
+	require.Len(t, spans, 1)
+
+	// The system prompt is content: without the inputs opt-in the attribute must be absent.
+	assertMissingAttribute(t, spans[0].Attributes, "gen_ai.system_instructions")
 }
 
 func TestTracingInterceptor_ModelAndProvider_OnInvocationSpan(t *testing.T) {

--- a/plugins/otel/tool.go
+++ b/plugins/otel/tool.go
@@ -132,7 +132,13 @@ func (t *TracingInterceptor) InterceptToolExecution(
 		// Case 2: Tool returned error content (analogous to MCP isError=true).
 		// Per OTel MCP semconv: error.type SHOULD be "tool_error" and span status SHOULD be Error.
 		// gen_ai.tool.call.result is NOT recorded (spec: "if execution was successful").
-		setToolError(span, string(resp.Result))
+		// The error payload carries the same kind of content as a successful result,
+		// so it only reaches the status description when output recording is enabled.
+		if t.cfg.recordOutputs {
+			setToolError(span, string(resp.Result))
+		} else {
+			setToolError(span, "tool returned an error")
+		}
 		span.SetAttributes(toolResultAvailable(false))
 	default:
 		// Case 3: Success


### PR DESCRIPTION
Two span attributes carried content even with `WithRecordInputs`/`WithRecordOutputs` disabled, so "no content recording" still leaked payloads. Both writes now sit behind the existing opt-in flags; enabled behavior is unchanged. Per the GenAI semconv, all content attributes are Opt-In and status descriptions should not carry payloads.

- Tool error payloads (`resp.Result` on `isError`) only reach the span status description with `WithRecordOutputs(true)`; otherwise the status is a generic "tool returned an error" with `error.type=tool_error` intact.
- `gen_ai.system_instructions` on the invoke_agent span is now gated on `WithRecordInputs(true)`.
- Added negative-path tests for both; the existing system-instructions test now opts in explicitly.