### PR TITLE
fix(openaicompat): classify decode and transport failures

### DIFF
--- a/providers/openaicompat/errors.go
+++ b/providers/openaicompat/errors.go
@@ -15,11 +15,36 @@
 package openaicompat
 
 import (
+	"context"
+	"encoding/json"
 	"errors"
+	"fmt"
+	"io"
+	"net"
 
 	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/packages/ssestream"
 
 	"github.com/redpanda-data/ai-sdk-go/llm"
+)
+
+// Codes for failures that never got far enough to carry an HTTP status. An
+// OpenAI-compatible upstream has no error taxonomy of its own for these, so we
+// supply one: without it the errors below reach the caller with no category and
+// no code, which is exactly how an openai-go SSE decoding bug presented as a
+// bare "unexpected end of JSON input" with nothing in the error to point at.
+const (
+	// codeResponseDecode: the upstream returned bytes we could not decode as an
+	// OpenAI-shaped response.
+	codeResponseDecode = "response_decode_error"
+
+	// codeTransport: the request failed below HTTP — connection reset,
+	// truncated body, DNS failure.
+	codeTransport = "transport_error"
+
+	// codeStreamError: the upstream reported a failure inside an SSE data frame
+	// instead of as an HTTP error.
+	codeStreamError = "stream_error"
 )
 
 // classifyError maps OpenAI SDK errors to *llm.ProviderError with the
@@ -33,6 +58,58 @@ func classifyError(err error) error {
 	var apiErr *openai.Error
 	if errors.As(err, &apiErr) {
 		return classifyHTTPError(apiErr)
+	}
+
+	return classifyNonHTTPError(err)
+}
+
+// classifyNonHTTPError handles the failures that carry no HTTP status: decode
+// failures, transport failures, and errors the upstream delivered inside an SSE
+// frame. Anything it does not recognise is returned unchanged.
+func classifyNonHTTPError(err error) error {
+	// Cancellation and deadlines belong to the caller, not to the provider.
+	// Return them untouched: ProviderError.Unwrap yields only Base, so wrapping
+	// would sever the chain and break errors.Is at the call site.
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return err
+	}
+
+	var streamErr *ssestream.StreamError
+	if errors.As(err, &streamErr) {
+		// No status code to map — the error arrived as a data frame. Not marked
+		// retryable: the payload is opaque at this layer, and a mid-stream
+		// failure is as likely to be terminal as transient.
+		return &llm.ProviderError{
+			Base:    llm.ErrAPICall,
+			Code:    codeStreamError,
+			Message: streamErr.Error(),
+		}
+	}
+
+	var (
+		syntaxErr *json.SyntaxError
+		typeErr   *json.UnmarshalTypeError
+	)
+
+	if errors.As(err, &syntaxErr) || errors.As(err, &typeErr) {
+		// Retryable: the usual cause is protocol noise on a slow upstream
+		// response, which the same request often survives on a second attempt.
+		return &llm.ProviderError{
+			Base:      llm.ErrServerError,
+			Code:      codeResponseDecode,
+			Message:   fmt.Sprintf("could not decode provider response: %s", err),
+			Retryable: true,
+		}
+	}
+
+	var netErr net.Error
+	if errors.As(err, &netErr) || errors.Is(err, io.ErrUnexpectedEOF) || errors.Is(err, io.EOF) {
+		return &llm.ProviderError{
+			Base:      llm.ErrServerError,
+			Code:      codeTransport,
+			Message:   fmt.Sprintf("transport failure: %s", err),
+			Retryable: true,
+		}
 	}
 
 	return err

--- a/providers/openaicompat/errors_test.go
+++ b/providers/openaicompat/errors_test.go
@@ -15,12 +15,19 @@
 package openaicompat
 
 import (
+	"context"
+	"encoding/json"
 	"errors"
+	"fmt"
+	"io"
+	"net"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"testing"
 
 	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/packages/ssestream"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -100,4 +107,149 @@ func TestClassifyHTTPError_ProviderErrorFields(t *testing.T) {
 	assert.Equal(t, "rate_limit_exceeded", pe.Code)
 	assert.Equal(t, "Rate limit exceeded", pe.Message)
 	assert.True(t, pe.Retryable)
+}
+
+func TestClassifyError_DecodeFailure(t *testing.T) {
+	t.Parallel()
+
+	// The shape openai-go's SSE decoder produced on an empty data buffer.
+	err := json.Unmarshal([]byte{}, &struct{}{})
+	require.Error(t, err)
+
+	result := classifyError(err)
+
+	var pe *llm.ProviderError
+	require.ErrorAs(t, result, &pe)
+	require.ErrorIs(t, pe, llm.ErrServerError)
+	assert.Equal(t, codeResponseDecode, pe.Code)
+	assert.True(t, pe.Retryable)
+	assert.True(t, llm.IsRetryable(result))
+	assert.Contains(t, pe.Message, "unexpected end of JSON input")
+}
+
+func TestClassifyError_DecodeTypeMismatch(t *testing.T) {
+	t.Parallel()
+
+	var target struct {
+		N int `json:"n"`
+	}
+
+	err := json.Unmarshal([]byte(`{"n":"not-a-number"}`), &target)
+	require.Error(t, err)
+
+	result := classifyError(err)
+
+	var pe *llm.ProviderError
+	require.ErrorAs(t, result, &pe)
+	require.ErrorIs(t, pe, llm.ErrServerError)
+	assert.Equal(t, codeResponseDecode, pe.Code)
+	assert.True(t, pe.Retryable)
+}
+
+func TestClassifyError_StreamError(t *testing.T) {
+	t.Parallel()
+
+	result := classifyError(&ssestream.StreamError{Message: "received error while streaming: overloaded"})
+
+	var pe *llm.ProviderError
+	require.ErrorAs(t, result, &pe)
+	require.ErrorIs(t, pe, llm.ErrAPICall)
+	assert.Equal(t, codeStreamError, pe.Code)
+	assert.False(t, pe.Retryable)
+	assert.Contains(t, pe.Message, "overloaded")
+}
+
+func TestClassifyError_Transport(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{"net error", &net.OpError{Op: "dial", Err: errors.New("connection refused")}},
+		{"url error", &url.Error{Op: "Post", URL: "https://openrouter.ai", Err: errors.New("EOF")}},
+		{"truncated body", fmt.Errorf("reading body: %w", io.ErrUnexpectedEOF)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			result := classifyError(tt.err)
+
+			var pe *llm.ProviderError
+			require.ErrorAs(t, result, &pe)
+			require.ErrorIs(t, pe, llm.ErrServerError)
+			assert.Equal(t, codeTransport, pe.Code)
+			assert.True(t, pe.Retryable)
+		})
+	}
+}
+
+// Cancellation and deadlines are the caller's, and callers match them with
+// errors.Is. ProviderError.Unwrap returns only Base, so wrapping them here
+// would sever that chain.
+func TestClassifyError_ContextErrorsPassThrough(t *testing.T) {
+	t.Parallel()
+
+	for _, sentinel := range []error{context.Canceled, context.DeadlineExceeded} {
+		t.Run(sentinel.Error(), func(t *testing.T) {
+			t.Parallel()
+
+			wrapped := &url.Error{Op: "Post", URL: "https://openrouter.ai", Err: sentinel}
+
+			result := classifyError(wrapped)
+			require.ErrorIs(t, result, sentinel)
+
+			var pe *llm.ProviderError
+			assert.NotErrorAs(t, result, &pe)
+		})
+	}
+}
+
+// TestStreamDecodeErrorIsClassified exercises the real path: a malformed SSE
+// frame from the upstream, through model.GenerateEvents, out to the caller.
+// Before decode errors were classified, this arrived as a bare "unexpected end
+// of JSON input" with no category, no code, and no status.
+func TestStreamDecodeErrorIsClassified(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: {\"id\":\"gen-1\",\"choices\":[\n\n"))
+	}))
+	t.Cleanup(server.Close)
+
+	provider, err := NewProvider("sk-test-key", WithBaseURL(server.URL))
+	require.NoError(t, err)
+
+	model, err := provider.NewModel("m")
+	require.NoError(t, err)
+
+	var streamErr error
+
+	for _, err := range model.GenerateEvents(t.Context(), &llm.Request{
+		Messages: []llm.Message{{
+			Role:    llm.RoleUser,
+			Content: []llm.Part{llm.NewTextPart("hi")},
+		}},
+	}) {
+		if err != nil {
+			streamErr = err
+			break
+		}
+	}
+
+	require.Error(t, streamErr)
+	require.ErrorIs(t, streamErr, llm.ErrAPICall)
+	require.ErrorIs(t, streamErr, llm.ErrServerError)
+
+	var pe *llm.ProviderError
+	require.ErrorAs(t, streamErr, &pe)
+	assert.Equal(t, codeResponseDecode, pe.Code)
+	assert.True(t, llm.IsRetryable(streamErr))
+	assert.Equal(t,
+		"API call failed: server error: [response_decode_error] "+
+			"could not decode provider response: unexpected end of JSON input",
+		streamErr.Error())
 }


### PR DESCRIPTION
## What

`classifyError` in `providers/openaicompat` now produces a structured `*llm.ProviderError` for failures that never carried an HTTP status: JSON decode failures, transport failures, and errors the upstream delivered inside an SSE data frame.

Follow-up to the openai-go v3.43.0 bump (#200), independent of it.

## Why

`classifyError` only built a `ProviderError` for `*openai.Error`. Everything else was returned raw, so any failure below HTTP reached the caller with no category, no code and no status.

That is how an openai-go SSE decoding bug (AI-1902) presented in production. Streaming against OpenRouter died with

```
agent: model generation failed: API call failed: unexpected end of JSON input
```

category `unknown`, code `-1`. Nothing in the error said the failure was a decode failure rather than something the upstream rejected, and nothing said a retry was worth attempting. Diagnosing it took a raw SSE capture off the customer's gateway. The same error now reads

```
API call failed: server error: [response_decode_error] could not decode provider response: unexpected end of JSON input
```

## Implementation details

| Failure | Base | Code | Retryable |
| --- | --- | --- | --- |
| `*json.SyntaxError`, `*json.UnmarshalTypeError` | `ErrServerError` | `response_decode_error` | yes |
| `net.Error`, `io.ErrUnexpectedEOF`, `io.EOF` | `ErrServerError` | `transport_error` | yes |
| `*ssestream.StreamError` | `ErrAPICall` | `stream_error` | no |

**Why decode failures are retryable.** The usual cause is protocol noise on a slow upstream response — keepalives, a truncated frame — and the same request often survives a second attempt. AI-1902 was intermittent for exactly this reason: it only fired when the upstream held the connection open.

**Why `stream_error` is not.** The payload is opaque at this layer — a mid-stream error object could be a rate limit or a hard model failure, and there is no status code to tell them apart. A mid-stream failure is as likely to be terminal as transient, so it does not claim to be retryable.

**Context errors are returned untouched.** `ProviderError.Unwrap` yields only `Base`, so wrapping a `context.Canceled` would sever the chain and break `errors.Is(err, context.Canceled)` at the call site. Checked before everything else, since a `context.DeadlineExceeded` inside a `*url.Error` also satisfies `net.Error`.

Unrecognised errors still pass through unchanged, so nothing that already worked changes shape.

Codes are unexported. The goal is a log line an operator can read, not new public API surface.

**Scope.** `providers/openai`, `anthropic`, `google` and `bedrock` have the same gap in their own `classifyError`. Left alone here to keep this reviewable; folding the non-HTTP half into a shared helper is the obvious follow-up if the team wants it.

Tests cover each branch plus the end-to-end path — a malformed SSE frame from an `httptest` upstream, through `GenerateEvents`, asserting the category, code, retryability and the exact message the caller sees.

## References

- AI-1902
- #200 (the openai-go bump that fixes the bug this made undiagnosable)