### PR TITLE
fix(openaicompat): retry transport failures instead of guessing at them

### DIFF
--- a/providers/openaicompat/errors.go
+++ b/providers/openaicompat/errors.go
@@ -19,8 +19,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
-	"net"
 
 	"github.com/openai/openai-go/v3"
 	"github.com/openai/openai-go/v3/packages/ssestream"
@@ -28,28 +26,13 @@ import (
 	"github.com/redpanda-data/ai-sdk-go/llm"
 )
 
-// Codes for failures that never got far enough to carry an HTTP status. An
-// OpenAI-compatible upstream has no error taxonomy of its own for these, so we
-// supply one: without it the errors below reach the caller with no category and
-// no code, which is exactly how an openai-go SSE decoding bug presented as a
-// bare "unexpected end of JSON input" with nothing in the error to point at.
 const (
-	// codeResponseDecode: the upstream returned bytes we could not decode as an
-	// OpenAI-shaped response.
 	codeResponseDecode = "response_decode_error"
-
-	// codeTransport: the request failed below HTTP — connection reset,
-	// truncated body, DNS failure.
-	codeTransport = "transport_error"
-
-	// codeStreamError: the upstream reported a failure inside an SSE data frame
-	// instead of as an HTTP error.
-	codeStreamError = "stream_error"
+	codeTransport      = "transport_error"
+	codeStreamError    = "stream_error"
 )
 
-// classifyError maps OpenAI SDK errors to *llm.ProviderError with the
-// appropriate sentinel base and Retryable flag.
-// This is used by both the model and response mapper.
+// classifyError maps SDK errors to *llm.ProviderError.
 func classifyError(err error) error {
 	if err == nil {
 		return nil
@@ -63,22 +46,17 @@ func classifyError(err error) error {
 	return classifyNonHTTPError(err)
 }
 
-// classifyNonHTTPError handles the failures that carry no HTTP status: decode
-// failures, transport failures, and errors the upstream delivered inside an SSE
-// frame. Anything it does not recognise is returned unchanged.
 func classifyNonHTTPError(err error) error {
-	// Cancellation and deadlines belong to the caller, not to the provider.
-	// Return them untouched: ProviderError.Unwrap yields only Base, so wrapping
-	// would sever the chain and break errors.Is at the call site.
+	// Returned untouched: ProviderError.Unwrap yields only Base, so wrapping
+	// these would break errors.Is against them at the call site.
 	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 		return err
 	}
 
+	// Not retryable: the frame's payload is opaque here, and a mid-stream
+	// failure is as likely to be terminal as transient.
 	var streamErr *ssestream.StreamError
 	if errors.As(err, &streamErr) {
-		// No status code to map — the error arrived as a data frame. Not marked
-		// retryable: the payload is opaque at this layer, and a mid-stream
-		// failure is as likely to be terminal as transient.
 		return &llm.ProviderError{
 			Base:    llm.ErrAPICall,
 			Code:    codeStreamError,
@@ -86,14 +64,19 @@ func classifyNonHTTPError(err error) error {
 		}
 	}
 
-	var (
-		syntaxErr *json.SyntaxError
-		typeErr   *json.UnmarshalTypeError
-	)
+	// Well-formed JSON disagreeing with our structs replays identically.
+	var typeErr *json.UnmarshalTypeError
+	if errors.As(err, &typeErr) {
+		return &llm.ProviderError{
+			Base:    llm.ErrResponseMapping,
+			Code:    codeResponseDecode,
+			Message: fmt.Sprintf("could not decode provider response: %s", err),
+		}
+	}
 
-	if errors.As(err, &syntaxErr) || errors.As(err, &typeErr) {
-		// Retryable: the usual cause is protocol noise on a slow upstream
-		// response, which the same request often survives on a second attempt.
+	// A mangled stream; a second attempt can land on a clean response.
+	var syntaxErr *json.SyntaxError
+	if errors.As(err, &syntaxErr) {
 		return &llm.ProviderError{
 			Base:      llm.ErrServerError,
 			Code:      codeResponseDecode,
@@ -102,17 +85,17 @@ func classifyNonHTTPError(err error) error {
 		}
 	}
 
-	var netErr net.Error
-	if errors.As(err, &netErr) || errors.Is(err, io.ErrUnexpectedEOF) || errors.Is(err, io.EOF) {
-		return &llm.ProviderError{
-			Base:      llm.ErrServerError,
-			Code:      codeTransport,
-			Message:   fmt.Sprintf("transport failure: %s", err),
-			Retryable: true,
-		}
+	// Do not narrow this to net.Error or an errno set. An h2 stream reset is
+	// net/http's unexported http2StreamError: not a net.Error, unreachable by
+	// errors.As, and h2 is the default for https upstreams. Whatever such a
+	// check missed would silently become permanent, which costs the caller's
+	// whole task where a needless retry costs three short attempts.
+	return &llm.ProviderError{
+		Base:      llm.ErrServerError,
+		Code:      codeTransport,
+		Message:   fmt.Sprintf("transport failure: %s", err),
+		Retryable: true,
 	}
-
-	return err
 }
 
 // classifyHTTPError maps an OpenAI HTTP API error to a *llm.ProviderError.

--- a/providers/openaicompat/errors_test.go
+++ b/providers/openaicompat/errors_test.go
@@ -40,12 +40,17 @@ func TestClassifyError_Nil(t *testing.T) {
 	assert.NoError(t, classifyError(nil))
 }
 
-func TestClassifyError_UnknownError(t *testing.T) {
+func TestClassifyError_UnrecognisedIsRetryableTransport(t *testing.T) {
 	t.Parallel()
 
-	err := errors.New("something unexpected")
-	result := classifyError(err)
-	assert.Equal(t, err, result)
+	result := classifyError(errors.New("something unexpected"))
+
+	var pe *llm.ProviderError
+	require.ErrorAs(t, result, &pe)
+	require.ErrorIs(t, pe, llm.ErrServerError)
+	assert.Equal(t, codeTransport, pe.Code)
+	assert.True(t, pe.Retryable)
+	assert.True(t, llm.IsRetryable(result))
 }
 
 func TestClassifyHTTPError(t *testing.T) {
@@ -127,7 +132,7 @@ func TestClassifyError_DecodeFailure(t *testing.T) {
 	assert.Contains(t, pe.Message, "unexpected end of JSON input")
 }
 
-func TestClassifyError_DecodeTypeMismatch(t *testing.T) {
+func TestClassifyError_DecodeTypeMismatchIsNotRetryable(t *testing.T) {
 	t.Parallel()
 
 	var target struct {
@@ -141,9 +146,10 @@ func TestClassifyError_DecodeTypeMismatch(t *testing.T) {
 
 	var pe *llm.ProviderError
 	require.ErrorAs(t, result, &pe)
-	require.ErrorIs(t, pe, llm.ErrServerError)
+	require.ErrorIs(t, pe, llm.ErrResponseMapping)
 	assert.Equal(t, codeResponseDecode, pe.Code)
-	assert.True(t, pe.Retryable)
+	assert.False(t, pe.Retryable, "a type mismatch replays identically")
+	assert.False(t, llm.IsRetryable(result))
 }
 
 func TestClassifyError_StreamError(t *testing.T) {
@@ -252,4 +258,47 @@ func TestStreamDecodeErrorIsClassified(t *testing.T) {
 		"API call failed: server error: [response_decode_error] "+
 			"could not decode provider response: unexpected end of JSON input",
 		streamErr.Error())
+}
+
+// Guards the classifier's transport default against being narrowed; see the
+// comment on that arm in errors.go.
+func TestHTTP2StreamResetIsRetryable(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"gen-1","object":"chat.completion","choices":[`))
+
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+
+		// A short Content-Length yields a plain EOF and misses this path.
+		panic(http.ErrAbortHandler) //nolint:forbidigo // aborts h2 with RST_STREAM
+	}))
+	server.EnableHTTP2 = true
+	server.StartTLS()
+	t.Cleanup(server.Close)
+
+	provider, err := NewProvider("sk-test-key",
+		WithBaseURL(server.URL+"/v1"), WithHTTPClient(server.Client()))
+	require.NoError(t, err)
+
+	model, err := provider.NewModel("m")
+	require.NoError(t, err)
+
+	_, err = model.Generate(t.Context(), &llm.Request{
+		Messages: []llm.Message{{
+			Role:    llm.RoleUser,
+			Content: []llm.Part{llm.NewTextPart("hi")},
+		}},
+	})
+	require.Error(t, err)
+	require.ErrorContains(t, err, "INTERNAL_ERROR", "expected an h2 stream reset")
+
+	var pe *llm.ProviderError
+	require.ErrorAs(t, err, &pe)
+	assert.Equal(t, codeTransport, pe.Code)
+	assert.True(t, pe.Retryable)
+	assert.True(t, llm.IsRetryable(err))
 }


### PR DESCRIPTION
## What

`openaicompat` classifies any non-HTTP failure it does not specifically recognise as a retryable `transport_error`, rather than testing which transport failures are transient.

`*json.UnmarshalTypeError` no longer retries; `*json.SyntaxError` still does.

## Why

**`net.Error` does not describe the set of transport failures.** An HTTP/2 stream reset arrives as net/http's `http2StreamError`: unexported, not a `net.Error`, and unreachable by `errors.As` because net/http vendors its own copy of x/net/http2. Any entry condition narrower than "everything else" misses it, and it then leaves the classifier with no code, no category and `Retryable` unset, which `llm.IsRetryable` reads as false. h2 is the default for `https://` upstreams and OpenAI/OpenRouter-class gateways emit server-initiated resets routinely, so this is the most common transient failure on the default protocol.

**The set cannot be enumerated.** Socket errnos differ per platform — Winsock's `WSAECONNREFUSED` is not `syscall.ECONNREFUSED`, so an errno table classifies every socket failure permanent on Windows. Proxies invent their own hangups. New protocols add more. Under an allowlist every condition not yet enumerated becomes permanent, which is the wrong way to be wrong.

**The two directions cost differently.** Retrying a permanent failure — a scheme typo, an untrusted certificate — costs three attempts at 200/400/800ms (`plugins/retry` defaults) and then reports the error it would have reported anyway. Refusing to retry a transient one fails the caller's whole task. Roughly 1.4 seconds against a dead task is not a trade worth a taxonomy to win.

`*json.UnmarshalTypeError` is the one case where retrying is provably pointless and detection is free: well-formed JSON whose shape disagrees with our structs replays identically. It becomes a non-retryable `ErrResponseMapping`. `*json.SyntaxError` is what a truncated or interleaved stream produces, so it stays retryable.

## Implementation details

`classifyNonHTTPError` keeps its recognised shapes and defaults the rest:

| failure | Base | Code | Retryable |
| --- | --- | --- | --- |
| `context.Canceled` / `DeadlineExceeded` | returned untouched | — | — |
| error inside an SSE frame | `llm.ErrAPICall` | `stream_error` | no |
| `*json.UnmarshalTypeError` | `llm.ErrResponseMapping` | `response_decode_error` | no |
| `*json.SyntaxError` | `llm.ErrServerError` | `response_decode_error` | yes |
| anything else | `llm.ErrServerError` | `transport_error` | yes |

Context errors are returned unwrapped because `ProviderError.Unwrap` yields only `Base`, so classifying them would sever the chain and break `errors.Is(err, context.Canceled)` at the call site. A `WithTimeout` expiry surfaces as `context.DeadlineExceeded` and is therefore also passed through.

Nothing in the transport arm inspects the error's shape, so there are no per-platform files and no build tags. `go vet` is clean across linux, darwin, windows, freebsd, wasip1, plan9 and js.

`TestHTTP2StreamResetIsRetryable` pins the arm that has no other observable contract, driving a real reset through the provider against an h2 `httptest` server. It aborts the response with `panic(http.ErrAbortHandler)`: a short `Content-Length` yields a plain EOF and does not reach this path.

## Not addressed

- `ProviderError.Unwrap` returns only `Base`, so classifying severs the original cause — `errors.Is(err, syscall.ECONNREFUSED)` on the result is false. Fixing it means giving `llm.ProviderError` a wrapped cause and a multi-error `Unwrap`, which touches every provider.
- `insufficient_quota` arrives as HTTP 429 and is classified by status, so a permanent billing failure is retried like a rate limit. Belongs in a change to the HTTP path.
- openai-go's client retries transport errors twice before `classifyError` sees anything, so two retry loops multiply. `option.WithMaxRetries(0)` and letting the retry interceptor own the policy is the fix.
- A provider-side timeout is indistinguishable from a caller deadline by error value, so it is not marked retryable. `model.go:74` and `:217` both hold the `ctx`, and `ctx.Err() == nil` beside a deadline error would identify it — at the cost of threading `ctx` through the exported `ResponseMapper.FromProviderError`.
- `providers/openai`, `anthropic`, `google` and `bedrock` return non-HTTP errors raw.

## References

- AI-1902
- #200, #201
