### PR TITLE
fix(anthropic): put the cache breakpoint on the last cacheable block

### DIFF
--- a/providers/anthropic/cache_conversation_test.go
+++ b/providers/anthropic/cache_conversation_test.go
@@ -1,0 +1,132 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package anthropic_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/redpanda-data/ai-sdk-go/llm"
+	"github.com/redpanda-data/ai-sdk-go/providers/anthropic"
+	"github.com/redpanda-data/ai-sdk-go/providers/anthropic/anthropictest"
+	"github.com/redpanda-data/ai-sdk-go/providers/testutil"
+)
+
+// TestAnthropicConversationCaching_Integration is the end-to-end proof that an
+// agentic conversation caches, against the live API.
+//
+// It replays the shape of a real tool-calling loop: every turn appends an
+// assistant tool_use and a user tool_result, so from turn 2 on the last message
+// carries no text block at all. Two things are being established that a
+// request-shape unit test cannot:
+//
+//  1. Anthropic accepts cache_control on a tool_result block. A rejected
+//     breakpoint is a 400 on the whole request, so any Generate error fails here.
+//  2. The conversation, not just the static tools+system prefix, is cached.
+//     The signature is cache_read GROWING turn over turn. When the breakpoint is
+//     restricted to text blocks the tool_result turns go unmarked, no cache entry
+//     is ever written past the system blocks, and cache_read sits FLAT at the
+//     system-prefix size while input_tokens climbs with the history.
+func TestAnthropicConversationCaching_Integration(t *testing.T) {
+	t.Parallel()
+
+	apiKey := anthropictest.GetAPIKeyOrSkipTest(t)
+
+	provider, err := anthropic.NewProvider(apiKey, anthropic.WithTimeout(3*time.Minute))
+	require.NoError(t, err)
+
+	// Keep the output budget small: only usage accounting matters here.
+	model, err := provider.NewModel(anthropictest.TestModelName, anthropic.WithMaxTokens(64))
+	require.NoError(t, err)
+
+	tools := []llm.ToolDefinition{{
+		Name:        "lookup_record",
+		Description: "Look up a record by id.",
+		Parameters:  json.RawMessage(`{"type":"object","properties":{"id":{"type":"string"}},"required":["id"]}`),
+	}}
+
+	// The cacheable prefix has a per-model token minimum (1024 on Sonnet), so
+	// the system prompt has to clear it on its own for turn 1 to write anything.
+	messages := []llm.Message{
+		{
+			Role:    llm.RoleSystem,
+			Content: []llm.Part{llm.NewTextPart(testutil.GenerateLargePrompt(1800))},
+		},
+		{
+			Role:    llm.RoleUser,
+			Content: []llm.Part{llm.NewTextPart("Look up record alpha.")},
+		},
+	}
+
+	ctx := context.Background()
+
+	const turns = 4
+
+	reads := make([]int, 0, turns)
+	inputs := make([]int, 0, turns)
+
+	for turn := 1; turn <= turns; turn++ {
+		resp, err := model.Generate(ctx, &llm.Request{Messages: messages, Tools: tools})
+		require.NoError(t, err, "turn %d: a rejected cache_control breakpoint surfaces as a 400 here", turn)
+		require.NotNil(t, resp.Usage)
+
+		reads = append(reads, resp.Usage.CachedInputTokens)
+		inputs = append(inputs, resp.Usage.InputTokens)
+
+		t.Logf("turn %d: input %d, cache_read %d, cache_write %d",
+			turn, resp.Usage.InputTokens, resp.Usage.CachedInputTokens,
+			resp.Usage.CacheCreation5mTokens+resp.Usage.CacheCreationUnknownTTLTokens)
+
+		// Append a fixed tool round-trip rather than the model's own reply: the
+		// cache is a byte-prefix match, so the history has to be reproduced
+		// exactly on the next turn. A non-deterministic assistant turn would
+		// invalidate the prefix and make this test measure nothing.
+		callID := fmt.Sprintf("call_%d", turn)
+		messages = append(messages,
+			llm.Message{
+				Role: llm.RoleAssistant,
+				Content: []llm.Part{
+					llm.NewToolRequestPart(callID, "lookup_record",
+						json.RawMessage(fmt.Sprintf(`{"id":"record-%d"}`, turn))),
+				},
+			},
+			llm.Message{
+				Role: llm.RoleUser,
+				Content: []llm.Part{
+					llm.NewToolResponsePart(callID, "lookup_record",
+						json.RawMessage(fmt.Sprintf(`{"id":"record-%d","body":%q}`,
+							turn, testutil.GenerateLargePrompt(400))), false),
+				},
+			},
+		)
+	}
+
+	// Turn 1 writes; from turn 2 on every request must read a prefix that
+	// includes the preceding tool_result turns, so the read grows each time.
+	require.Positive(t, reads[1], "turn 2 must read the cached prefix written by turn 1")
+
+	for turn := 2; turn < turns; turn++ {
+		require.Greater(t, reads[turn], reads[turn-1],
+			"cache_read must grow as the conversation grows (turn %d: %d vs turn %d: %d); "+
+				"a flat cache_read while input climbs (%v) means the tool_result turns carry no breakpoint "+
+				"and only the static system prefix is cached",
+			turn+1, reads[turn], turn, reads[turn-1], inputs)
+	}
+}

--- a/providers/anthropic/cache_default_test.go
+++ b/providers/anthropic/cache_default_test.go
@@ -147,9 +147,12 @@ func hasCacheMarker(cc anthropic.BetaCacheControlEphemeralParam) bool {
 }
 
 // lastMessageHasCacheMarker reports whether any block in the message carries a
-// cache_control marker. It has to cover every block type the mapper can mark,
-// not just text: a helper that only looked at text blocks would report "no
-// marker" for a tool_result turn that is in fact correctly marked.
+// cache_control marker.
+//
+// It must cover every block type markLastCacheableBlock can mark. A helper that
+// is narrower than the mapper reports "no marker" for a turn that is in fact
+// correctly marked, and the assert.False call sites would then pass silently on
+// exactly the regression they exist to catch.
 func lastMessageHasCacheMarker(msg anthropic.BetaMessageParam) bool {
 	for _, block := range msg.Content {
 		switch {
@@ -158,6 +161,10 @@ func lastMessageHasCacheMarker(msg anthropic.BetaMessageParam) bool {
 		case block.OfToolResult != nil && hasCacheMarker(block.OfToolResult.CacheControl):
 			return true
 		case block.OfToolUse != nil && hasCacheMarker(block.OfToolUse.CacheControl):
+			return true
+		case block.OfImage != nil && hasCacheMarker(block.OfImage.CacheControl):
+			return true
+		case block.OfDocument != nil && hasCacheMarker(block.OfDocument.CacheControl):
 			return true
 		}
 	}

--- a/providers/anthropic/cache_default_test.go
+++ b/providers/anthropic/cache_default_test.go
@@ -146,11 +146,18 @@ func hasCacheMarker(cc anthropic.BetaCacheControlEphemeralParam) bool {
 	return cc.Type != ""
 }
 
-// lastMessageHasCacheMarker reports whether any text block in the message
-// carries a cache_control marker.
+// lastMessageHasCacheMarker reports whether any block in the message carries a
+// cache_control marker. It has to cover every block type the mapper can mark,
+// not just text: a helper that only looked at text blocks would report "no
+// marker" for a tool_result turn that is in fact correctly marked.
 func lastMessageHasCacheMarker(msg anthropic.BetaMessageParam) bool {
 	for _, block := range msg.Content {
-		if block.OfText != nil && hasCacheMarker(block.OfText.CacheControl) {
+		switch {
+		case block.OfText != nil && hasCacheMarker(block.OfText.CacheControl):
+			return true
+		case block.OfToolResult != nil && hasCacheMarker(block.OfToolResult.CacheControl):
+			return true
+		case block.OfToolUse != nil && hasCacheMarker(block.OfToolUse.CacheControl):
 			return true
 		}
 	}

--- a/providers/anthropic/cache_tool_result_test.go
+++ b/providers/anthropic/cache_tool_result_test.go
@@ -1,0 +1,197 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package anthropic
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/anthropics/anthropic-sdk-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/redpanda-data/ai-sdk-go/llm"
+)
+
+// TestCacheBreakpointOnToolResultTurn is the regression test for the shape that
+// dominates an agentic loop: the last message is a user turn holding only
+// tool_result blocks. Marking text blocks only left that turn unmarked, so the
+// request went out with a breakpoint on the system blocks alone and the whole
+// conversation was re-billed at full input price after every tool call.
+func TestCacheBreakpointOnToolResultTurn(t *testing.T) {
+	t.Parallel()
+
+	apiReq := mapCachedRequest(t, []llm.Message{
+		{
+			Role:    llm.RoleSystem,
+			Content: []llm.Part{llm.NewTextPart("You are a helpful assistant.")},
+		},
+		{
+			Role:    llm.RoleUser,
+			Content: []llm.Part{llm.NewTextPart("What is the weather?")},
+		},
+		{
+			Role: llm.RoleAssistant,
+			Content: []llm.Part{
+				llm.NewToolRequestPart("call_1", "get_weather", json.RawMessage(`{"city":"Berlin"}`)),
+			},
+		},
+		{
+			Role: llm.RoleUser,
+			Content: []llm.Part{
+				llm.NewToolResponsePart("call_1", "get_weather", json.RawMessage(`{"temp_c":21}`), false),
+			},
+		},
+	})
+
+	last := apiReq.Messages[len(apiReq.Messages)-1]
+	require.Len(t, last.Content, 1)
+	require.NotNil(t, last.Content[0].OfToolResult, "last block must be the tool_result")
+
+	assert.True(t, hasCacheMarker(last.Content[0].OfToolResult.CacheControl),
+		"tool_result-only turn must carry the cache breakpoint; without it the conversation never caches")
+}
+
+// TestCacheBreakpointOnParallelToolResults covers parallel tool calls, where the
+// turn carries several tool_result blocks. Exactly one breakpoint belongs on the
+// turn — the last block — because Anthropic allows only four per request.
+func TestCacheBreakpointOnParallelToolResults(t *testing.T) {
+	t.Parallel()
+
+	apiReq := mapCachedRequest(t, []llm.Message{
+		{
+			Role:    llm.RoleUser,
+			Content: []llm.Part{llm.NewTextPart("Compare Berlin and Paris.")},
+		},
+		{
+			Role: llm.RoleAssistant,
+			Content: []llm.Part{
+				llm.NewToolRequestPart("call_1", "get_weather", json.RawMessage(`{"city":"Berlin"}`)),
+				llm.NewToolRequestPart("call_2", "get_weather", json.RawMessage(`{"city":"Paris"}`)),
+			},
+		},
+		{
+			Role: llm.RoleUser,
+			Content: []llm.Part{
+				llm.NewToolResponsePart("call_1", "get_weather", json.RawMessage(`{"temp_c":21}`), false),
+				llm.NewToolResponsePart("call_2", "get_weather", json.RawMessage(`{"temp_c":24}`), false),
+			},
+		},
+	})
+
+	last := apiReq.Messages[len(apiReq.Messages)-1]
+	require.Len(t, last.Content, 2)
+
+	assert.False(t, hasCacheMarker(last.Content[0].OfToolResult.CacheControl),
+		"only the final block of the turn gets a breakpoint")
+	assert.True(t, hasCacheMarker(last.Content[1].OfToolResult.CacheControl),
+		"final tool_result of a parallel batch must carry the breakpoint")
+}
+
+// TestCacheBreakpointSkipsThinkingBlock pins the one block type Anthropic
+// rejects a breakpoint on. An assistant turn ending in a thinking block must
+// fall back to the previous cacheable block rather than marking the thinking
+// block (a 400) or marking nothing (no caching).
+func TestCacheBreakpointSkipsThinkingBlock(t *testing.T) {
+	t.Parallel()
+
+	apiReq := mapCachedRequest(t, []llm.Message{
+		{
+			Role:    llm.RoleUser,
+			Content: []llm.Part{llm.NewTextPart("Think about this.")},
+		},
+		{
+			Role: llm.RoleAssistant,
+			Content: []llm.Part{
+				llm.NewTextPart("Working on it."),
+				llm.NewReasoningPart("internal reasoning"),
+			},
+		},
+	})
+
+	last := apiReq.Messages[len(apiReq.Messages)-1]
+	require.Len(t, last.Content, 2)
+	require.NotNil(t, last.Content[1].OfThinking, "trailing block must be the thinking block")
+
+	assert.True(t, hasCacheMarker(last.Content[0].OfText.CacheControl),
+		"breakpoint must fall back to the text block preceding the thinking block")
+}
+
+// TestCacheBreakpointSerializesOnToolResult proves the marker survives to the
+// wire, not just to the param struct: a hand-built `cache_control` on a
+// tool_result is only useful if the SDK actually serializes it there.
+func TestCacheBreakpointSerializesOnToolResult(t *testing.T) {
+	t.Parallel()
+
+	apiReq := mapCachedRequest(t, []llm.Message{
+		{
+			Role:    llm.RoleUser,
+			Content: []llm.Part{llm.NewTextPart("Call the tool.")},
+		},
+		{
+			Role: llm.RoleAssistant,
+			Content: []llm.Part{
+				llm.NewToolRequestPart("call_1", "get_weather", json.RawMessage(`{"city":"Berlin"}`)),
+			},
+		},
+		{
+			Role: llm.RoleUser,
+			Content: []llm.Part{
+				llm.NewToolResponsePart("call_1", "get_weather", json.RawMessage(`{"temp_c":21}`), false),
+			},
+		},
+	})
+
+	body, err := json.Marshal(apiReq)
+	require.NoError(t, err)
+
+	var wire struct {
+		Messages []struct {
+			Content []struct {
+				Type         string          `json:"type"`
+				CacheControl json.RawMessage `json:"cache_control"`
+			} `json:"content"`
+		} `json:"messages"`
+	}
+	require.NoError(t, json.Unmarshal(body, &wire))
+
+	require.NotEmpty(t, wire.Messages)
+	lastBlocks := wire.Messages[len(wire.Messages)-1].Content
+	require.Len(t, lastBlocks, 1)
+
+	assert.Equal(t, "tool_result", lastBlocks[0].Type)
+	assert.JSONEq(t, `{"type":"ephemeral"}`, string(lastBlocks[0].CacheControl),
+		"cache_control must serialize onto the tool_result block itself")
+}
+
+// mapCachedRequest maps messages through a default (caching-on) model.
+func mapCachedRequest(t *testing.T, messages []llm.Message) anthropic.BetaMessageNewParams {
+	t.Helper()
+
+	p, err := NewProvider("test-key")
+	require.NoError(t, err)
+
+	model, err := p.NewModel(ModelClaudeSonnet45)
+	require.NoError(t, err)
+
+	m, ok := model.(*Model)
+	require.True(t, ok, "NewModel must return *Model")
+
+	apiReq, err := m.requestMapper.ToProvider(&llm.Request{Messages: messages})
+	require.NoError(t, err)
+	require.NotEmpty(t, apiReq.Messages)
+
+	return apiReq
+}

--- a/providers/anthropic/cache_tool_result_test.go
+++ b/providers/anthropic/cache_tool_result_test.go
@@ -93,6 +93,8 @@ func TestCacheBreakpointOnParallelToolResults(t *testing.T) {
 
 	last := apiReq.Messages[len(apiReq.Messages)-1]
 	require.Len(t, last.Content, 2)
+	require.NotNil(t, last.Content[0].OfToolResult)
+	require.NotNil(t, last.Content[1].OfToolResult)
 
 	assert.False(t, hasCacheMarker(last.Content[0].OfToolResult.CacheControl),
 		"only the final block of the turn gets a breakpoint")
@@ -124,9 +126,46 @@ func TestCacheBreakpointSkipsThinkingBlock(t *testing.T) {
 	last := apiReq.Messages[len(apiReq.Messages)-1]
 	require.Len(t, last.Content, 2)
 	require.NotNil(t, last.Content[1].OfThinking, "trailing block must be the thinking block")
+	require.NotNil(t, last.Content[0].OfText)
 
 	assert.True(t, hasCacheMarker(last.Content[0].OfText.CacheControl),
 		"breakpoint must fall back to the text block preceding the thinking block")
+}
+
+// TestCacheBreakpointOnThinkingOnlyTurn pins the deliberate no-op: when the last
+// message holds nothing but thinking blocks there is no legal place for a
+// breakpoint, so the turn goes uncached rather than earning a 400. Falling back
+// to the previous message's tail would also be valid — a shorter cached prefix
+// still caches — but the shape is rare enough not to be worth the complexity.
+func TestCacheBreakpointOnThinkingOnlyTurn(t *testing.T) {
+	t.Parallel()
+
+	apiReq := mapCachedRequest(t, []llm.Message{
+		{
+			Role:    llm.RoleSystem,
+			Content: []llm.Part{llm.NewTextPart("You are a helpful assistant.")},
+		},
+		{
+			Role:    llm.RoleUser,
+			Content: []llm.Part{llm.NewTextPart("Think.")},
+		},
+		{
+			Role:    llm.RoleAssistant,
+			Content: []llm.Part{llm.NewReasoningPart("internal reasoning")},
+		},
+	})
+
+	last := apiReq.Messages[len(apiReq.Messages)-1]
+	require.Len(t, last.Content, 1)
+	require.NotNil(t, last.Content[0].OfThinking)
+
+	assert.False(t, lastMessageHasCacheMarker(last),
+		"a thinking-only turn must be left unmarked; Anthropic rejects cache_control on thinking blocks")
+
+	// The system-side breakpoint is independent and must survive.
+	require.NotEmpty(t, apiReq.System)
+	assert.True(t, hasCacheMarker(apiReq.System[len(apiReq.System)-1].CacheControl),
+		"skipping the message breakpoint must not disturb the system breakpoint")
 }
 
 // TestCacheBreakpointSerializesOnToolResult proves the marker survives to the

--- a/providers/anthropic/request_mapper.go
+++ b/providers/anthropic/request_mapper.go
@@ -209,22 +209,53 @@ func (rm *RequestMapper) mapMessages(messages []llm.Message) ([]anthropic.BetaMe
 			systemBlocks[lastIdx] = block
 		}
 
-		// Also mark the last text block of the last message
+		// Also mark the tail of the conversation, so the history gets cached
+		// and not just the static tools+system prefix. The marker has to land
+		// on whatever block type ends the turn: in an agentic loop the last
+		// message is usually a user turn carrying nothing but tool_result
+		// blocks, and marking text blocks only left every post-tool-call
+		// request re-paying full input price for the entire history.
+		//
+		// A tail breakpoint is deliberate rather than a fragile index.
+		// Anthropic reads the longest already-cached prefix and writes a fresh
+		// entry at each breakpoint, so marking the newest turn extends the
+		// cached prefix by one turn per request. Anchoring by content to some
+		// stable earlier message would instead re-cache the preamble — a job
+		// the system-block marker above already does.
 		if len(apiMessages) > 0 {
-			lastMsg := &apiMessages[len(apiMessages)-1]
-			for i := len(lastMsg.Content) - 1; i >= 0; i-- {
-				if lastMsg.Content[i].OfText != nil {
-					content := lastMsg.Content[i]
-					content.OfText.CacheControl = anthropic.NewBetaCacheControlEphemeralParam()
-					lastMsg.Content[i] = content
-
-					break
-				}
-			}
+			markLastCacheableBlock(&apiMessages[len(apiMessages)-1])
 		}
 	}
 
 	return apiMessages, systemBlocks, nil
+}
+
+// markLastCacheableBlock sets cache_control on the last block of msg that can
+// carry it, walking backwards.
+//
+// Anthropic accepts a breakpoint on text, tool_use and tool_result blocks and
+// rejects it on thinking blocks; those four are exactly what this mapper emits.
+// Anything else is skipped rather than marked, because a 400 on the whole
+// request is a worse outcome than one turn going uncached.
+func markLastCacheableBlock(msg *anthropic.BetaMessageParam) {
+	marker := anthropic.NewBetaCacheControlEphemeralParam()
+
+	for i := len(msg.Content) - 1; i >= 0; i-- {
+		block := msg.Content[i]
+
+		switch {
+		case block.OfText != nil:
+			block.OfText.CacheControl = marker
+		case block.OfToolResult != nil:
+			block.OfToolResult.CacheControl = marker
+		case block.OfToolUse != nil:
+			block.OfToolUse.CacheControl = marker
+		default:
+			continue
+		}
+
+		return
+	}
 }
 
 // mapUserMessage converts a user message to Anthropic format.

--- a/providers/anthropic/request_mapper.go
+++ b/providers/anthropic/request_mapper.go
@@ -233,9 +233,15 @@ func (rm *RequestMapper) mapMessages(messages []llm.Message) ([]anthropic.BetaMe
 // markLastCacheableBlock sets cache_control on the last block of msg that can
 // carry it, walking backwards.
 //
-// Anthropic accepts a breakpoint on text, tool_use and tool_result blocks and
-// rejects it on thinking blocks; those four are exactly what this mapper emits.
-// Anything else is skipped rather than marked, because a 400 on the whole
+// Anthropic accepts a breakpoint on text, image, document, tool_use and
+// tool_result blocks, and rejects it on thinking blocks. Only text, tool_use,
+// tool_result and thinking are reachable from this mapper today; image and
+// document are covered anyway, so that wiring either into mapUserMessage later
+// cannot silently drop the breakpoint. That failure would show up as a
+// cache_read that quietly stops growing — precisely the bug this function
+// exists to prevent, and one with no compile error to catch it.
+//
+// Anything still unrecognized is skipped rather than marked: a 400 on the whole
 // request is a worse outcome than one turn going uncached.
 func markLastCacheableBlock(msg *anthropic.BetaMessageParam) {
 	marker := anthropic.NewBetaCacheControlEphemeralParam()
@@ -250,6 +256,10 @@ func markLastCacheableBlock(msg *anthropic.BetaMessageParam) {
 			block.OfToolResult.CacheControl = marker
 		case block.OfToolUse != nil:
 			block.OfToolUse.CacheControl = marker
+		case block.OfImage != nil:
+			block.OfImage.CacheControl = marker
+		case block.OfDocument != nil:
+			block.OfDocument.CacheControl = marker
 		default:
 			continue
 		}


### PR DESCRIPTION
## What

The Anthropic request mapper placed the message-side `cache_control` breakpoint on the last *text* block of the last message. It now places it on the last block that can carry a breakpoint, whatever type that block is.

## Why

In an agentic loop the last message is usually a user turn holding nothing but `tool_result` blocks. It has no text block, so the loop marked nothing and the request went out with a breakpoint on the system blocks alone. The static tools+system prefix cached; the conversation never did, and every turn after a tool call re-paid full input price for the entire history.

Measured with a proxy between the agent and the Anthropic API, recording per-call usage and the `cache_control` markers actually present in each request body. The signature is a constant `cache_read` while `input` climbs:

```
single agent:  #2 input  535  cache_read 7881   markers: system
               #3 input  910  cache_read 7881   markers: system
               #4 input 1427  cache_read 7881   markers: system
subagent:      #3 input  541  cache_read 4908   markers: system
               #4 input  916  cache_read 4908   markers: system
               #5 input 1473  cache_read 4908   markers: system
```

First turns, where the last message is text, show `markers: system+messages` and do get a cache write. Every turn after a tool call shows `system` only.

After this change, the same shape measured against the live API by the new integration test in CI:

```
turn 1: input 3, cache_read    0, cache_write 2878
turn 2: input 5, cache_read 2878, cache_write  637
turn 3: input 5, cache_read 3515, cache_write  638
turn 4: input 5, cache_read 4153, cache_write  638
```

`cache_read` now grows with the conversation (2878 -> 3515 -> 4153) and each turn writes only its own ~638-token increment. Before, `cache_read` would have stayed pinned at 2878 — the system prefix — with the growing history re-billed as fresh input every turn.

## Implementation details

**Which blocks get marked.** `markLastCacheableBlock` walks the last message's blocks backwards and marks the first one that can carry `cache_control`. The pinned `anthropics/anthropic-sdk-go` v1.27.1 exposes a `CacheControl` field on every `Beta*BlockParam` in the content union except `BetaThinkingBlockParam` and `BetaRedactedThinkingBlockParam`, which matches the API: text, `tool_use`, `tool_result`, image and document accept a breakpoint, thinking blocks do not.

Only text, `tool_use`, `tool_result` and thinking are reachable from this mapper today. Image and document are covered anyway, because wiring either into `mapUserMessage` later would otherwise drop the breakpoint with no compile error and no failing test — the only symptom being a `cache_read` that quietly stops growing, i.e. this exact bug again. Anything still unrecognized is skipped rather than marked: a 400 on the whole request is a worse outcome than one turn going uncached. A thinking-only last message therefore goes uncached, which is deliberate and now pinned by a test.

The `tool_use` arm is defensive rather than exercised: Anthropic rejects an unanswered `tool_use`, so an assistant turn ending in one cannot legally be the last message. Its correctness rests on the SDK field inventory above, not on a live-API observation.

**Why the marker stays on the tail, by index.** CrewAI fixed the same class of bug by identifying the message to mark by content rather than by index. That reasoning does not transfer here, and the index is deliberate. Anthropic reads the longest already-cached prefix and writes a fresh entry at each breakpoint, so a marker on the newest turn extends the cached prefix by one turn per request — the standard incremental pattern for a growing conversation. Anchoring by content to a stable earlier message would instead re-cache the preamble, which the system-block marker immediately above already covers. The fragility CrewAI was avoiding belongs to the shared-prefix case (many requests over one fixed preamble, breakpoint at the end of the shared part), which is not this code path.

**Bedrock is unaffected.** `providers/bedrock/request_mapper.go` appends a standalone `CachePointBlock` to the last message's content instead of decorating an existing block, so it has no block-type filter to get wrong. No change was needed there.

**What the new tests establish.** `cache_tool_result_test.go` pins the request shape: a `tool_result`-only turn is marked, a parallel batch is marked exactly once on its final block, a trailing thinking block is skipped in favour of the block before it, a thinking-only turn is left unmarked while the system breakpoint survives, and the marker survives JSON serialization onto the `tool_result` block itself. Three of them fail against the old mapper. `cache_conversation_test.go` is the part that separates "the marker is set" from "the conversation actually caches": it replays a growing tool-calling conversation against the live API and asserts `cache_read` grows turn over turn. It also catches a rejected breakpoint, since that arrives as a 400 on `Generate`. The helper in `cache_default_test.go` had the same text-only blind spot as the mapper and would have reported "no marker" for a correctly marked `tool_result` turn, so it was widened too.

**Known residual limit, not addressed here.** Anthropic walks back at most 20 content blocks from a breakpoint to find a prior cache entry, so a single turn emitting more than 20 blocks (a wide parallel tool fan-out) can still miss. This uses 2 of the 4 breakpoints allowed per request, so there is room for intermediate markers. Filed as #205.

**Not a regression, but worth knowing.** The tail breakpoint writes a cache entry on essentially every request, so the last turn of a conversation pays a ~1.25x write on its delta that nothing ever reads. That was already true for text-ending turns before this change, and it is dwarfed by what the fix recovers — visible above as the 638-token per-turn write against a 4153-token read.

## References

- #205 — the 20-block cache lookback, split out rather than folded in here.
- Follow-up, deliberately not in this PR: cloudv2's `ai-agent` needs an ai-sdk-go release and a `go.mod` bump to pick this up. That bump is a separate change and should not gate this one.
