### PR TITLE
fix(bedrock): cache tool definitions

### DIFF
--- a/providers/bedrock/request_mapper.go
+++ b/providers/bedrock/request_mapper.go
@@ -359,6 +359,23 @@ func (rm *RequestMapper) mapToolConfig(tools []llm.ToolDefinition, choice *llm.T
 		})
 	}
 
+	// Cache the tool definitions.
+	//
+	// Bedrock's toolConfig is a separate top-level field from system and messages,
+	// so a CachePointBlock in either of those does not cover it: without a marker
+	// here the whole tool schema is re-sent uncached on every single call. For a
+	// tool-heavy server that is the largest STABLE block in the request — measured
+	// against a ServiceNow MCP, six generated tools are ~6 KB of JSON Schema, and
+	// an agent making nine calls paid for all of it nine times.
+	//
+	// The marker goes last, after every tool, because a cache point covers the
+	// prefix up to itself and the tool set is fixed for the life of the agent.
+	if rm.config.EnableCaching && len(apiTools) > 0 {
+		apiTools = append(apiTools, &types.ToolMemberCachePoint{
+			Value: types.CachePointBlock{Type: types.CachePointTypeDefault},
+		})
+	}
+
 	config := &types.ToolConfiguration{
 		Tools: apiTools,
 	}


### PR DESCRIPTION
## What

Emit a `CachePointBlock` at the end of Bedrock's `toolConfig` so tool definitions are cached.

## Why

Bedrock's Converse API carries `toolConfig` in a top-level field of its own, separate from `system` and `messages`. The cache points we already emit land after the last system block and after the last content block of the last message. Neither covers the tool schema, and `mapToolConfig` emitted nothing. The tool schema was therefore re-sent uncached on every model call, for every agent.

For a tool-heavy MCP that schema is the largest *stable* block in the request. Measured against a ServiceNow MCP with generated per-table tools: six tools is ~6 KB of JSON Schema, and one agent making nine calls in a single task paid for all of it nine times.

## Implementation details

`types.ToolMemberCachePoint` already exists in `github.com/aws/aws-sdk-go-v2/service/bedrockruntime/types`. Nothing emitted it.

The marker goes after every tool: a cache point covers the prefix up to itself, and an agent's tool set is fixed for its lifetime, so there is no reason to split it.

Guarded by `EnableCaching`, so `WithCachingDisabled` still emits no markers.
