### PR TITLE
feat(llmagent): make the advertised input schema configurable

### DIFF
--- a/agent/llmagent/config.go
+++ b/agent/llmagent/config.go
@@ -44,6 +44,7 @@ type config struct {
 	description          string
 	systemPrompt         string
 	systemPromptProvider SystemPromptProvider
+	inputSchema          map[string]any
 	id                   string
 	version              string
 	model                llm.Model
@@ -100,6 +101,24 @@ type Option func(*config)
 func WithSystemPromptProvider(p SystemPromptProvider) Option {
 	return func(c *config) {
 		c.systemPromptProvider = p
+	}
+}
+
+// WithInputSchema overrides the JSON Schema this agent advertises for its input.
+//
+// It matters for a SUB-agent. agenttool derives the delegation tool's parameters
+// from Agent.InputSchema, and the default is a single freeform `message` string —
+// so a router has exactly one field to say everything in, and anything it forgets
+// to mention is simply gone. A structured schema turns the delegation contract into
+// named arguments the caller must fill, which is how OpenAI's Agents SDK typed
+// handoffs and LangGraph's typed state work.
+//
+// The schema is advertised, not enforced beyond JSON Schema validation: agenttool
+// hands the encoded arguments to the sub-agent as its user message, so the callee
+// sees the JSON.
+func WithInputSchema(schema map[string]any) Option {
+	return func(c *config) {
+		c.inputSchema = schema
 	}
 }
 

--- a/agent/llmagent/llmagent.go
+++ b/agent/llmagent/llmagent.go
@@ -103,9 +103,15 @@ func (a *LLMAgent) Info() agent.Info {
 
 // InputSchema returns the expected input schema.
 //
-// For now, this returns a simple text message schema. Future versions
-// may support structured inputs.
+// Defaults to a single freeform text message. WithInputSchema replaces it, which
+// is what a sub-agent wants: the delegation tool's parameters come from here, so a
+// structured schema gives the caller named fields instead of one string to cram
+// everything into.
 func (a *LLMAgent) InputSchema() map[string]any {
+	if a.config.inputSchema != nil {
+		return a.config.inputSchema
+	}
+
 	return map[string]any{
 		"type": "object",
 		"properties": map[string]any{


### PR DESCRIPTION
## What

Add `llmagent.WithInputSchema` to override the JSON Schema an agent advertises for its input. Without the option, the default schema is returned exactly as before.

## Why

`LLMAgent.InputSchema()` hardcoded `{"message": string}` (required). The comment on it said "For now, this returns a simple text message schema. Future versions may support structured inputs."

That schema is not cosmetic. `agenttool.AgentTool.Definition()` derives the delegation tool's parameters from `Agent.InputSchema()`, so for a *sub-agent* it is the entire contract between a router and its expert: one freeform string.

The consequence is that a router has exactly one field to say everything in. A user message containing two distinct requests has nowhere to record the second, so it is silently dropped. Measured on a multi-intent case ("my VPN keeps dropping and I also need a docking station"): a router with the default schema lost the second request in 1 run of 8. With a structured schema carrying a required `remaining_work` field, the router stated the leftover at delegation time.

Typed delegation contracts are the norm elsewhere: the OpenAI Agents SDK takes `input_type` on a handoff, LangGraph passes typed state via `Send`, CrewAI uses a fixed `{task, context, coworker}`.

## Implementation details

The schema is advertised, not enforced beyond JSON Schema validation. `agenttool` hands the encoded arguments to the sub-agent as its user message, so the callee sees the JSON.
