### PR TITLE
feat(agent,otel): structured compaction events with a redpanda.compaction span

### DIFF
--- a/agent/compaction.go
+++ b/agent/compaction.go
@@ -1,0 +1,112 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//nolint:funcorder // isEvent() marker methods are intentionally placed after type definitions for clarity
+package agent
+
+import (
+	"fmt"
+	"time"
+)
+
+// ContextUsage breaks a request's estimated token footprint down by category.
+// Values use the runtime's conservative heuristic and are not provider-billed
+// usage.
+type ContextUsage struct {
+	// Total is the sum of every category below.
+	Total int `json:"total"`
+
+	// SystemPrompt is the resolved system prompt.
+	SystemPrompt int `json:"system_prompt"`
+
+	// ToolDefinitions is the tool schemas sent with every request.
+	ToolDefinitions int `json:"tool_definitions"`
+
+	// Text is user and assistant text content.
+	Text int `json:"text"`
+
+	// Reasoning is model reasoning content carried in the history.
+	Reasoning int `json:"reasoning"`
+
+	// ToolCalls is the tool invocations (name + arguments).
+	ToolCalls int `json:"tool_calls"`
+
+	// ToolResults is the tool results, including compaction markers.
+	ToolResults int `json:"tool_results"`
+
+	// Framing is the per-message protocol overhead.
+	Framing int `json:"framing"`
+}
+
+// CompactionPhase identifies which pass produced a CompactionReport.
+type CompactionPhase string
+
+// Compaction phases, as reported in CompactionReport.Phase.
+const (
+	// CompactionPhaseProactive is the top-of-turn pass that runs when the
+	// estimated request crosses the trigger.
+	CompactionPhaseProactive CompactionPhase = "proactive"
+
+	// CompactionPhaseReactive is the forced pass after a provider rejected
+	// the request as too large.
+	CompactionPhaseReactive CompactionPhase = "reactive"
+)
+
+// CompactionReport describes one context compaction pass: when it ran, why,
+// what it removed, and the request's token footprint before and after.
+// Aggregate only - applications needing a full transcript must persist the
+// event stream separately.
+type CompactionReport struct {
+	// At is when the pass ran.
+	At time.Time `json:"at"`
+
+	// Phase is CompactionPhaseProactive or CompactionPhaseReactive.
+	Phase CompactionPhase `json:"phase"`
+
+	// PrunedResults is how many tool results were replaced with markers.
+	PrunedResults int `json:"pruned_results"`
+
+	// DroppedMessages is how many whole messages were removed.
+	DroppedMessages int `json:"dropped_messages"`
+
+	// Before and After are the request footprint around the pass.
+	Before ContextUsage `json:"before"`
+	After  ContextUsage `json:"after"`
+}
+
+// String renders the report as the one-line human description used by
+// terminal UIs and logs.
+func (r CompactionReport) String() string {
+	s := fmt.Sprintf("pruned %d results, dropped %d messages, %dk -> %dk tokens",
+		r.PrunedResults, r.DroppedMessages, r.Before.Total/1000, r.After.Total/1000)
+
+	if r.Phase == CompactionPhaseReactive {
+		s += " (after provider overflow)"
+	}
+
+	return s
+}
+
+// CompactionEvent reports that the runtime rewrote the session to fit the
+// model's context window. Emitted at the moment the pass ran, before the
+// request it made room for.
+type CompactionEvent struct {
+	Envelope EventEnvelope    `json:"envelope"`
+	Report   CompactionReport `json:"report"`
+}
+
+func (CompactionEvent) isEvent() {}
+
+// GetEnvelope returns the event envelope containing observability metadata.
+func (e CompactionEvent) GetEnvelope() EventEnvelope { return e.Envelope }

--- a/agent/event.go
+++ b/agent/event.go
@@ -93,10 +93,6 @@ const (
 	StatusStageRunInterrupted StatusStage = "run_canceled"
 	StatusStageTurnStarted    StatusStage = "turn_started"
 	StatusStageTurnCompleted  StatusStage = "turn_completed"
-
-	// StatusStageCompaction is emitted after the runtime rewrote the session
-	// to fit the model's context window; Details reports what was reduced.
-	StatusStageCompaction StatusStage = "compaction"
 )
 
 // MessageEvent carries an assistant message from the LLM.

--- a/agent/interceptors.go
+++ b/agent/interceptors.go
@@ -250,13 +250,30 @@ type ToolInterceptor interface {
 	InterceptToolExecution(ctx context.Context, info *ToolCallInfo, next ToolExecutionNext) (*llm.ToolResponsePart, error)
 }
 
+// EventObserver is an optional interface an interceptor can implement to
+// observe every event before it reaches the consumer. Observe-only: events
+// cannot be modified or suppressed. Meant for telemetry (spans, structured
+// logs).
+//
+// Observers receive every non-nil event, including ErrorEvent, but never
+// terminal errors yielded as (nil, err). ctx is the emission-scope context:
+// the interceptor-derived turn context for turn events, the run context for
+// lifecycle events.
+//
+// Called synchronously on the yield path; keep observers fast and never
+// block.
+type EventObserver interface {
+	ObserveEvent(ctx context.Context, inv *InvocationMetadata, event Event)
+}
+
 // ImplementsAnyInterceptor checks if interceptor i implements at least one interceptor interface.
 // Used during interceptor registration to catch mistakes early.
 func ImplementsAnyInterceptor(i Interceptor) bool {
 	switch i.(type) {
 	case TurnInterceptor,
 		ModelInterceptor,
-		ToolInterceptor:
+		ToolInterceptor,
+		EventObserver:
 		return true
 	}
 
@@ -373,4 +390,38 @@ func ApplyToolInterceptors(
 	}
 
 	return executor
+}
+
+// ApplyEventObservers wraps yield so every non-nil event reaches each
+// EventObserver, in interceptor order, before the consumer. ctx must be the
+// emission-scope context (see EventObserver).
+//
+// Returns yield unchanged if no interceptor implements EventObserver.
+func ApplyEventObservers(
+	ctx context.Context,
+	inv *InvocationMetadata,
+	interceptors []Interceptor,
+	yield func(Event, error) bool,
+) func(Event, error) bool {
+	var observers []EventObserver
+
+	for _, interceptor := range interceptors {
+		if obs, ok := interceptor.(EventObserver); ok {
+			observers = append(observers, obs)
+		}
+	}
+
+	if len(observers) == 0 {
+		return yield
+	}
+
+	return func(ev Event, err error) bool {
+		if ev != nil {
+			for _, obs := range observers {
+				obs.ObserveEvent(ctx, inv, ev)
+			}
+		}
+
+		return yield(ev, err)
+	}
 }

--- a/agent/interceptors_test.go
+++ b/agent/interceptors_test.go
@@ -987,3 +987,111 @@ func (m *testModel) GenerateEvents(ctx context.Context, req *llm.Request) iter.S
 		}, nil)
 	}
 }
+
+// eventRecorder is an EventObserver that appends to a shared order recorder.
+type eventRecorder struct {
+	name     string
+	recorder *orderRecorder
+	lastCtx  context.Context //nolint:containedctx // Captured for assertion only
+}
+
+func (e *eventRecorder) ObserveEvent(ctx context.Context, _ *agent.InvocationMetadata, event agent.Event) {
+	e.lastCtx = ctx
+	e.recorder.record(e.name + ":" + eventKind(event))
+}
+
+func eventKind(event agent.Event) string {
+	switch event.(type) {
+	case agent.StatusEvent:
+		return "status"
+	case agent.ErrorEvent:
+		return "error"
+	case agent.CompactionEvent:
+		return "compaction"
+	default:
+		return "other"
+	}
+}
+
+func TestApplyEventObservers_OrderAndErrorContract(t *testing.T) {
+	t.Parallel()
+
+	recorder := &orderRecorder{}
+	obs1 := &eventRecorder{name: "obs1", recorder: recorder}
+	obs2 := &eventRecorder{name: "obs2", recorder: recorder}
+
+	inv := agent.NewInvocationMetadata(&session.State{ID: "sess"}, agent.Info{Name: "a"})
+
+	var consumed []agent.Event
+
+	var consumedErrs []error
+
+	yield := agent.ApplyEventObservers(t.Context(), inv, []agent.Interceptor{obs1, obs2},
+		func(ev agent.Event, err error) bool {
+			if ev != nil {
+				recorder.record("consumer:" + eventKind(ev))
+			}
+
+			consumed = append(consumed, ev)
+			consumedErrs = append(consumedErrs, err)
+
+			return true
+		})
+
+	// Non-nil events reach observers in order, before the consumer.
+	require.True(t, yield(agent.StatusEvent{Stage: agent.StatusStageTurnStarted}, nil))
+	require.True(t, yield(agent.ErrorEvent{}, nil))
+
+	// Terminal errors pass through unobserved.
+	require.True(t, yield(nil, errors.New("terminal")))
+
+	assert.Equal(t, []string{
+		"obs1:status", "obs2:status", "consumer:status",
+		"obs1:error", "obs2:error", "consumer:error",
+	}, recorder.get())
+
+	require.Len(t, consumed, 3)
+	assert.Nil(t, consumed[2])
+	require.Error(t, consumedErrs[2])
+}
+
+func TestApplyEventObservers_WrapTimeContext(t *testing.T) {
+	t.Parallel()
+
+	type ctxKey struct{}
+
+	recorder := &orderRecorder{}
+	obs := &eventRecorder{name: "obs", recorder: recorder}
+	inv := agent.NewInvocationMetadata(&session.State{ID: "sess"}, agent.Info{Name: "a"})
+
+	ctx := context.WithValue(t.Context(), ctxKey{}, "sentinel")
+
+	yield := agent.ApplyEventObservers(ctx, inv, []agent.Interceptor{obs},
+		func(agent.Event, error) bool { return true })
+
+	yield(agent.StatusEvent{}, nil)
+
+	require.NotNil(t, obs.lastCtx)
+	assert.Equal(t, "sentinel", obs.lastCtx.Value(ctxKey{}))
+}
+
+func TestApplyEventObservers_NoObservers(t *testing.T) {
+	t.Parallel()
+
+	inv := agent.NewInvocationMetadata(&session.State{ID: "sess"}, agent.Info{Name: "a"})
+
+	// A non-observer interceptor must not break pass-through behavior.
+	nonObserver := &testModelInterceptor{name: "model-only"}
+
+	var consumed int
+
+	yield := agent.ApplyEventObservers(t.Context(), inv, []agent.Interceptor{nonObserver},
+		func(agent.Event, error) bool {
+			consumed++
+
+			return false
+		})
+
+	assert.False(t, yield(agent.StatusEvent{}, nil), "consumer's return value must pass through")
+	assert.Equal(t, 1, consumed)
+}

--- a/agent/llmagent/compaction.go
+++ b/agent/llmagent/compaction.go
@@ -18,7 +18,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"slices"
+	"time"
 
+	"github.com/redpanda-data/ai-sdk-go/agent"
 	"github.com/redpanda-data/ai-sdk-go/llm"
 	"github.com/redpanda-data/ai-sdk-go/store/session"
 )
@@ -408,9 +410,14 @@ func cannotFitError(counted int, b contextBudget) error {
 		counted, b.hardLimit, b.window, b.reserve, llm.ErrContextOverflow)
 }
 
-// compactionDetails renders the StatusEvent details line.
-func compactionDetails(stats compactionStats) string {
-	return fmt.Sprintf("pruned %d results, dropped %d messages, %dk -> %dk tokens",
-		stats.prunedResults, stats.droppedMessages,
-		stats.beforeTokens/1000, stats.afterTokens/1000)
+// compactionReport assembles the observability report for one pass.
+func compactionReport(phase agent.CompactionPhase, stats compactionStats, before, after agent.ContextUsage) agent.CompactionReport {
+	return agent.CompactionReport{
+		At:              time.Now().UTC(),
+		Phase:           phase,
+		PrunedResults:   stats.prunedResults,
+		DroppedMessages: stats.droppedMessages,
+		Before:          before,
+		After:           after,
+	}
 }

--- a/agent/llmagent/compaction_e2e_test.go
+++ b/agent/llmagent/compaction_e2e_test.go
@@ -113,12 +113,12 @@ func runOnce(t *testing.T, ag *llmagent.LLMAgent, sess *session.State) ([]agent.
 	return events, nil
 }
 
-func compactionEvents(events []agent.Event) []agent.StatusEvent {
-	var out []agent.StatusEvent
+func compactionEvents(events []agent.Event) []agent.CompactionEvent {
+	var out []agent.CompactionEvent
 
 	for _, ev := range events {
-		if st, ok := ev.(agent.StatusEvent); ok && st.Stage == agent.StatusStageCompaction {
-			out = append(out, st)
+		if ce, ok := ev.(agent.CompactionEvent); ok {
+			out = append(out, ce)
 		}
 	}
 
@@ -297,7 +297,7 @@ func TestCompaction_ReactiveRetry(t *testing.T) {
 
 	comps := compactionEvents(events)
 	require.NotEmpty(t, comps)
-	assert.Contains(t, comps[len(comps)-1].Details, "after provider overflow")
+	assert.Equal(t, agent.CompactionPhaseReactive, comps[len(comps)-1].Report.Phase)
 }
 
 // TestCompaction_OverflowFinishReasonIsTerminalButUnwedges: a mid-generation
@@ -460,6 +460,44 @@ func TestCompaction_BurstDivisionDeterministic(t *testing.T) {
 	assert.Equal(t, first, second, "request content must not depend on tool completion order")
 }
 
+// TestCompaction_ReportsContextBreakdown: every pass appends an
+// agent.CompactionReport with a per-category before/after footprint, drained
+// exactly once by whoever consumes it.
+func TestCompaction_ReportsContextBreakdown(t *testing.T) {
+	t.Parallel()
+
+	ag, _ := compactionAgent(t, 16_000, llmagent.WithCompaction(llmagent.CompactionConfig{}))
+
+	sess := &session.State{ID: "report"}
+	sess.Messages = append(sess.Messages, llm.NewMessage(llm.RoleUser, llm.NewTextPart("start")))
+
+	for i := range 6 {
+		oldTurn(sess, i, 3_000)
+	}
+
+	sess.Messages = append(sess.Messages, llm.NewMessage(llm.RoleUser, llm.NewTextPart("summarise")))
+
+	events, runErr := runOnce(t, ag, sess)
+	require.NoError(t, runErr)
+
+	compactions := compactionEvents(events)
+	require.Len(t, compactions, 1)
+
+	rep := compactions[0].Report
+	assert.Equal(t, agent.CompactionPhaseProactive, rep.Phase)
+	assert.Positive(t, rep.PrunedResults)
+	assert.Greater(t, rep.Before.Total, rep.After.Total)
+	assert.Greater(t, rep.Before.ToolResults, rep.After.ToolResults)
+	assert.Positive(t, rep.Before.SystemPrompt)
+	assert.Positive(t, rep.Before.Text)
+	assert.NotEmpty(t, rep.String())
+
+	for _, u := range []agent.ContextUsage{rep.Before, rep.After} {
+		sum := u.SystemPrompt + u.ToolDefinitions + u.Text + u.Reasoning + u.ToolCalls + u.ToolResults + u.Framing
+		assert.Equal(t, u.Total, sum, "categories must sum to the total")
+	}
+}
+
 // hugeTool returns a result far larger than any test window.
 type hugeTool struct{}
 
@@ -568,7 +606,6 @@ func TestCompaction_RecoveryBudgetIncludesFixedCosts(t *testing.T) {
 	require.NotEmpty(t, model.Calls())
 
 	var recovered *llm.ToolResponsePart
-
 	for _, message := range model.Calls()[0].Request.Messages {
 		for _, part := range message.Content {
 			if response, ok := part.(*llm.ToolResponsePart); ok {

--- a/agent/llmagent/llmagent.go
+++ b/agent/llmagent/llmagent.go
@@ -136,6 +136,12 @@ func (a *LLMAgent) InputSchema() map[string]any {
 // The stream always ends with InvocationEndEvent, even on error or cancellation.
 func (a *LLMAgent) Run(ctx context.Context, inv *agent.InvocationMetadata) iter.Seq2[agent.Event, error] {
 	return func(yield func(agent.Event, error) bool) {
+		// Observers see every non-nil event before the consumer. Turn events
+		// are re-wrapped below with the turn context; lifecycle events use
+		// the run context.
+		consumerYield := yield
+		yield = agent.ApplyEventObservers(ctx, inv, a.config.interceptors, consumerYield)
+
 		// Helper: create event envelope
 		makeEnvelope := func() agent.EventEnvelope {
 			return agent.EventEnvelope{
@@ -180,7 +186,10 @@ func (a *LLMAgent) Run(ctx context.Context, inv *agent.InvocationMetadata) iter.
 			// Create turn execution function that can be wrapped by interceptors
 			// This encapsulates the entire turn execution logic
 			executeTurn := func(ctx context.Context, info *agent.TurnInfo) (agent.FinishReason, error) {
-				return a.executeSingleTurn(ctx, info.Inv, makeEnvelope, yield)
+				// Turn events carry the interceptor-derived turn context.
+				turnYield := agent.ApplyEventObservers(ctx, info.Inv, a.config.interceptors, consumerYield)
+
+				return a.executeSingleTurn(ctx, info.Inv, makeEnvelope, turnYield)
 			}
 
 			// Apply turn interceptors
@@ -264,18 +273,26 @@ func (a *LLMAgent) executeSingleTurn(
 	// below is the backstop, and its retry rebuilds the request and interceptor
 	// chain so request-time transformations are applied again.
 	fixedTokens := 0
+	sysTokens := 0
+	toolDefTokens := 0
 
 	if a.config.compaction != nil {
-		fixedTokens = estimateMessageTokens(reqMessages[0]) + estimateToolTokens(toolDefs)
+		sysTokens = estimateMessageTokens(reqMessages[0])
+		toolDefTokens = estimateToolTokens(toolDefs)
+		fixedTokens = sysTokens + toolDefTokens
+
+		before := measureContext(sysTokens, toolDefTokens, sess.Messages)
 
 		stats, fitErr := a.ensureFits(sess, fixedTokens)
 		if stats.changed() {
 			reqMessages = append([]llm.Message{reqMessages[0]}, sess.Messages...)
 
-			if !yield(agent.StatusEvent{
+			report := compactionReport(agent.CompactionPhaseProactive, stats,
+				before, measureContext(sysTokens, toolDefTokens, sess.Messages))
+
+			if !yield(agent.CompactionEvent{
 				Envelope: makeEnvelope(),
-				Stage:    agent.StatusStageCompaction,
-				Details:  compactionDetails(stats),
+				Report:   report,
 			}, nil) {
 				return agent.FinishReasonInterrupted, nil
 			}
@@ -291,21 +308,24 @@ func (a *LLMAgent) executeSingleTurn(
 		// Reactive path: the provider rejected the request pre-flight, so
 		// nothing was emitted. Force a strictly smaller request - hard
 		// floors, at least 25% below the failed size - and retry once.
+		before := measureContext(sysTokens, toolDefTokens, sess.Messages)
+
 		stats, reduced := a.reduceAfterOverflow(sess, fixedTokens)
 		if !reduced {
 			return "", cannotFitError(stats.afterTokens, a.deriveContextBudget())
 		}
 
-		if !yield(agent.StatusEvent{
+		report := compactionReport(agent.CompactionPhaseReactive, stats,
+			before, measureContext(sysTokens, toolDefTokens, sess.Messages))
+
+		if !yield(agent.CompactionEvent{
 			Envelope: makeEnvelope(),
-			Stage:    agent.StatusStageCompaction,
-			Details:  compactionDetails(stats) + " (after provider overflow)",
+			Report:   report,
 		}, nil) {
 			return agent.FinishReasonInterrupted, nil
 		}
 
 		retryMessages := append([]llm.Message{reqMessages[0]}, sess.Messages...)
-
 		resp, sentReq, err = a.generateAttempt(ctx, inv, retryMessages, toolDefs, makeEnvelope, yield)
 		if err != nil && errors.Is(err, llm.ErrContextOverflow) {
 			return "", fmt.Errorf("llmagent: request still exceeds the context window after forced compaction: %w", err)
@@ -492,7 +512,6 @@ func cloneToolDefinitions(defs []llm.ToolDefinition) []llm.ToolDefinition {
 	cloned := make([]llm.ToolDefinition, len(defs))
 	for i, def := range defs {
 		cloned[i] = def
-
 		cloned[i].Parameters = append(json.RawMessage(nil), def.Parameters...)
 		if def.Metadata != nil {
 			cloned[i].Metadata = make(map[string]any, len(def.Metadata))
@@ -828,7 +847,6 @@ func (a *LLMAgent) recoverIncompleteToolCalls(
 	// Execute the incomplete tools.
 	toolDefs := a.config.tools.List()
 	fixedTokens := 0
-
 	if a.config.compaction != nil {
 		reqMessages, err := a.resolveSystemPrompt(ctx, inv, sess.Messages)
 		if err != nil {

--- a/agent/llmagent/llmagent_observer_test.go
+++ b/agent/llmagent/llmagent_observer_test.go
@@ -1,0 +1,140 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package llmagent_test
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/redpanda-data/ai-sdk-go/agent"
+	"github.com/redpanda-data/ai-sdk-go/agent/llmagent"
+	"github.com/redpanda-data/ai-sdk-go/llm"
+	"github.com/redpanda-data/ai-sdk-go/llm/fakellm"
+	"github.com/redpanda-data/ai-sdk-go/store/session"
+)
+
+type turnSentinelKey struct{}
+
+// observedEvent records what an observer saw and with which context scope.
+type observedEvent struct {
+	event       agent.Event
+	hasSentinel bool
+}
+
+// turnCtxObserver derives a sentinel-carrying turn context (as the otel
+// plugin does with its invocation span) and records which observed events
+// carried it.
+type turnCtxObserver struct {
+	mu       sync.Mutex
+	observed []observedEvent
+}
+
+func (o *turnCtxObserver) InterceptTurn(ctx context.Context, info *agent.TurnInfo, next agent.TurnNext) (agent.FinishReason, error) {
+	return next(context.WithValue(ctx, turnSentinelKey{}, true), info)
+}
+
+func (o *turnCtxObserver) ObserveEvent(ctx context.Context, _ *agent.InvocationMetadata, event agent.Event) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+
+	sentinel, _ := ctx.Value(turnSentinelKey{}).(bool)
+	o.observed = append(o.observed, observedEvent{event: event, hasSentinel: sentinel})
+}
+
+// TestEventObserver_EmissionScopeContext: turn events are observed with the
+// interceptor-derived turn context, lifecycle events with the run context.
+func TestEventObserver_EmissionScopeContext(t *testing.T) {
+	t.Parallel()
+
+	obs := &turnCtxObserver{}
+	ag, _ := compactionAgent(t, 16_000,
+		llmagent.WithCompaction(llmagent.CompactionConfig{}),
+		llmagent.WithInterceptors(obs),
+	)
+
+	sess := &session.State{ID: "observer"}
+	sess.Messages = append(sess.Messages, llm.NewMessage(llm.RoleUser, llm.NewTextPart("start")))
+
+	for i := range 4 {
+		oldTurn(sess, i, 3_000)
+	}
+
+	sess.Messages = append(sess.Messages, llm.NewMessage(llm.RoleUser,
+		llm.NewTextPart(strings.Repeat("new question ", 800))))
+
+	events, err := runOnce(t, ag, sess)
+	require.NoError(t, err)
+	require.NotEmpty(t, compactionEvents(events), "setup must trigger compaction")
+
+	// Every consumed event was also observed, in the same order.
+	require.Len(t, obs.observed, len(events), "observer must see exactly the consumer's events")
+
+	for i, oe := range obs.observed {
+		assert.IsType(t, events[i], oe.event, "event %d: observer order must match consumer order", i)
+	}
+
+	var sawCompaction, sawMessage, sawTurnStarted, sawEnd bool
+
+	for _, oe := range obs.observed {
+		switch ev := oe.event.(type) {
+		case agent.CompactionEvent:
+			sawCompaction = true
+
+			assert.True(t, oe.hasSentinel, "compaction events are emitted inside the turn and must carry the turn context")
+		case agent.MessageEvent:
+			sawMessage = true
+
+			assert.True(t, oe.hasSentinel, "message events are emitted inside the turn and must carry the turn context")
+		case agent.StatusEvent:
+			if ev.Stage == agent.StatusStageTurnStarted {
+				sawTurnStarted = true
+
+				assert.False(t, oe.hasSentinel, "turn-started is emitted outside the turn and must not carry the turn context")
+			}
+		case agent.InvocationEndEvent:
+			sawEnd = true
+
+			assert.False(t, oe.hasSentinel, "invocation-end is emitted outside the turn and must not carry the turn context")
+		}
+	}
+
+	assert.True(t, sawCompaction, "observer must see the compaction event")
+	assert.True(t, sawMessage, "observer must see the assistant message")
+	assert.True(t, sawTurnStarted, "observer must see turn-started")
+	assert.True(t, sawEnd, "observer must see invocation-end")
+}
+
+// observerOnly implements just EventObserver.
+type observerOnly struct{}
+
+func (observerOnly) ObserveEvent(context.Context, *agent.InvocationMetadata, agent.Event) {}
+
+// TestEventObserver_ObserverOnlyInterceptorIsValid: an observer-only
+// interceptor passes registration validation.
+func TestEventObserver_ObserverOnlyInterceptorIsValid(t *testing.T) {
+	t.Parallel()
+
+	model := fakellm.NewFakeModel()
+	model.When(fakellm.Any()).ThenRespondText("done")
+
+	_, err := llmagent.New("observer-agent", "You are a test assistant.", model,
+		llmagent.WithInterceptors(observerOnly{}))
+	require.NoError(t, err)
+}

--- a/agent/llmagent/token_estimate.go
+++ b/agent/llmagent/token_estimate.go
@@ -17,6 +17,7 @@ package llmagent
 import (
 	"encoding/json"
 
+	"github.com/redpanda-data/ai-sdk-go/agent"
 	"github.com/redpanda-data/ai-sdk-go/llm"
 )
 
@@ -102,6 +103,44 @@ func estimateHistoryTokens(msgs []llm.Message) int {
 	}
 
 	return total
+}
+
+// measureContext breaks the estimated request footprint down by category for
+// observability. Unknown part kinds count as text until they earn a category.
+func measureContext(systemTokens, toolDefTokens int, msgs []llm.Message) agent.ContextUsage {
+	var text, reasoning, toolCalls, toolResults, framing int
+
+	for _, msg := range msgs {
+		framing += perMessageOverheadTokens
+
+		for _, part := range msg.Content {
+			size := estimatePartTokens(part)
+
+			switch part.(type) {
+			case *llm.ReasoningPart:
+				reasoning += size
+			case *llm.ToolRequestPart:
+				toolCalls += size
+			case *llm.ToolResponsePart:
+				toolResults += size
+			default:
+				text += size
+			}
+		}
+	}
+
+	u := agent.ContextUsage{
+		SystemPrompt:    systemTokens,
+		ToolDefinitions: toolDefTokens,
+		Text:            text,
+		Reasoning:       reasoning,
+		ToolCalls:       toolCalls,
+		ToolResults:     toolResults,
+		Framing:         framing,
+	}
+	u.Total = u.SystemPrompt + u.ToolDefinitions + u.Text + u.Reasoning + u.ToolCalls + u.ToolResults + u.Framing
+
+	return u
 }
 
 // estimateToolTokens estimates tokens for the tool schemas sent with every request.

--- a/docs/context-compaction.md
+++ b/docs/context-compaction.md
@@ -1,0 +1,515 @@
+# Context compaction — V1
+
+Status: accepted design, V1 implemented (2026-08-21) on branch
+`martin/compaction-v1`.
+
+This is the single normative document for V1. It deliberately describes a
+small, deterministic mechanism — no summarisation, no archive, no persisted
+state — chosen so each later capability can be added against evidence from a
+shipped baseline. Deferred features and the reason each was deferred are in §12.
+
+Existing harness in the tree: `llm/fakellm/context_window.go` (window
+enforcement) and `agent/llmagent/context_budget_test.go`
+(`assertNeverOverflows`, `runBudget`). Field data came from a local
+context-overflow demo replaying a real 163k-token recorded session against a
+200k window.
+
+---
+
+## 1. The problem
+
+`llmagent` replays the whole session on every turn. Every tool result is
+appended to `session.State.Messages` and re-sent forever, so the prompt grows
+monotonically (`TestContextBudget_OverflowsWithoutCompaction`). Eventually the
+provider rejects the request (HTTP 400, today indistinguishable from a
+malformed request: `llm.ErrInvalidInput`) or reports
+`FinishReasonContextOverflow`. Either way the invocation dies mid-task and the
+work already paid for is wasted.
+
+## 2. The goal
+
+**Prevent avoidable context overflow, and return a typed, actionable error when
+the minimum valid request cannot fit.**
+
+Not "a conversation never dies": a request whose irreducible parts (system
+prompt + tool schemas + the unread frontier) exceed the usable window cannot be
+sent, and the correct behaviour is a typed error naming the numbers — not
+silent truncation of content the model has never seen.
+
+## 3. Shape
+
+- **Native in `llmagent`, not an interceptor.** Interceptors cannot yield
+  events, and compaction must persist its result into the session, which is the
+  agent's job. Unexported files inside `agent/llmagent` (`compact.go`,
+  `budget.go`, `count.go`); no new public package. Extract a `compaction`
+  package only when there is a second consumer.
+- **Opt-in.** `llmagent.WithCompaction(...)`, off by default. Zero cost when
+  disabled (nil check).
+- **Deterministic only.** V1 makes no model calls. Every step is a pure
+  rewrite, so the guarantee never depends on a summariser being reachable, and
+  idempotence and testability are structural.
+- **One check, before every model call.** At the top of `executeSingleTurn`,
+  after the system prompt is resolved and before the request is built. That
+  single position sees an oversized fresh user message (the runner appends it
+  before the loop runs) and every burst of tool results (appended before the
+  next call).
+
+## 4. Budget arithmetic
+
+Everything derives from the catalogue: `Constraints().MaxInputTokens` (the
+context window) and `Constraints().MaxOutputTokens`.
+
+```
+window    = MaxInputTokens
+reserve   = min(MaxOutputTokens, max(4096, window/10))   // room for the answer
+usable    = window − reserve
+trigger   = 0.8 × usable    // WHEN to compact: counted request crosses this
+target    = 0.6 × usable    // HOW FAR to reduce once compacting
+hardLimit = usable          // safety boundary: never knowingly exceed
+```
+
+200k window / 64k output → reserve 20k, usable 180k, trigger 144k, target 108k.
+32k window / 4k output → reserve 4k, usable 28k, trigger 22.4k, target 16.8k.
+
+The three lines have distinct jobs and must not be conflated:
+
+- **`trigger`** decides *when* to act.
+- **`target`** decides *how far* to reduce. The trigger−target gap (20% of
+  usable) is what makes compaction rare and big-step: after each compaction
+  there is ~20% of usable headroom to consume before the next one fires, so the
+  prompt-prefix cache is invalidated occasionally, not per-turn. This gap
+  replaces any separate "minimum reclaim" gate.
+- **`hardLimit`** is the safety boundary, not a compaction goal. A request that
+  cannot be reduced to `target` but still fits under `hardLimit` — for example
+  an irreducible 150k frontier against a 144k trigger on a 200k window — is
+  **sent, not rejected**. The typed error (§8) is returned only when the
+  request exceeds `hardLimit` after every safe reduction.
+
+`reserve` is what turns "prompt fits but there is no room for the answer" from
+a mystery into arithmetic. Callers who set a provider-specific `max_tokens` in
+`Request.Options` (unreadable generically — `Options` is `any`) override it via
+config.
+
+**Counting.** Heuristic, counted high on purpose: 3.0 chars/token over every
+part (text, reasoning, tool arguments, tool results), a flat cost per image
+part, per-message framing overhead, plus the tool schemas and the resolved
+system prompt. An estimate that is low costs a dead session; one that is high
+costs a slightly early compaction. The reactive path (§5.4) is the backstop for
+when the estimate is still wrong. No calibration in V1.
+
+**Internal constants** (named constants in code, not options — promote to
+options only when a real caller asks):
+
+| Constant | Value | Purpose |
+|---|---|---|
+| `charsPerToken` | 3.0 | count high |
+| `triggerFraction` | 0.8 | of usable — when to compact |
+| `targetFraction` | 0.6 | of usable — how far to reduce |
+| `keepRecentResults` | 5 | newest already-read tool results kept verbatim |
+| `pruneAboveTokens` | 2,000 | results smaller than this are not worth rewriting |
+| `minTailTurns` | 3 | verbatim recent turns the drop step retains (proactive mode) |
+
+**A "turn" is defined structurally:** an assistant message together with the
+messages that follow it up to the next assistant message. `minTailTurns = 3`
+keeps the last three such turns intact. The frontier — everything after the
+*last* assistant message — is protected separately and absolutely (§5.0).
+
+## 5. The algorithm
+
+When the counted request crosses `trigger`: prune toward `target`, re-count,
+drop if still over, re-count. Send if the result is under `hardLimit` (even
+when `target` was unreachable); return the typed error only when it is not.
+
+### 5.0 The unread frontier (inviolable)
+
+**The frontier is every message after the last assistant message** — the tool
+responses answering that assistant's calls, and any user message the runner
+appended. The model has not read any of it. Pruning or dropping it means the
+agent paid for work whose answer it never learns, silently. Nothing in V1 may
+touch the frontier; if the frontier alone cannot fit under `hardLimit`, that is
+the typed error (§8), not a truncation.
+
+The frontier is **derived structurally at check time**, never a tracked index:
+`recoverIncompleteToolCalls` inserts messages mid-history, so any stored index
+can shift. The "after the last assistant message" rule is immune to that.
+
+The frontier is kept affordable *by construction* through the per-call result
+cap (§6): the budget a turn's results may occupy is divided across the calls
+before any tool runs, so a parallel burst cannot assemble an unfittable
+frontier in the first place.
+
+### 5.1 Prune already-read tool results (primary)
+
+Tool observations dominate an agent's context (~84% of turn tokens in measured
+trajectories; see appendix) and most are re-derivable — the agent can call the
+tool again. For every `ToolResponsePart` that is
+
+- **not** in the frontier (the model has read it), and
+- **not** among the newest `keepRecentResults` read results (recently read is
+  probably still in play), and
+- larger than `pruneAboveTokens`,
+
+replace `Result` with a **marshalled marker object** — never spliced bytes;
+`Result` is `json.RawMessage` and must remain valid JSON — preserving the part,
+its `ID` and its pairing:
+
+```json
+{"pruned": true, "tool": "fetch_records", "status": "error",
+ "original_tokens": 12943,
+ "preview": "region=eu-central-1, 412 rows, first id 90c1…",
+ "note": "output removed from context to free space; re-run the tool if needed"}
+```
+
+- The part's error flag survives and `status` restates it: a failed tool pruned
+  without its failure marker becomes a fabricated success in later reasoning.
+- `preview` is the head of the original payload (~200 chars). A bare mask with
+  no preview measured strictly worse than an addressable one; the preview is
+  the cheap part of that result.
+- The word is **pruned**, not archived: the bytes are gone. No id promising a
+  recall that does not exist. (An archive + `recall` tool is the V2 upgrade.)
+- Pruning is idempotent by size: a marker is far below `pruneAboveTokens`.
+
+Pruning operates on **parts, not messages**, which is what makes the parallel
+burst tractable: `executeTools` packs all of a turn's results into one
+`RoleUser` message, so five 25k results are a single 125k message that no
+message-level rule can trim.
+
+### 5.2 Drop oldest messages (fallback)
+
+If still over `target` after pruning, drop whole messages from the front using
+the cut rule, until under `target` or nothing more is droppable. Never drop
+into the frontier, the newest user message, or (in proactive mode) the last
+`minTailTurns` turns.
+
+**The cut rule:** advance the cut index forward until `messages[cut]` contains
+no `ToolResponsePart`. A retained `tool_result` whose `tool_use` was dropped is
+a hard 400 on every subsequent request — a permanently wedged session. An
+assistant message carrying `tool_use` is a legal first retained message: its
+results follow it. Forward, not backward, so the retained tail can never grow
+past its budget.
+
+Dropped user turns are lost — V1 has no summary to represent them. This is the
+deliberate, documented cost of a deterministic V1, and the first thing V2
+addresses (§12). In practice pruning does the bulk of the work and dropping is
+rare; the drop step is why the guarantee holds when it isn't.
+
+### 5.3 Rewrite in place
+
+`sess.Messages` is rewritten directly — pruned parts and dropped messages are
+gone from the session. **What is in the session is what gets sent**: no derived
+view, no second prompt-assembly path, no stored offsets.
+
+The SDK forwards events; it does not persist them. **Applications that need an
+audit transcript must persist the event stream themselves, before enabling
+compaction.** Events carry content as the runtime recorded it — in particular,
+`ToolResponseEvent` carries the *capped* result (§6), the same bytes the model
+will see; an application that needs full tool outputs must capture them at the
+tool layer. One truth: session, events and prompt never diverge.
+
+### 5.4 Reactive path
+
+Our count is an estimate; providers count differently. The reactive retry
+applies to exactly one signal: **a model call that fails pre-flight with
+`llm.ErrContextOverflow`** (WP0) — an error, delivered before any
+content, so nothing has been emitted to the consumer.
+
+1. Re-run prune + drop in **hard mode**:
+   - target `min(target, 0.75 × counted size at failure)` — the provider just
+     proved the estimate wrong, so the reduction must be *forced*: even if the
+     estimate claims the request already fits, shrink it by at least 25%.
+     Retrying an identical request is never acceptable.
+   - `keepRecentResults` reduced to 0 and `minTailTurns` relaxed to 0 — only
+     the frontier stays protected, so the minimum request is actually minimal.
+2. Retry the call **once**.
+3. If it overflows again, fail with the typed error.
+
+`FinishReasonContextOverflow` is deliberately **not** retried in V1: the
+response may already carry delivered content (`llm/types.go` is explicit that
+content produced before the limit is still on the response), streaming emits
+deltas immediately, and `executeSingleTurn` appends and emits the
+`MessageEvent` before examining the finish reason — a retry would duplicate
+output. The invocation ends with that finish reason as it does today; the
+session is *not* wedged, because the next invocation's top-of-turn check
+compacts it before the first model call.
+
+### Observability
+
+Each pass yields a typed `agent.CompactionEvent` **after the rewrite**,
+carrying a `CompactionReport`: phase (proactive or reactive), pruned and
+dropped counts, and a before/after context breakdown by category in
+conservative heuristic estimates. `Report.String()` renders the one-line summary
+(`"pruned 14 results, dropped 6 messages, 158k -> 96k tokens"`). (Compaction
+is a deterministic rewrite measured in microseconds; a "starting…" event has
+nothing to report and is omitted.)
+
+Interceptors can implement the observe-only `agent.EventObserver` interface
+to see every event on the yield path. The otel plugin uses it to render each
+compaction as a zero-duration `redpanda.compaction` span and stamps
+`gen_ai.conversation.compacted` on chat spans thereafter.
+
+## 6. Public API
+
+The entire new public surface:
+
+```go
+// llm
+var ErrContextOverflow error   // wraps ErrInvalidInput; mapped per provider
+
+// agent
+type CompactionPhase string
+const (
+    CompactionPhaseProactive CompactionPhase = "proactive"
+    CompactionPhaseReactive  CompactionPhase = "reactive"
+)
+type ContextUsage struct { ... }     // per-category token footprint
+type CompactionReport struct { ... } // phase, counts, Before/After ContextUsage
+type CompactionEvent struct { ... }  // Envelope + Report; on the event stream
+
+type EventObserver interface {       // optional interceptor interface
+    ObserveEvent(ctx context.Context, inv *InvocationMetadata, event Event)
+}
+func ApplyEventObservers(...)        // yield-wrapping chain helper
+
+// llmagent
+func WithCompaction(cfg CompactionConfig) Option
+
+type CompactionConfig struct {
+    // OutputReserve overrides the derived answer-room reservation.
+    // 0 = min(MaxOutputTokens, max(4096, window/10)).
+    OutputReserve int
+    // TriggerFraction of the usable window at which compaction runs.
+    // 0 = 0.8.
+    TriggerFraction float64
+}
+
+func WithToolResultLimit(tokens int) Option  // per-result cap at collection time
+```
+
+A config struct rather than functional options so fields can be added without
+breaking callers, and so the signature survives a later extraction of the
+implementation into its own package.
+
+**Per-result cap.** `WithToolResultLimit` is prevention upstream, applied when
+`executeTools` collects results. A capped result is replaced by a marshalled
+marker object of the same shape as §5.1 (with `"truncated": true` and the
+preview) — never spliced bytes, so `Result` stays valid JSON, and the error
+flag survives (I8). Useful with or without compaction.
+
+**Deterministic burst division.** When compaction is enabled, the effective
+per-result cap for a turn is computed *before any tool runs* — the requested
+calls are all known at that point:
+
+```
+availableForResults = hardLimit − countedRequestSize
+effectiveCap        = max(markerFloor, min(configuredCap, availableForResults / numberOfCalls))
+```
+
+The same cap applies to every result in the turn **independently of completion
+order**, so runs are reproducible even though tools execute concurrently.
+`markerFloor` guarantees room for at least the marker object. This is what
+keeps a parallel burst — eight 25k results is ~200k before schemas — from
+assembling an unfittable frontier that compaction is (correctly) forbidden to
+touch. It is internal behaviour, not an option.
+
+**Configuration validation.** `llmagent.New` fails fast, at construction:
+`TriggerFraction` outside `(0.6, 1)`; `OutputReserve` ≥ the model's window;
+`WithToolResultLimit` < 0; and compaction enabled on a model whose catalogue
+reports no context window (`MaxInputTokens` zero or unknown) — compaction
+cannot budget against a window it does not know.
+
+## 7. Invariants
+
+Each is a test, not a comment.
+
+| | Invariant |
+|---|---|
+| I1 | **Frontier.** No message after the last assistant message is pruned or dropped. |
+| I2 | **Pairing.** The first retained message never contains a `ToolResponsePart`; no `tool_use` is retained without its result except as the final message. Every rewrite passes the fakellm conversation validator. |
+| I3 | **No empty content, no invalid JSON.** No step produces a message with zero parts. Pruning and capping replace `Result` with a marshalled marker object, never remove parts, never splice bytes. |
+| I4 | **Progress.** Compaction reduces toward `target`. If `target` is unreachable, a request ≤ `hardLimit` is sent anyway. The typed error is returned only when the request exceeds `hardLimit` after every safe reduction (hard mode: tail floor and recency protection relaxed, frontier never). Hard mode strictly reduces the counted size — an identical retry is impossible. Never an unbounded loop. |
+| I5 | **Session equals prompt.** `sess.Messages` is what gets sent. No hidden index, no second assembly path. |
+| I6 | **Idempotence.** Compaction on a history that already fits is a no-op. Compacting twice equals compacting once. |
+| I7 | **Cache stability.** Two consecutive turns without compaction produce byte-identical prompt prefixes; the trigger−target gap keeps compactions rare and big-step. |
+| I8 | **Error status survives.** A pruned or capped result that was an error is still identifiable as an error. |
+| I9 | **Determinism.** Given the same history, configuration and tool results, compaction and burst division produce identical output regardless of tool completion order. |
+
+## 8. Failure behaviour
+
+When system prompt + tool schemas + the frontier exceed `hardLimit` even after
+hard-mode compaction (everything already-read pruned and dropped):
+
+```
+llmagent: cannot fit request: minimum 34120 tokens exceeds usable window 28000
+(window 32000, output reserve 4000) — reduce attached content, lower
+WithToolResultLimit, or use a model with a larger context window
+```
+
+A typed error (wrapping `llm.ErrContextOverflow`), with the numbers and
+the available fixes. Silently truncating unread content is worse than saying it
+does not fit. Note the boundary is `hardLimit`, not `trigger`: a request that
+merely cannot reach the compaction target still gets sent (§4).
+
+## 9. Session contract change
+
+`store/session/store.go` documents `State.Messages` as "should be treated as
+append-only". The runtime already violates this (`recoverIncompleteToolCalls`
+inserts a repair message mid-history; the empty-content guard skips appends),
+and compaction rewrites it by design. V1 amends the doc comment: **`Messages`
+is the model's working context, owned and maintained by the runtime — not an
+audit transcript.** Applications that need a transcript must persist the event
+stream themselves (§5.3); the SDK forwards events but does not store them.
+
+## 10. Work packages
+
+Each independently reviewable; WP0–WP2 independently mergeable.
+
+- **WP0 — typed overflow error. DONE (2026-08-21).** `llm.ErrContextOverflow`
+  (named for symmetry with `FinishReasonContextOverflow`) wrapping
+  `ErrInvalidInput`; mapped in
+  `providers/{anthropic,openai,openaicompat,bedrock,google}/errors.go`
+  (Anthropic `prompt is too long`, OpenAI `context_length_exceeded`, Bedrock
+  `ValidationException` on input length, Google `input token count exceeds`).
+  Rate-limit payloads do not match; oversized max_tokens stays plain
+  `ErrInvalidInput`. Every mapping validated against live provider APIs and
+  covered by `providers/conformance` `TestContextOverflow` (integration) plus
+  per-provider unit tests with recorded payloads.
+- **WP1 — conversation validator. DONE.** `llm/fakellm`: validate every request's
+  shape as a provider would (orphaned `tool_result`, `tool_use` without a
+  following result, empty content, non-JSON `Result` payloads). Prerequisite
+  for the pairing property tests; does not validate role alternation
+  (provider-specific).
+- **WP2 — counting + budget. DONE.** Internal to `llmagent`. Parity with
+  `fakellm.CountRequestTokens` within 15% on the harness payloads; the budget
+  table (§4) asserted over windows 8k–1M, including
+  `target < trigger < hardLimit ≤ usable`.
+- **WP3 — prune step. DONE.** Part-level marker rewrite, frontier/recency/size
+  gates, idempotence, marker validity.
+- **WP4 — drop step. DONE.** Cut rule + retention floors (and their hard-mode
+  relaxation); property-tested against the WP1 validator on randomized
+  histories.
+- **WP5 — wiring. DONE.** Top-of-turn check, reactive retry, burst division in
+  `executeTools`, `CompactionEvent`, `WithCompaction`,
+  `WithToolResultLimit`, construction-time validation. The only
+  behaviour-changing PR, off by default.
+- **WP6 — docs. DONE.** Session-contract comment (§9), package docs, this
+  design doc. The context-overflow demo used for field data stays local.
+
+## 11. Test matrix
+
+1. `assertNeverOverflows` with compaction on: windows 16k/32k/200k × several
+   seeds × {1, 3} tool calls per turn — the provider is never handed a request
+   over the window.
+2. `TestContextBudget_SingleOversizedResult` passes with
+   `WithToolResultLimit` + compaction.
+3. Fresh user message larger than remaining space → compaction runs before the
+   first model call; turn proceeds.
+4. Irreducible-but-fitting: a request between `trigger` and `hardLimit` that
+   cannot reach `target` is **sent**, not rejected.
+5. Burst division: a turn requesting 8 parallel oversized results near the
+   limit → every result capped identically, request fits, byte-identical
+   output across shuffled completion orders (I9).
+6. Reactive: fakellm window smaller than advertised → hard mode, one retry,
+   run survives. Assert the retried request is strictly smaller than the
+   failed one — including when the failed estimate was already under
+   `hardLimit`.
+7. Overflow finish reason mid-generation → invocation ends terminally with no
+   retry and no duplicated events; the *next* invocation compacts at the top
+   of the turn and proceeds (session not wedged).
+8. Minimum request cannot fit → typed error with numbers; no retry loop.
+9. Property test: for randomized histories (parallel bursts, reasoning parts,
+   interleaved user turns), every rewrite passes the WP1 validator; output
+   never larger than input; frontier untouched; every rewritten `Result` is
+   valid JSON.
+10. Idempotence: compacting a fitting history is a no-op; compact twice ==
+    compact once.
+11. Error status: a pruned or capped error-result still reads as an error.
+12. Cache stability: consecutive under-trigger turns produce byte-identical
+    prefixes.
+13. Save/load round-trip mid-session: pruned stays pruned, no re-compaction,
+    no state to corrupt.
+14. Construction-time validation: each invalid configuration from §6 fails
+    `llmagent.New` with a descriptive error.
+
+## 12. Deferred, with reasons
+
+Ordered by expected V2 priority:
+
+- **Summarisation + pinned context.** The V1 drop step loses old user turns
+  outright; a summary (separate request, own system prompt, no tools, output
+  capped in code) plus `WithPinnedContext` for standing rules is the first
+  upgrade. Deferred because it introduces a model call into the guarantee
+  path, a prompt to tune, and persisted summary state — and the measurements
+  say pruning does most of the work anyway.
+- **Archive + `recall` tool.** Turns pruning from lossy to reversible.
+  Deferred: needs a storage interface with session/tenant namespacing and a
+  retention story; must not live in session metadata (the runner re-saves the
+  whole record every assistant message).
+- **Identifier ledger.** Mechanical harvest of tool calls/ids from dropped
+  regions. Deferred: free-text identifier scraping is heuristic and can pin
+  secrets into every subsequent prompt; revisit scoped to structured tool
+  arguments.
+- **Calibration (on provider-billed tokens). Built, then removed.** Field
+  data (real webfetch content, ~2.34 chars/token) showed the count-high
+  heuristic undercounting on token-dense content, so a billed/estimated
+  ratio briefly scaled the budget lines. It was removed: the moving scale
+  made every budget decision history-dependent and hard to reason about,
+  and the reactive overflow path already backstops a wrong estimate.
+  Revisit only with field data showing the reactive path firing often.
+- **Thrash detector + circuit breaker.** Deferred until compaction can fire
+  often enough to thrash — the trigger−target gap makes back-to-back
+  compaction rare by construction; revisit with field data.
+- **Deferral inside tool chains** (compact at sub-task boundaries between
+  trigger and hardLimit). Real measured win, small mechanism — first candidate
+  once V1 has soak time.
+- **Reactive retry for `FinishReasonContextOverflow`.** Requires proving no
+  delta or message was emitted for the call (a code reorder in
+  `executeSingleTurn` plus a streaming guard); V1 keeps it terminal.
+- **Package extraction, provider-side compaction, async compaction, retrieval
+  over archives, external memory.** Each waits on a concrete consumer.
+
+---
+
+## Appendix: evidence (condensed, 2026-08)
+
+From the 2025–2026 agent context-management literature and a source-level
+survey of Claude Code v2.1.237, Codex, OpenCode, Cline, Gemini CLI and Crush.
+The numbers that shaped V1:
+
+- **Tool observations are ~84% of turn tokens** in measured SWE-agent
+  trajectories; mechanically masking old ones matched or beat LLM
+  summarisation on solve rate in 4 of 5 configurations at roughly half the
+  cost. LLM condensers increased total token cost 24–94% in a second study and
+  summarised runs were 13–15% longer. → prune-first, no summariser in V1.
+- **Every shipping agent reserves output room** (Claude Code
+  `window − min(max_out, 20k) − 13k`; Codex 5%; OpenCode `min(20k, max_out)`)
+  and none uses a cheap model when they do summarise. → §4 arithmetic.
+- **Fire-high, reduce-low is the shipping pattern**: Cline fires at ~81% of
+  the window and reduces to ~63%. A trigger that doubles as the target
+  compacts every turn once the session hovers at the line. → separate
+  `trigger` and `target`.
+- **Splitting a tool pair wedges the session permanently** (400 on every
+  subsequent request). Cline enforces the safe-cut predicate three separate
+  ways; Gemini CLI's single safeguard is the same predicate. → the cut rule
+  and the WP1 validator.
+- **Crush evaluates its trigger after the step completes**, so a turn that
+  trips it has its tool results computed, charged and discarded. → the unread
+  frontier rule and the pre-call check position.
+- **Count high**: Cline divides characters by 3, not 4, explicitly so
+  thresholds fire before provider rejection. Codex and OpenCode omit tool
+  schemas from the driving count and both carry overflow bugs. → 3.0
+  chars/token, schemas and system prompt included.
+- **Rewrites invalidate the prompt-prefix cache** (cached input ≈ 10× cheaper);
+  Cline gates pruning on 64KB reclaimable for this reason; Anthropic's
+  context-editing API exposes `clear_at_least`. → rare, big-step compaction
+  via the trigger−target gap.
+- **88–100% of compaction-induced errors first manifest within 2–3 steps.**
+  → `minTailTurns = 3` and `keepRecentResults = 5` (Claude Code keeps 5;
+  Anthropic's context-editing default is 3).
+- **A bare mask is strictly worse than an addressable one** (99.4% vs 88.1%
+  needle-in-trajectory recall for archive+recall vs the best baseline). V1
+  keeps the cheap half (a preview in the marker); the archive is the named V2
+  upgrade.
+- **Reactive recovery should not trust the estimator that just failed**: Cline
+  forces its deterministic strategy on overflow recovery; Claude Code allows
+  one reactive attempt per turn. → deterministic-only hard mode with a forced
+  minimum reduction, one retry.

--- a/plugins/otel/attributes.go
+++ b/plugins/otel/attributes.go
@@ -48,6 +48,11 @@ const errorTypeToolError = "tool_error"
 // This is an internal constant - users should never access this directly.
 const metadataKeyInvocationSpan = "otel.invocation.span"
 
+// Metadata key recording that the conversation's context was compacted.
+// Stored in session metadata so the flag survives across invocations.
+// This is an internal constant - users should never access this directly.
+const metadataKeyConversationCompacted = "otel.conversation.compacted"
+
 // SpanType identifies the category of the operation being traced.
 type SpanType string
 
@@ -160,6 +165,44 @@ func genAISystemInstructions(instructions string) attribute.KeyValue {
 
 func genAIConversationID(id string) attribute.KeyValue {
 	return attribute.String(genai.AttrGenAIConversationID, id)
+}
+
+func genAIConversationCompacted() attribute.KeyValue {
+	return attribute.Bool(genai.AttrGenAIConversationCompacted, true)
+}
+
+// markConversationCompacted records the compaction in invocation metadata
+// and, for later invocations over the same history, session metadata.
+func markConversationCompacted(inv *agent.InvocationMetadata) {
+	inv.SetMetadata(metadataKeyConversationCompacted, true)
+
+	if sess := inv.Session(); sess != nil {
+		if sess.Metadata == nil {
+			sess.Metadata = make(map[string]any)
+		}
+
+		sess.Metadata[metadataKeyConversationCompacted] = true
+	}
+}
+
+// conversationCompacted reports whether this or a prior invocation over the
+// same session recorded a compaction.
+func conversationCompacted(inv *agent.InvocationMetadata) bool {
+	if inv == nil {
+		return false
+	}
+
+	if v, ok := inv.GetMetadata(metadataKeyConversationCompacted).(bool); ok && v {
+		return true
+	}
+
+	if sess := inv.Session(); sess != nil {
+		if v, ok := sess.Metadata[metadataKeyConversationCompacted].(bool); ok && v {
+			return true
+		}
+	}
+
+	return false
 }
 
 func genAIRequestModel(model string) attribute.KeyValue {

--- a/plugins/otel/compaction.go
+++ b/plugins/otel/compaction.go
@@ -1,0 +1,82 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package otel
+
+import (
+	"context"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/redpanda-data/ai-sdk-go/agent"
+)
+
+// compactionSpanName is the span emitted for each context compaction pass.
+// There is no gen_ai semantic convention for compaction yet, so the span and
+// its attributes live under the redpanda namespace.
+const compactionSpanName = "redpanda.compaction"
+
+// ObserveEvent implements agent.EventObserver: each CompactionEvent becomes a
+// zero-duration redpanda.compaction child span of the current emission span,
+// falling back to the invocation span, stamped at the time the pass ran.
+// Other events are ignored.
+func (t *TracingInterceptor) ObserveEvent(ctx context.Context, inv *agent.InvocationMetadata, event agent.Event) {
+	ce, ok := event.(agent.CompactionEvent)
+	if !ok {
+		return
+	}
+
+	// Prefer the span in ctx; fall back to the stored invocation span.
+	if !trace.SpanContextFromContext(ctx).IsValid() {
+		if invSpan, found := getInvocationSpan(inv); found {
+			ctx = trace.ContextWithSpan(ctx, invSpan)
+		}
+	}
+
+	report := ce.Report
+
+	attrs := make([]attribute.KeyValue, 0, 19)
+	attrs = append(attrs,
+		attribute.String("redpanda.compaction.phase", string(report.Phase)),
+		attribute.Int("redpanda.compaction.pruned_results", report.PrunedResults),
+		attribute.Int("redpanda.compaction.dropped_messages", report.DroppedMessages),
+	)
+	attrs = append(attrs, contextUsageAttrs("redpanda.compaction.before", report.Before)...)
+	attrs = append(attrs, contextUsageAttrs("redpanda.compaction.after", report.After)...)
+
+	_, span := t.tracer.Start(ctx, compactionSpanName,
+		trace.WithTimestamp(report.At),
+		trace.WithAttributes(attrs...),
+	)
+	span.End(trace.WithTimestamp(report.At))
+
+	// Later chat spans carry gen_ai.conversation.compacted.
+	markConversationCompacted(inv)
+}
+
+// contextUsageAttrs flattens one side of a report's context breakdown.
+// Values are conservative heuristic token estimates.
+func contextUsageAttrs(prefix string, u agent.ContextUsage) []attribute.KeyValue {
+	return []attribute.KeyValue{
+		attribute.Int(prefix+".tokens", u.Total),
+		attribute.Int(prefix+".system_prompt", u.SystemPrompt),
+		attribute.Int(prefix+".tool_definitions", u.ToolDefinitions),
+		attribute.Int(prefix+".text", u.Text),
+		attribute.Int(prefix+".reasoning", u.Reasoning),
+		attribute.Int(prefix+".tool_calls", u.ToolCalls),
+		attribute.Int(prefix+".tool_results", u.ToolResults),
+		attribute.Int(prefix+".framing", u.Framing),
+	}
+}

--- a/plugins/otel/compaction_test.go
+++ b/plugins/otel/compaction_test.go
@@ -1,0 +1,239 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package otel_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/redpanda-data/ai-sdk-go/agent"
+	"github.com/redpanda-data/ai-sdk-go/llm"
+	pluginotel "github.com/redpanda-data/ai-sdk-go/plugins/otel"
+	"github.com/redpanda-data/ai-sdk-go/store/session"
+)
+
+const compactionSpanName = "redpanda.compaction"
+
+// TestTracingInterceptor_EmitsCompactionSpan: a compaction event becomes a
+// redpanda.compaction span with phase, counts and before/after breakdown.
+// Observes with a span-free ctx, exercising the metadata fallback path.
+func TestTracingInterceptor_EmitsCompactionSpan(t *testing.T) {
+	t.Parallel()
+
+	exporter, tp := setupTracer()
+	defer tp.Shutdown(t.Context()) //nolint:errcheck // Test cleanup
+
+	interceptor := pluginotel.New(pluginotel.WithTracerProvider(tp))
+
+	inv := agent.NewInvocationMetadata(&session.State{ID: "sess-compact"}, agent.Info{Name: "test-agent"})
+
+	report := agent.CompactionReport{
+		At:              time.Now().UTC(),
+		Phase:           agent.CompactionPhaseProactive,
+		PrunedResults:   3,
+		DroppedMessages: 1,
+		Before: agent.ContextUsage{
+			Total: 150_000, SystemPrompt: 2_000, ToolDefinitions: 1_000,
+			Text: 20_000, ToolCalls: 7_000, ToolResults: 119_500, Framing: 500,
+		},
+		After: agent.ContextUsage{
+			Total: 90_000, SystemPrompt: 2_000, ToolDefinitions: 1_000,
+			Text: 20_000, ToolCalls: 7_000, ToolResults: 59_600, Framing: 400,
+		},
+	}
+
+	_, err := interceptor.InterceptTurn(t.Context(), &agent.TurnInfo{Inv: inv},
+		func(ctx context.Context, info *agent.TurnInfo) (agent.FinishReason, error) {
+			// Strip the span from the context to force the fallback.
+			ctx = trace.ContextWithSpanContext(ctx, trace.SpanContext{})
+			interceptor.ObserveEvent(ctx, info.Inv, agent.CompactionEvent{Report: report})
+
+			return agent.FinishReasonStop, nil
+		})
+	require.NoError(t, err)
+
+	var compactionSpan *tracetest.SpanStub
+
+	spans := exporter.GetSpans()
+	for i := range spans {
+		if spans[i].Name == compactionSpanName {
+			compactionSpan = &spans[i]
+		}
+	}
+
+	require.NotNil(t, compactionSpan, "a compaction report must become a redpanda.compaction span")
+
+	attrs := make(map[string]any, len(compactionSpan.Attributes))
+	for _, kv := range compactionSpan.Attributes {
+		attrs[string(kv.Key)] = kv.Value.AsInterface()
+	}
+
+	assert.Equal(t, "proactive", attrs["redpanda.compaction.phase"])
+	assert.Equal(t, int64(3), attrs["redpanda.compaction.pruned_results"])
+	assert.Equal(t, int64(1), attrs["redpanda.compaction.dropped_messages"])
+	assert.Equal(t, int64(150_000), attrs["redpanda.compaction.before.tokens"])
+	assert.Equal(t, int64(90_000), attrs["redpanda.compaction.after.tokens"])
+	assert.Equal(t, int64(119_500), attrs["redpanda.compaction.before.tool_results"])
+	assert.Equal(t, int64(2_000), attrs["redpanda.compaction.after.system_prompt"])
+
+	// Child of the invocation span, stamped at the pass time.
+	var invocationSpan *tracetest.SpanStub
+
+	for i := range spans {
+		if spans[i].Name != compactionSpanName {
+			invocationSpan = &spans[i]
+		}
+	}
+
+	require.NotNil(t, invocationSpan)
+	assert.Equal(t, invocationSpan.SpanContext.SpanID(), compactionSpan.Parent.SpanID())
+	assert.Equal(t, report.At, compactionSpan.StartTime)
+}
+
+// TestTracingInterceptor_CompactionParentsUnderEmissionSpan: with a live
+// span in ctx, the compaction span parents under it, not under the
+// invocation span stored in metadata.
+func TestTracingInterceptor_CompactionParentsUnderEmissionSpan(t *testing.T) {
+	t.Parallel()
+
+	exporter, tp := setupTracer()
+	defer tp.Shutdown(t.Context()) //nolint:errcheck // Test cleanup
+
+	interceptor := pluginotel.New(pluginotel.WithTracerProvider(tp))
+
+	inv := agent.NewInvocationMetadata(&session.State{ID: "sess-emission"}, agent.Info{Name: "test-agent"})
+
+	var emissionSpanID trace.SpanID
+
+	_, err := interceptor.InterceptTurn(t.Context(), &agent.TurnInfo{Inv: inv},
+		func(ctx context.Context, info *agent.TurnInfo) (agent.FinishReason, error) {
+			// Distinct from the invocation span stored in metadata.
+			ctx, emissionSpan := tp.Tracer("test").Start(ctx, "emission-scope")
+			defer emissionSpan.End()
+
+			emissionSpanID = emissionSpan.SpanContext().SpanID()
+
+			interceptor.ObserveEvent(ctx, info.Inv, agent.CompactionEvent{Report: agent.CompactionReport{
+				At:    time.Now().UTC(),
+				Phase: agent.CompactionPhaseProactive,
+			}})
+
+			return agent.FinishReasonStop, nil
+		})
+	require.NoError(t, err)
+
+	var compactionSpan *tracetest.SpanStub
+
+	spans := exporter.GetSpans()
+	for i := range spans {
+		if spans[i].Name == compactionSpanName {
+			compactionSpan = &spans[i]
+		}
+	}
+
+	require.NotNil(t, compactionSpan)
+	assert.Equal(t, emissionSpanID, compactionSpan.Parent.SpanID(),
+		"compaction span must parent under the emission-scope span from ctx, not the invocation span from metadata")
+}
+
+// TestTracingInterceptor_MarksLaterChatSpansCompacted: chat spans after a
+// compaction carry gen_ai.conversation.compacted=true, earlier ones carry
+// nothing, and the flag persists into later invocations over the session.
+func TestTracingInterceptor_MarksLaterChatSpansCompacted(t *testing.T) {
+	t.Parallel()
+
+	exporter, tp := setupTracer()
+	defer tp.Shutdown(t.Context()) //nolint:errcheck // Test cleanup
+
+	interceptor := pluginotel.New(pluginotel.WithTracerProvider(tp))
+
+	sess := &session.State{ID: "sess-compact-flag"}
+
+	chat := func(ctx context.Context, inv *agent.InvocationMetadata) {
+		modelInfo := &agent.ModelCallInfo{
+			InvocationMetadata: inv,
+			Model:              &mockModelInfo{name: "gpt-4", provider: "openai"},
+			Req:                &llm.Request{},
+		}
+
+		handler := interceptor.InterceptModel(ctx, modelInfo, &mockModelHandler{})
+		_, err := handler.Generate(ctx, &llm.Request{})
+		require.NoError(t, err)
+	}
+
+	inv := agent.NewInvocationMetadata(sess, agent.Info{Name: "test-agent"})
+
+	_, err := interceptor.InterceptTurn(t.Context(), &agent.TurnInfo{Inv: inv},
+		func(ctx context.Context, info *agent.TurnInfo) (agent.FinishReason, error) {
+			chat(ctx, info.Inv) // before compaction
+
+			interceptor.ObserveEvent(ctx, info.Inv, agent.CompactionEvent{Report: agent.CompactionReport{
+				At:    time.Now().UTC(),
+				Phase: agent.CompactionPhaseReactive,
+			}})
+
+			chat(ctx, info.Inv) // after compaction
+
+			return agent.FinishReasonStop, nil
+		})
+	require.NoError(t, err)
+
+	// Second invocation over the same (rewritten, persisted) session.
+	inv2 := agent.NewInvocationMetadata(sess, agent.Info{Name: "test-agent"})
+
+	_, err = interceptor.InterceptTurn(t.Context(), &agent.TurnInfo{Inv: inv2},
+		func(ctx context.Context, info *agent.TurnInfo) (agent.FinishReason, error) {
+			chat(ctx, info.Inv)
+
+			return agent.FinishReasonStop, nil
+		})
+	require.NoError(t, err)
+
+	var chatSpans []tracetest.SpanStub
+
+	for _, span := range exporter.GetSpans() {
+		if strings.HasPrefix(span.Name, "chat") {
+			chatSpans = append(chatSpans, span)
+		}
+	}
+
+	require.Len(t, chatSpans, 3)
+
+	compacted := func(span tracetest.SpanStub) (bool, bool) {
+		for _, kv := range span.Attributes {
+			if kv.Key == "gen_ai.conversation.compacted" {
+				return kv.Value.AsBool(), true
+			}
+		}
+
+		return false, false
+	}
+
+	_, present := compacted(chatSpans[0])
+	assert.False(t, present, "pre-compaction chat span must not carry the attribute (never false, only unset)")
+
+	value, present := compacted(chatSpans[1])
+	assert.True(t, present && value, "post-compaction chat span must carry gen_ai.conversation.compacted=true")
+
+	value, present = compacted(chatSpans[2])
+	assert.True(t, present && value, "chat span in a later invocation over the same session must carry the attribute")
+}

--- a/plugins/otel/genai/semconv.go
+++ b/plugins/otel/genai/semconv.go
@@ -56,6 +56,11 @@ const (
 	AttrGenAIToolCallResult                = "gen_ai.tool.call.result"
 	AttrGenAIToolType                      = "gen_ai.tool.type"
 	AttrGenAIToolDescription               = "gen_ai.tool.description"
+
+	// AttrGenAIConversationCompacted marks an inference span whose context
+	// is a compacted view of the conversation. Development stability: set
+	// true or leave unset, never false.
+	AttrGenAIConversationCompacted = "gen_ai.conversation.compacted"
 )
 
 // Operation name constants.

--- a/plugins/otel/interceptor.go
+++ b/plugins/otel/interceptor.go
@@ -85,6 +85,7 @@ var (
 	_ agent.TurnInterceptor  = (*TracingInterceptor)(nil)
 	_ agent.ModelInterceptor = (*TracingInterceptor)(nil)
 	_ agent.ToolInterceptor  = (*TracingInterceptor)(nil)
+	_ agent.EventObserver    = (*TracingInterceptor)(nil)
 )
 
 // New creates a TracingInterceptor with the given options.

--- a/plugins/otel/model.go
+++ b/plugins/otel/model.go
@@ -140,6 +140,11 @@ func (h *tracingModelHandler) startSpan(ctx context.Context, req *llm.Request) (
 		genAIConversationID(h.convID),
 	}
 
+	// Set at span start so sampling can see it; true or unset, never false.
+	if conversationCompacted(h.inv) {
+		attrs = append(attrs, genAIConversationCompacted())
+	}
+
 	// Call attribute injector if configured (before span creation for sampling)
 	if h.cfg.attributeInjector != nil {
 		spanCtx := SpanContext{

--- a/plugins/otel/tool.go
+++ b/plugins/otel/tool.go
@@ -139,6 +139,7 @@ func (t *TracingInterceptor) InterceptToolExecution(
 		} else {
 			setToolError(span, "tool returned an error")
 		}
+
 		span.SetAttributes(toolResultAvailable(false))
 	default:
 		// Case 3: Success


### PR DESCRIPTION
Stacked on #208.

## Motivation

When compaction rewrites the session, downstream consumers rendering conversation history from spans see the history change between two model calls with nothing explaining why. Trace UIs need a marker at exactly that point, with numbers.

## What this adds

- `agent.CompactionEvent`: a first-class structured event per compaction pass, replacing the compaction StatusEvent. Carries phase (proactive or reactive), pruned and dropped counts, and a before/after context breakdown by category: system prompt, tool definitions, text, reasoning, tool calls, tool results, framing. All values in calibrated provider tokens so they line up with billed usage. `Report.Summary()` renders the human one-liner.
- `agent.EventObserver`: an optional observe-only interceptor interface. The agent notifies observers of every event on its yield path, so telemetry gets the event stream without a side channel and without being able to modify or suppress anything. Useful beyond compaction (structured logging, metrics).
- The otel plugin implements the observer and renders each CompactionEvent as a zero-duration `redpanda.compaction` child span of the invocation span, stamped at the time the pass ran, with the full breakdown as `redpanda.compaction.before.*` / `.after.*` attributes. Parenting is recovered from the invocation metadata since the yield path carries no span.

## Notes for reviewers

- An earlier iteration used a metadata append/drain bridge between llmagent and the otel plugin. Rejected: drain-once semantics means only one consumer ever sees the reports, and the event stream is the SDK's documented observability surface. Events are naturally multi-consumer.
- There is no gen_ai semantic convention for compaction yet, hence the redpanda namespace.