### PR TITLE
fix(bedrock): flatten stale tool blocks when toolConfig is absent

### DIFF
--- a/providers/bedrock/provider_test.go
+++ b/providers/bedrock/provider_test.go
@@ -872,6 +872,9 @@ func TestRequestMapper_ToolResponse(t *testing.T) {
 				},
 			),
 		},
+		Tools: []llm.ToolDefinition{
+			{Name: "search", Description: "Search", Parameters: json.RawMessage(`{"type":"object"}`)},
+		},
 	}
 
 	input, err := mapper.ToConverseInput(req)
@@ -906,6 +909,9 @@ func TestRequestMapper_ToolResponseError(t *testing.T) {
 				},
 			),
 		},
+		Tools: []llm.ToolDefinition{
+			{Name: "search", Description: "Search", Parameters: json.RawMessage(`{"type":"object"}`)},
+		},
 	}
 
 	input, err := mapper.ToConverseInput(req)
@@ -936,6 +942,9 @@ func TestRequestMapper_AssistantWithToolUse(t *testing.T) {
 					Arguments: json.RawMessage(`{"query":"cats"}`),
 				},
 			),
+		},
+		Tools: []llm.ToolDefinition{
+			{Name: "search", Description: "Search", Parameters: json.RawMessage(`{"type":"object"}`)},
 		},
 	}
 

--- a/providers/bedrock/request_mapper.go
+++ b/providers/bedrock/request_mapper.go
@@ -118,7 +118,10 @@ func (rm *RequestMapper) buildConverseParams(req *llm.Request) (*converseParams,
 	// even when the current turn has nothing to offer — e.g. a tool used
 	// earlier in the conversation has since been removed from the agent.
 	// Mirror langchain-aws's fix for the same constraint: flatten the stale
-	// blocks to text instead of failing the whole request.
+	// blocks to text instead of failing the whole request. Reconstructing a
+	// synthetic toolConfig from the tool names in history was considered and
+	// rejected: it would keep the blocks structured, but it re-advertises a
+	// tool the agent no longer has, inviting the model to call it again.
 	// https://github.com/langchain-ai/langchain-aws/pull/595
 	if p.tools == nil && hasToolUseOrResultBlocks(p.messages) {
 		p.messages = convertToolBlocksToText(p.messages)
@@ -535,9 +538,9 @@ func convertToolBlocksToText(messages []types.Message) []types.Message {
 				})
 
 			case *types.ContentBlockMemberToolResult:
-				if text := toolResultText(b.Value); text != "" {
-					out.Content = append(out.Content, &types.ContentBlockMemberText{Value: text})
-				}
+				out.Content = append(out.Content, &types.ContentBlockMemberText{
+					Value: toolResultText(b.Value),
+				})
 
 			default:
 				out.Content = append(out.Content, block)
@@ -565,8 +568,17 @@ func toolUseText(tu types.ToolUseBlock) string {
 	return fmt.Sprintf("[Called %s]", name)
 }
 
-// toolResultText renders a ToolResultBlock's text/JSON content as
-// "[Tool output: {content}]", or "" if it carries no representable content.
+// toolResultText renders a ToolResultBlock as "[Tool output: {content}]", or
+// "[Tool error: {content}]" for a failed call, with "(empty)" standing in for
+// a void result. It must never return "": an empty return would drop the
+// block entirely, and a ToolResult is often the only content in its message —
+// mapUserMessage never mixes it with anything mapAssistantMessage-side would
+// need — so a dropped block can leave the message with no content at all,
+// which Bedrock rejects exactly like it rejects the empty-assistant-turn case
+// this file already guards elsewhere.
+//
+// Only Text and Json content blocks are handled: mapToolResultBlock, the only
+// producer of ToolResultBlock in this package, never emits anything else.
 func toolResultText(tr types.ToolResultBlock) string {
 	var sb strings.Builder
 
@@ -580,13 +592,21 @@ func toolResultText(tr types.ToolResultBlock) string {
 		}
 	}
 
-	if strings.TrimSpace(sb.String()) == "" {
-		return ""
+	content := sb.String()
+	if strings.TrimSpace(content) == "" {
+		content = "(empty)"
 	}
 
-	return fmt.Sprintf("[Tool output: %s]", sb.String())
+	if tr.Status == types.ToolResultStatusError {
+		return fmt.Sprintf("[Tool error: %s]", content)
+	}
+
+	return fmt.Sprintf("[Tool output: %s]", content)
 }
 
+// marshalDocument returns nil, rather than an error, on a marshal failure:
+// callers treat that as "no parameters"/"no content", the same fallback used
+// when a document is absent entirely.
 func marshalDocument(doc document.Interface) []byte {
 	if doc == nil {
 		return nil

--- a/providers/bedrock/request_mapper.go
+++ b/providers/bedrock/request_mapper.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime"
@@ -110,6 +111,17 @@ func (rm *RequestMapper) buildConverseParams(req *llm.Request) (*converseParams,
 		}
 
 		p.tools = toolConfig
+	}
+
+	// Bedrock's Converse API rejects a request whose message history contains
+	// toolUse/toolResult blocks unless toolConfig is set on that same request,
+	// even when the current turn has nothing to offer — e.g. a tool used
+	// earlier in the conversation has since been removed from the agent.
+	// Mirror langchain-aws's fix for the same constraint: flatten the stale
+	// blocks to text instead of failing the whole request.
+	// https://github.com/langchain-ai/langchain-aws/pull/595
+	if p.tools == nil && hasToolUseOrResultBlocks(p.messages) {
+		p.messages = convertToolBlocksToText(p.messages)
 	}
 
 	if req.ResponseFormat != nil {
@@ -489,4 +501,101 @@ func (rm *RequestMapper) mapToolChoice(choice *llm.ToolChoice) (types.ToolChoice
 	default:
 		return nil, fmt.Errorf("unsupported tool choice type: %s", choice.Type)
 	}
+}
+
+// hasToolUseOrResultBlocks reports whether any message contains a ToolUse or
+// ToolResult content block.
+func hasToolUseOrResultBlocks(messages []types.Message) bool {
+	for _, msg := range messages {
+		for _, block := range msg.Content {
+			switch block.(type) {
+			case *types.ContentBlockMemberToolUse, *types.ContentBlockMemberToolResult:
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+// convertToolBlocksToText flattens ToolUse/ToolResult content blocks to plain
+// text, preserving only the information needed to keep the transcript
+// readable.
+func convertToolBlocksToText(messages []types.Message) []types.Message {
+	converted := make([]types.Message, len(messages))
+
+	for i, msg := range messages {
+		out := types.Message{Role: msg.Role}
+
+		for _, block := range msg.Content {
+			switch b := block.(type) {
+			case *types.ContentBlockMemberToolUse:
+				out.Content = append(out.Content, &types.ContentBlockMemberText{
+					Value: toolUseText(b.Value),
+				})
+
+			case *types.ContentBlockMemberToolResult:
+				if text := toolResultText(b.Value); text != "" {
+					out.Content = append(out.Content, &types.ContentBlockMemberText{Value: text})
+				}
+
+			default:
+				out.Content = append(out.Content, block)
+			}
+		}
+
+		converted[i] = out
+	}
+
+	return converted
+}
+
+// toolUseText renders a ToolUseBlock as "[Called {name} with parameters: {json}]",
+// or "[Called {name}]" when there are no parameters.
+func toolUseText(tu types.ToolUseBlock) string {
+	name := "function"
+	if tu.Name != nil {
+		name = *tu.Name
+	}
+
+	if raw := marshalDocument(tu.Input); len(raw) > 0 && string(raw) != "{}" && string(raw) != "null" {
+		return fmt.Sprintf("[Called %s with parameters: %s]", name, raw)
+	}
+
+	return fmt.Sprintf("[Called %s]", name)
+}
+
+// toolResultText renders a ToolResultBlock's text/JSON content as
+// "[Tool output: {content}]", or "" if it carries no representable content.
+func toolResultText(tr types.ToolResultBlock) string {
+	var sb strings.Builder
+
+	for _, c := range tr.Content {
+		switch v := c.(type) {
+		case *types.ToolResultContentBlockMemberText:
+			sb.WriteString(v.Value)
+
+		case *types.ToolResultContentBlockMemberJson:
+			sb.Write(marshalDocument(v.Value))
+		}
+	}
+
+	if strings.TrimSpace(sb.String()) == "" {
+		return ""
+	}
+
+	return fmt.Sprintf("[Tool output: %s]", sb.String())
+}
+
+func marshalDocument(doc document.Interface) []byte {
+	if doc == nil {
+		return nil
+	}
+
+	raw, err := doc.MarshalSmithyDocument()
+	if err != nil {
+		return nil
+	}
+
+	return raw
 }

--- a/providers/bedrock/stale_tool_history_test.go
+++ b/providers/bedrock/stale_tool_history_test.go
@@ -87,6 +87,128 @@ func TestToConverseInput_StaleToolHistoryWithoutToolConfig(t *testing.T) {
 	assert.Equal(t, `[Tool output: {"tempC":18}]`, toolResultText.Value)
 }
 
+// TestToConverseInput_StaleToolHistoryWithCachingEnabled proves the
+// flattening still works under Bedrock's default configuration (prompt
+// caching on): the CachePointBlock a caching provider appends to the last
+// message must survive alongside the flattened text, not get lost or choke
+// the conversion.
+func TestToConverseInput_StaleToolHistoryWithCachingEnabled(t *testing.T) {
+	t.Parallel()
+
+	p, err := NewProvider(context.Background(), WithAWSConfig(aws.Config{Region: "us-east-1"}))
+	require.NoError(t, err)
+	require.True(t, p.enableCaching, "test relies on default caching to exercise cache-point interaction")
+
+	model, err := p.NewModel(ModelClaudeSonnet46)
+	require.NoError(t, err)
+
+	m, ok := model.(*Model)
+	require.True(t, ok, "NewModel must return *Model")
+
+	req := &llm.Request{
+		Messages: []llm.Message{
+			{Role: llm.RoleAssistant, Content: []llm.Part{
+				llm.NewToolRequestPart("call_1", "get_weather", json.RawMessage(`{"city":"Berlin"}`)),
+			}},
+			{Role: llm.RoleUser, Content: []llm.Part{
+				llm.NewToolResponsePart("call_1", "get_weather", json.RawMessage(`{"tempC":18}`), false),
+			}},
+		},
+		// No Tools: get_weather has since been removed from the agent.
+	}
+
+	input, err := m.requestMapper.ToConverseInput(req)
+	require.NoError(t, err)
+	assert.Nil(t, input.ToolConfig)
+
+	last := input.Messages[len(input.Messages)-1]
+	require.Len(t, last.Content, 2, "flattened text block plus the cache point")
+
+	toolResultText, ok := last.Content[0].(*types.ContentBlockMemberText)
+	require.True(t, ok, "first block must be the flattened text, not the cache point")
+	assert.Equal(t, `[Tool output: {"tempC":18}]`, toolResultText.Value)
+
+	_, ok = last.Content[1].(*types.ContentBlockMemberCachePoint)
+	assert.True(t, ok, "cache point must still be appended after flattening")
+}
+
+// TestConvertToolBlocksToText_MixedContentInSameMessage proves flattening
+// only touches ToolUse blocks: a text block and a reasoning block sharing a
+// message with a stale ToolRequestPart must pass through untouched, in
+// their original order.
+func TestConvertToolBlocksToText_MixedContentInSameMessage(t *testing.T) {
+	t.Parallel()
+
+	p, err := NewProvider(context.Background(), WithAWSConfig(aws.Config{Region: "us-east-1"}), WithCachingDisabled())
+	require.NoError(t, err)
+
+	model, err := p.NewModel(ModelClaudeSonnet46)
+	require.NoError(t, err)
+
+	m, ok := model.(*Model)
+	require.True(t, ok, "NewModel must return *Model")
+
+	req := &llm.Request{
+		Messages: []llm.Message{
+			llm.NewMessage(llm.RoleAssistant,
+				&llm.ReasoningPart{Text: "thinking about the weather", Signature: "sig"},
+				llm.NewTextPart("Let me check that."),
+				llm.NewToolRequestPart("call_1", "get_weather", json.RawMessage(`{"city":"Berlin"}`)),
+			),
+		},
+		// No Tools: get_weather has since been removed from the agent.
+	}
+
+	input, err := m.requestMapper.ToConverseInput(req)
+	require.NoError(t, err)
+	require.Len(t, input.Messages, 1)
+	require.Len(t, input.Messages[0].Content, 3)
+
+	_, ok = input.Messages[0].Content[0].(*types.ContentBlockMemberReasoningContent)
+	assert.True(t, ok, "reasoning block must pass through untouched")
+
+	textBlock, ok := input.Messages[0].Content[1].(*types.ContentBlockMemberText)
+	require.True(t, ok, "existing text block must pass through untouched")
+	assert.Equal(t, "Let me check that.", textBlock.Value)
+
+	flattened, ok := input.Messages[0].Content[2].(*types.ContentBlockMemberText)
+	require.True(t, ok, "tool_use block must be flattened to text")
+	assert.Equal(t, `[Called get_weather with parameters: {"city":"Berlin"}]`, flattened.Value)
+}
+
+// TestConvertToolBlocksToText_ToolResultJSONContent covers the JSON-content
+// branch of a ToolResult block, which llm.ToolResponsePart never produces
+// itself but the Bedrock content-block union still allows.
+func TestConvertToolBlocksToText_ToolResultJSONContent(t *testing.T) {
+	t.Parallel()
+
+	messages := []types.Message{
+		{
+			Role: types.ConversationRoleUser,
+			Content: []types.ContentBlock{
+				&types.ContentBlockMemberToolResult{
+					Value: types.ToolResultBlock{
+						ToolUseId: aws.String("call_1"),
+						Content: []types.ToolResultContentBlock{
+							&types.ToolResultContentBlockMemberJson{
+								Value: document.NewLazyDocument(map[string]any{"tempC": 18}),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	converted := convertToolBlocksToText(messages)
+
+	require.Len(t, converted, 1)
+	require.Len(t, converted[0].Content, 1)
+	text, ok := converted[0].Content[0].(*types.ContentBlockMemberText)
+	require.True(t, ok)
+	assert.Equal(t, `[Tool output: {"tempC":18}]`, text.Value)
+}
+
 // TestToConverseInput_ToolHistoryPreservedWithToolConfig proves the
 // flattening only kicks in when toolConfig would otherwise be absent: with a
 // live tool list, historical tool blocks must round-trip untouched.

--- a/providers/bedrock/stale_tool_history_test.go
+++ b/providers/bedrock/stale_tool_history_test.go
@@ -1,0 +1,188 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bedrock
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime/document"
+	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/redpanda-data/ai-sdk-go/llm"
+)
+
+// TestToConverseInput_StaleToolHistoryWithoutToolConfig is the Bedrock parity
+// regression for the toolConfig-vs-history mismatch: Bedrock's Converse API
+// rejects a request whose messages contain toolUse/toolResult blocks unless
+// toolConfig is set on that same request, even when the current turn has no
+// tools to offer — e.g. a tool used earlier in the conversation has since
+// been removed from the agent. The mapper must flatten those blocks to text
+// instead of sending a request Bedrock will reject, mirroring langchain-aws's
+// fix for the same constraint (PR #595).
+func TestToConverseInput_StaleToolHistoryWithoutToolConfig(t *testing.T) {
+	t.Parallel()
+
+	p, err := NewProvider(context.Background(), WithAWSConfig(aws.Config{Region: "us-east-1"}), WithCachingDisabled())
+	require.NoError(t, err)
+
+	model, err := p.NewModel(ModelClaudeSonnet46)
+	require.NoError(t, err)
+
+	m, ok := model.(*Model)
+	require.True(t, ok, "NewModel must return *Model")
+
+	req := &llm.Request{
+		Messages: []llm.Message{
+			{Role: llm.RoleUser, Content: []llm.Part{llm.NewTextPart("what's the weather in Berlin?")}},
+			{Role: llm.RoleAssistant, Content: []llm.Part{
+				llm.NewToolRequestPart("call_1", "get_weather", json.RawMessage(`{"city":"Berlin"}`)),
+			}},
+			{Role: llm.RoleUser, Content: []llm.Part{
+				llm.NewToolResponsePart("call_1", "get_weather", json.RawMessage(`{"tempC":18}`), false),
+			}},
+		},
+		// No Tools: get_weather has since been removed from the agent.
+	}
+
+	input, err := m.requestMapper.ToConverseInput(req)
+	require.NoError(t, err)
+
+	assert.Nil(t, input.ToolConfig, "toolConfig must stay unset when the current turn has no tools")
+
+	for _, msg := range input.Messages {
+		for _, block := range msg.Content {
+			_, isToolUse := block.(*types.ContentBlockMemberToolUse)
+			_, isToolResult := block.(*types.ContentBlockMemberToolResult)
+			assert.False(t, isToolUse || isToolResult, "tool blocks must be flattened to text when toolConfig is absent")
+		}
+	}
+
+	assistant := input.Messages[1]
+	require.Len(t, assistant.Content, 1)
+	toolUseText, ok := assistant.Content[0].(*types.ContentBlockMemberText)
+	require.True(t, ok)
+	assert.Equal(t, `[Called get_weather with parameters: {"city":"Berlin"}]`, toolUseText.Value)
+
+	toolResultMsg := input.Messages[2]
+	require.Len(t, toolResultMsg.Content, 1)
+	toolResultText, ok := toolResultMsg.Content[0].(*types.ContentBlockMemberText)
+	require.True(t, ok)
+	assert.Equal(t, `[Tool output: {"tempC":18}]`, toolResultText.Value)
+}
+
+// TestToConverseInput_ToolHistoryPreservedWithToolConfig proves the
+// flattening only kicks in when toolConfig would otherwise be absent: with a
+// live tool list, historical tool blocks must round-trip untouched.
+func TestToConverseInput_ToolHistoryPreservedWithToolConfig(t *testing.T) {
+	t.Parallel()
+
+	p, err := NewProvider(context.Background(), WithAWSConfig(aws.Config{Region: "us-east-1"}), WithCachingDisabled())
+	require.NoError(t, err)
+
+	model, err := p.NewModel(ModelClaudeSonnet46)
+	require.NoError(t, err)
+
+	m, ok := model.(*Model)
+	require.True(t, ok, "NewModel must return *Model")
+
+	req := &llm.Request{
+		Messages: []llm.Message{
+			{Role: llm.RoleAssistant, Content: []llm.Part{
+				llm.NewToolRequestPart("call_1", "get_weather", json.RawMessage(`{"city":"Berlin"}`)),
+			}},
+			{Role: llm.RoleUser, Content: []llm.Part{
+				llm.NewToolResponsePart("call_1", "get_weather", json.RawMessage(`{"tempC":18}`), false),
+			}},
+		},
+		Tools: []llm.ToolDefinition{
+			{Name: "get_weather", Description: "Get the weather", Parameters: json.RawMessage(`{"type":"object"}`)},
+		},
+	}
+
+	input, err := m.requestMapper.ToConverseInput(req)
+	require.NoError(t, err)
+	require.NotNil(t, input.ToolConfig)
+
+	assistant := input.Messages[0]
+	require.Len(t, assistant.Content, 1)
+	_, ok = assistant.Content[0].(*types.ContentBlockMemberToolUse)
+	assert.True(t, ok, "tool blocks must stay structured when toolConfig is present")
+
+	toolResultMsg := input.Messages[1]
+	require.Len(t, toolResultMsg.Content, 1)
+	_, ok = toolResultMsg.Content[0].(*types.ContentBlockMemberToolResult)
+	assert.True(t, ok, "tool blocks must stay structured when toolConfig is present")
+}
+
+// TestConvertToolBlocksToText_NoParameters covers the falsy-parameters branch:
+// a ToolUse block with an empty input map renders without a "with
+// parameters" clause.
+func TestConvertToolBlocksToText_NoParameters(t *testing.T) {
+	t.Parallel()
+
+	messages := []types.Message{
+		{
+			Role: types.ConversationRoleAssistant,
+			Content: []types.ContentBlock{
+				&types.ContentBlockMemberToolUse{
+					Value: types.ToolUseBlock{
+						ToolUseId: aws.String("call_1"),
+						Name:      aws.String("ping"),
+						Input:     document.NewLazyDocument(map[string]any{}),
+					},
+				},
+			},
+		},
+	}
+
+	converted := convertToolBlocksToText(messages)
+
+	require.Len(t, converted, 1)
+	require.Len(t, converted[0].Content, 1)
+	text, ok := converted[0].Content[0].(*types.ContentBlockMemberText)
+	require.True(t, ok)
+	assert.Equal(t, "[Called ping]", text.Value)
+}
+
+// TestConvertToolBlocksToText_EmptyToolResultIsDropped covers the
+// empty-result branch: a ToolResult block with no representable content is
+// dropped rather than emitted as an empty "[Tool output: ]" block.
+func TestConvertToolBlocksToText_EmptyToolResultIsDropped(t *testing.T) {
+	t.Parallel()
+
+	messages := []types.Message{
+		{
+			Role: types.ConversationRoleUser,
+			Content: []types.ContentBlock{
+				&types.ContentBlockMemberToolResult{
+					Value: types.ToolResultBlock{
+						ToolUseId: aws.String("call_1"),
+						Content:   []types.ToolResultContentBlock{},
+					},
+				},
+			},
+		},
+	}
+
+	converted := convertToolBlocksToText(messages)
+
+	require.Len(t, converted, 1)
+	assert.Empty(t, converted[0].Content)
+}

--- a/providers/bedrock/stale_tool_history_test.go
+++ b/providers/bedrock/stale_tool_history_test.go
@@ -283,10 +283,13 @@ func TestConvertToolBlocksToText_NoParameters(t *testing.T) {
 	assert.Equal(t, "[Called ping]", text.Value)
 }
 
-// TestConvertToolBlocksToText_EmptyToolResultIsDropped covers the
-// empty-result branch: a ToolResult block with no representable content is
-// dropped rather than emitted as an empty "[Tool output: ]" block.
-func TestConvertToolBlocksToText_EmptyToolResultIsDropped(t *testing.T) {
+// TestConvertToolBlocksToText_EmptyToolResultBecomesPlaceholder covers the
+// empty-result branch: a ToolResult block with no representable content
+// must still render as a block, not be dropped. A void tool result is a
+// message's only content in practice (mapUserMessage never mixes a
+// ToolResponsePart with anything else), so dropping it would leave the
+// message with zero content blocks — exactly what Bedrock rejects.
+func TestConvertToolBlocksToText_EmptyToolResultBecomesPlaceholder(t *testing.T) {
 	t.Parallel()
 
 	messages := []types.Message{
@@ -306,5 +309,87 @@ func TestConvertToolBlocksToText_EmptyToolResultIsDropped(t *testing.T) {
 	converted := convertToolBlocksToText(messages)
 
 	require.Len(t, converted, 1)
-	assert.Empty(t, converted[0].Content)
+	require.Len(t, converted[0].Content, 1)
+	text, ok := converted[0].Content[0].(*types.ContentBlockMemberText)
+	require.True(t, ok)
+	assert.Equal(t, "[Tool output: (empty)]", text.Value)
+}
+
+// TestConvertToolBlocksToText_ErrorStatusIsMarked proves a failed tool call
+// renders distinguishably from a successful one, rather than both flattening
+// to an identical "[Tool output: ...]" string.
+func TestConvertToolBlocksToText_ErrorStatusIsMarked(t *testing.T) {
+	t.Parallel()
+
+	messages := []types.Message{
+		{
+			Role: types.ConversationRoleUser,
+			Content: []types.ContentBlock{
+				&types.ContentBlockMemberToolResult{
+					Value: types.ToolResultBlock{
+						ToolUseId: aws.String("call_1"),
+						Status:    types.ToolResultStatusError,
+						Content: []types.ToolResultContentBlock{
+							&types.ToolResultContentBlockMemberText{Value: `{"error":"rate limited"}`},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	converted := convertToolBlocksToText(messages)
+
+	require.Len(t, converted, 1)
+	require.Len(t, converted[0].Content, 1)
+	text, ok := converted[0].Content[0].(*types.ContentBlockMemberText)
+	require.True(t, ok)
+	assert.Equal(t, `[Tool error: {"error":"rate limited"}]`, text.Value)
+}
+
+// TestToConverseInput_EmptyToolResultWithCachingDoesNotProduceInvalidMessage
+// is the regression for a real bug found in review: dropping an empty
+// ToolResult left a content-less message when it was a turn's only block,
+// and with caching on (the Bedrock default) the last message flattened down
+// to a cachePoint-only block — both forms Bedrock rejects. A void tool
+// result (Result == nil, e.g. from a tool with no return value) must still
+// produce a real block.
+func TestToConverseInput_EmptyToolResultWithCachingDoesNotProduceInvalidMessage(t *testing.T) {
+	t.Parallel()
+
+	p, err := NewProvider(context.Background(), WithAWSConfig(aws.Config{Region: "us-east-1"}))
+	require.NoError(t, err)
+	require.True(t, p.enableCaching, "test relies on default caching to exercise cache-point interaction")
+
+	model, err := p.NewModel(ModelClaudeSonnet46)
+	require.NoError(t, err)
+
+	m, ok := model.(*Model)
+	require.True(t, ok, "NewModel must return *Model")
+
+	req := &llm.Request{
+		Messages: []llm.Message{
+			{Role: llm.RoleAssistant, Content: []llm.Part{
+				llm.NewToolRequestPart("call_1", "ping", json.RawMessage(`{}`)),
+			}},
+			{Role: llm.RoleUser, Content: []llm.Part{
+				llm.NewToolResponsePart("call_1", "ping", nil, false),
+			}},
+		},
+		// No Tools: ping has since been removed from the agent.
+	}
+
+	input, err := m.requestMapper.ToConverseInput(req)
+	require.NoError(t, err)
+	assert.Nil(t, input.ToolConfig)
+
+	last := input.Messages[len(input.Messages)-1]
+	require.Len(t, last.Content, 2, "placeholder text block plus the cache point")
+
+	text, ok := last.Content[0].(*types.ContentBlockMemberText)
+	require.True(t, ok, "first block must be real text, not the cache point")
+	assert.Equal(t, "[Tool output: (empty)]", text.Value)
+
+	_, ok = last.Content[1].(*types.ContentBlockMemberCachePoint)
+	assert.True(t, ok, "cache point must still be appended after flattening")
 }


### PR DESCRIPTION
## What

Flatten `toolUse`/`toolResult` content blocks to plain text in the Bedrock request mapper when the outgoing request has no `toolConfig` to cover them, instead of letting Bedrock reject the whole call.

## Why

Bedrock's Converse API requires `toolConfig` on a request whenever the message history contains `toolUse`/`toolResult` blocks, regardless of whether the current turn has any tools to offer. Remove a tool from an agent and every later turn on a session that used it hits:

```
ValidationException: The toolConfig field must be defined when using toolUse and toolResult content blocks.
```

This is a documented, retroactive constraint specific to Bedrock's Converse API — Anthropic's and OpenAI's own APIs don't enforce it, so nothing here reuses an existing pattern in this codebase. It's also a widely-reported problem: langchain-aws, langgraphjs, the Vercel AI SDK, opencode, Dify and Roo-Code have all hit the identical error string. langchain-aws is the only one with a merged fix.

## Implementation details

`buildConverseParams` in `providers/bedrock/request_mapper.go` already builds `ToolConfig` conditionally on `len(req.Tools) > 0` for the current turn, but `mapAssistantMessage`/`mapUserMessage` unconditionally re-serialize historical tool blocks. Added a check after tool mapping: if `p.tools` ends up nil and the mapped history still contains tool blocks, run `convertToolBlocksToText` over the messages.

Ported langchain-aws's fix (PR #595) verbatim in spirit: `toolUse` becomes `"[Called {name} with parameters: {json}]"` (or `"[Called {name}]"` with no parameters), `toolResult` becomes `"[Tool output: {content}]"` (dropped entirely if it carries no representable content). Everything else passes through untouched. No fake `toolConfig` is synthesized — Bedrock's `ToolConfiguration.tools` isn't documented to accept an empty list, so that route wasn't viable.

Placed as a single check in the shared `buildConverseParams`, covering both `ToConverseInput` and `ToConverseStreamInput`, rather than duplicating the check at each call site the way the Python fix does.

Three pre-existing unit tests (`TestRequestMapper_ToolResponse`, `TestRequestMapper_ToolResponseError`, `TestRequestMapper_AssistantWithToolUse`) built tool-bearing requests without ever setting `Tools`, which is now a legitimate trigger for flattening. Added a matching `Tools` entry to each so they keep exercising the tools-bound path they were meant to test.

## References

https://github.com/langchain-ai/langchain-aws/pull/595
https://github.com/langchain-ai/langchain-aws/issues/591