### PR TITLE
feat(google): add Gemini 3.8 Flash

### DIFF
--- a/catalog/facts_data.go
+++ b/catalog/facts_data.go
@@ -63,6 +63,7 @@ const (
 
 	// Google models.
 
+	ModelGemini38Flash       ModelID = "google/gemini-3.8-flash"
 	ModelGemini37Flash       ModelID = "google/gemini-3.7-flash"
 	ModelGemini36Flash       ModelID = "google/gemini-3.6-flash"
 	ModelGemini35Flash       ModelID = "google/gemini-3.5-flash"
@@ -287,6 +288,13 @@ var defaultRegistry = Registry{
 	},
 
 	// ---- Google ----
+	ModelGemini38Flash: {
+		DisplayName: "Gemini 3.8 Flash", Series: "gemini-flash",
+		// Released 2026-09-02 per the Gemini API changelog and deprecations
+		// page. Knowledge cutoff "March 2026" per the DeepMind model card.
+		Released: MustDate("2026-09-02"), Knowledge: MustDate("2026-03-31"),
+		Description: "Gemini 3.8 Flash is Google's most intelligent Flash model, built for long-horizon software engineering, autonomous agents, and complex enterprise workflows.",
+	},
 	ModelGemini37Flash: {
 		DisplayName: "Gemini 3.7 Flash", Series: "gemini-flash",
 		// Google publishes "Latest update: August 2026" without a day;

--- a/catalog/snapshot.json
+++ b/catalog/snapshot.json
@@ -151,6 +151,13 @@
       "series": "gemini-flash",
       "released": "2026-08-13"
     },
+    "google/gemini-3.8-flash": {
+      "display_name": "Gemini 3.8 Flash",
+      "description": "Gemini 3.8 Flash is Google's most intelligent Flash model, built for long-horizon software engineering, autonomous agents, and complex enterprise workflows.",
+      "series": "gemini-flash",
+      "released": "2026-09-02",
+      "knowledge": "2026-03-31"
+    },
     "google/gemma-4-26b-a4b": {
       "display_name": "Gemma 4 26B A4B",
       "description": "Gemma 4 26B A4B IT is an instruction-tuned Mixture-of-Experts (MoE) model from Google DeepMind.",
@@ -5068,6 +5075,75 @@
           "lifecycle": {
             "stage": "ga",
             "available": "2026-08-13"
+          },
+          "derived": {
+            "price_tier": "low",
+            "replacement": "google/gemini-3.8-flash"
+          }
+        },
+        {
+          "id": "gemini-3.8-flash",
+          "model": "google/gemini-3.8-flash",
+          "display_name": "Gemini 3.8 Flash",
+          "capabilities": {
+            "audio": true,
+            "json_mode": true,
+            "multi_turn": true,
+            "reasoning": true,
+            "streaming": true,
+            "structured_output": true,
+            "system_prompts": true,
+            "tools": true,
+            "vision": true
+          },
+          "constraints": {
+            "max_input_tokens": 1048576,
+            "max_output_tokens": 65536,
+            "supported_params": [
+              "temperature",
+              "top_p",
+              "top_k",
+              "max_tokens",
+              "stop",
+              "presence_penalty",
+              "frequency_penalty"
+            ],
+            "temperature_range": [
+              0,
+              2
+            ]
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image",
+              "audio",
+              "video",
+              "document"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "reasoning": {
+            "efforts": [
+              "low",
+              "medium",
+              "high"
+            ]
+          },
+          "pricing": {
+            "default": {
+              "base": {
+                "input_microcents_per_million": 75000000,
+                "output_microcents_per_million": 375000000,
+                "cached_input_microcents_per_million": 7500000
+              }
+            }
+          },
+          "lifecycle": {
+            "stage": "ga",
+            "available": "2026-09-02"
           },
           "derived": {
             "price_tier": "low"

--- a/providers/google/google_conformance_test.go
+++ b/providers/google/google_conformance_test.go
@@ -119,6 +119,7 @@ func TestGoogleConformance_Integration(t *testing.T) {
 	t.Parallel()
 
 	modelsToTest := []string{
+		google.ModelGemini38Flash,       // gemini-3.8-flash
 		google.ModelGemini36Flash,       // gemini-3.6-flash
 		google.ModelGemini35FlashLite,   // gemini-3.5-flash-lite
 		google.ModelGemini35Flash,       // gemini-3.5-flash

--- a/providers/google/models.go
+++ b/providers/google/models.go
@@ -24,6 +24,7 @@ import (
 
 // Model ID constants for Google Gemini models.
 const (
+	ModelGemini38Flash      = "gemini-3.8-flash"
 	ModelGemini37Flash      = "gemini-3.7-flash"
 	ModelGemini36Flash      = "gemini-3.6-flash"
 	ModelGemini35FlashLite  = "gemini-3.5-flash-lite"
@@ -100,8 +101,8 @@ var (
 		ReasoningEffortMedium,
 		ReasoningEffortHigh,
 	}
-	// Gemini 3.7 Flash rejects "minimal" ("minimal is not supported and
-	// returns an error" — model page).
+	// Gemini 3.7 and 3.8 Flash reject "minimal" ("minimal is not supported
+	// and returns an error" — model pages).
 	gemini37FlashReasoningEfforts = []ReasoningEffort{
 		ReasoningEffortLow,
 		ReasoningEffortMedium,
@@ -169,6 +170,28 @@ var geminiParams = []string{"temperature", "top_p", "top_k", "max_tokens", "stop
 // has an announced shutdown.
 func entries() []catalog.Entry {
 	return []catalog.Entry{
+		{
+			ID:           ModelGemini38Flash,
+			Model:        catalog.ModelGemini38Flash,
+			Capabilities: geminiCaps,
+			Modalities:   geminiModalities,
+			Reasoning: catalog.ReasoningSupport{
+				Efforts: gemini37FlashReasoningEfforts,
+			},
+			Constraints: llm.ModelConstraints{
+				TemperatureRange: [2]float64{0.0, 2.0},
+				MaxInputTokens:   1048576,
+				MaxOutputTokens:  65536,
+				SupportedParams:  geminiParams,
+			},
+			Life: catalog.Lifecycle{
+				Available: catalog.MustDate("2026-09-02"),
+			},
+			// Google lists $0.75/$3.75 (cache $0.075) through 2026-12-31,
+			// rising to $1.50/$7.50/$0.15 on 2027-01-01. Only the rate in
+			// effect is tracked. No long-context tier is published.
+			Pricing: pricing.FlatInfo(0.75, 3.75, 0.075),
+		},
 		{
 			ID:           ModelGemini37Flash,
 			Model:        catalog.ModelGemini37Flash,


### PR DESCRIPTION
Adds `gemini-3.8-flash` (GA 2026-09-02) to the Google catalog.

- 1M input / 64K output, thinking low/medium/high (minimal rejected)
- Introductory pricing $0.75 / $3.75 / $0.075 cache through 2026-12-31
- Knowledge cutoff March 2026 (DeepMind model card)
- No retirement date or replacement announced; existing lifecycles unchanged
- Added to the Google integration conformance model list

Sources: ai.google.dev model page, pricing page, changelog, deprecations.