### PR TITLE
feat(anthropic): add Claude Fable 5.1

### DIFF
--- a/catalog/facts_data.go
+++ b/catalog/facts_data.go
@@ -21,6 +21,7 @@ package catalog
 const (
 	// Anthropic models.
 
+	ModelClaudeFable51  ModelID = "anthropic/claude-fable-5-1"
 	ModelClaudeFable5   ModelID = "anthropic/claude-fable-5"
 	ModelClaudeOpus5    ModelID = "anthropic/claude-opus-5"
 	ModelClaudeOpus48   ModelID = "anthropic/claude-opus-4-8"
@@ -98,6 +99,13 @@ const (
 // luna ← gpt-nano), matching OpenAI's own recommended replacements.
 var defaultRegistry = Registry{
 	// ---- Anthropic ----
+	ModelClaudeFable51: {
+		DisplayName: "Claude Fable 5.1", Series: "claude-fable",
+		// Released and reliable knowledge cutoff ("Jun 2026") per
+		// platform.claude.com/docs/en/models/fable-5-1/overview.
+		Released: MustDate("2026-09-01"), Knowledge: MustDate("2026-06-30"),
+		Description: "Claude Fable 5.1 is Anthropic’s most capable Mythos-class model for demanding reasoning and long-horizon agentic work.",
+	},
 	ModelClaudeFable5: {
 		DisplayName: "Claude Fable 5", Series: "claude-fable",
 		Released:    MustDate("2026-06-07"),

--- a/catalog/snapshot.json
+++ b/catalog/snapshot.json
@@ -13,6 +13,13 @@
       "series": "claude-fable",
       "released": "2026-06-07"
     },
+    "anthropic/claude-fable-5-1": {
+      "display_name": "Claude Fable 5.1",
+      "description": "Claude Fable 5.1 is Anthropic’s most capable Mythos-class model for demanding reasoning and long-horizon agentic work.",
+      "series": "claude-fable",
+      "released": "2026-09-01",
+      "knowledge": "2026-06-30"
+    },
     "anthropic/claude-haiku-4-5": {
       "display_name": "Claude Haiku 4.5",
       "description": "Claude Haiku 4.5 is Anthropic’s fastest and most efficient model, delivering near-frontier intelligence at a fraction of the cost and latency of larger Claude models.",
@@ -415,6 +422,69 @@
           "lifecycle": {
             "stage": "ga",
             "available": "2026-06-07"
+          },
+          "derived": {
+            "price_tier": "high",
+            "replacement": "anthropic/claude-fable-5-1"
+          }
+        },
+        {
+          "id": "claude-fable-5-1",
+          "model": "anthropic/claude-fable-5-1",
+          "display_name": "Claude Fable 5.1",
+          "capabilities": {
+            "audio": false,
+            "json_mode": false,
+            "multi_turn": true,
+            "reasoning": true,
+            "streaming": true,
+            "structured_output": true,
+            "system_prompts": true,
+            "tools": true,
+            "vision": true
+          },
+          "constraints": {
+            "max_input_tokens": 1000000,
+            "max_output_tokens": 128000,
+            "supported_params": [
+              "max_tokens",
+              "reasoning_effort"
+            ]
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image",
+              "document"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "reasoning": {
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ],
+            "adaptive": true
+          },
+          "pricing": {
+            "default": {
+              "base": {
+                "input_microcents_per_million": 1000000000,
+                "output_microcents_per_million": 5000000000,
+                "cached_input_microcents_per_million": 25000000,
+                "cache_creation_5m_microcents_per_million": 1250000000,
+                "cache_creation_1h_microcents_per_million": 2000000000
+              }
+            }
+          },
+          "lifecycle": {
+            "stage": "ga",
+            "available": "2026-09-01"
           },
           "derived": {
             "price_tier": "high"

--- a/providers/anthropic/alias_test.go
+++ b/providers/anthropic/alias_test.go
@@ -30,6 +30,11 @@ func TestModelResolution(t *testing.T) {
 		expectedModel string
 	}{
 		{
+			name:          "claude-fable-5-1 family name resolves",
+			modelKey:      ModelClaudeFable51,
+			expectedModel: ModelClaudeFable51,
+		},
+		{
 			name:          "claude-fable-5 family name resolves",
 			modelKey:      "claude-fable-5",
 			expectedModel: "claude-fable-5",
@@ -223,6 +228,14 @@ func TestWithThinkingBudget(t *testing.T) {
 		assert.Contains(t, err.Error(), "thinking_budget")
 	})
 
+	t.Run("rejected on Fable 5.1", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := provider.NewModel(ModelClaudeFable51, WithThinkingBudget(2048))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "thinking_budget")
+	})
+
 	t.Run("rejected on Opus 5", func(t *testing.T) {
 		t.Parallel()
 
@@ -388,6 +401,14 @@ func TestWithSpeed(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "speed")
 	})
+
+	t.Run("rejected on Fable 5.1", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := provider.NewModel(ModelClaudeFable51, WithSpeed(SpeedFast))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "speed")
+	})
 }
 
 func TestRestrictedSamplingParametersRejected(t *testing.T) {
@@ -406,7 +427,7 @@ func TestRestrictedSamplingParametersRejected(t *testing.T) {
 		{name: "top_k", opt: WithTopK(10), want: "top_k"},
 	}
 
-	for _, model := range []string{ModelClaudeFable5, ModelClaudeOpus5} {
+	for _, model := range []string{ModelClaudeFable51, ModelClaudeFable5, ModelClaudeOpus5} {
 		t.Run(model, func(t *testing.T) {
 			t.Parallel()
 

--- a/providers/anthropic/models.go
+++ b/providers/anthropic/models.go
@@ -26,6 +26,7 @@ import (
 // These are model family identifiers (non-timestamped). The Anthropic API
 // accepts them directly and resolves to the latest snapshot.
 const (
+	ModelClaudeFable51  = "claude-fable-5-1"
 	ModelClaudeFable5   = "claude-fable-5"
 	ModelClaudeOpus5    = "claude-opus-5"
 	ModelClaudeSonnet5  = "claude-sonnet-5"
@@ -126,6 +127,33 @@ var claudeModalities = catalog.Modalities{
 // failure stays explainable.
 func entries() []catalog.Entry {
 	return []catalog.Entry{
+		{
+			ID:           ModelClaudeFable51,
+			Model:        catalog.ModelClaudeFable51,
+			Capabilities: claudeCaps,
+			Modalities:   claudeModalities,
+			Constraints: llm.ModelConstraints{
+				MaxInputTokens:  1000000, // 1M context window
+				MaxOutputTokens: 128000,  // 128K output tokens
+				// Fable 5.1 keeps Fable 5's surface: thinking is always on
+				// (thinking.type.enabled is rejected) and non-default sampling
+				// parameters return 400. Fast mode is not offered.
+				SupportedParams: []string{"max_tokens", "reasoning_effort"},
+			},
+			Reasoning: catalog.ReasoningSupport{
+				Efforts:  []ReasoningEffort{ReasoningEffortLow, ReasoningEffortMedium, ReasoningEffortHigh, ReasoningEffortXHigh, ReasoningEffortMax},
+				Adaptive: true,
+			},
+			Life: catalog.Lifecycle{
+				Available: catalog.MustDate("2026-09-01"),
+			},
+			// Same base and cache-write rates as Fable 5. Cache reads are the
+			// exception to Anthropic's 0.10x multiplier: the pricing page
+			// prices Fable 5.1 hits at 0.025x base input ($0.25/MTok).
+			Pricing: pricing.FlatInfoFromRates(
+				pricing.NewRates(10.00, 50.00, 0.25).WithCacheCreation(12.50, 20.00, 0),
+			),
+		},
 		{
 			ID:           ModelClaudeFable5,
 			Model:        catalog.ModelClaudeFable5,


### PR DESCRIPTION
Adds `claude-fable-5-1` (released 2026-09-01) to the Anthropic catalog.

- 1M context / 128K output, adaptive thinking always on, efforts low–max, no fast mode
- $10 / $50, cache writes $12.50 (5m) / $20 (1h); cache reads $0.25 (0.025x, not the usual 0.10x)
- Reliable knowledge cutoff June 2026
- "Not sooner than 2027-09-01" retirement floor, so `Retires` stays unset; no other lifecycle changes
- Tests: model resolution, thinking-budget/speed/sampling rejection

Source: platform.claude.com model overview, pricing, and model-deprecations pages.