### PR TITLE
feat(bedrock): add Claude Fable 5.1 profiles

### DIFF
--- a/catalog/snapshot.json
+++ b/catalog/snapshot.json
@@ -1678,7 +1678,8 @@
             }
           ],
           "derived": {
-            "price_tier": "high"
+            "price_tier": "high",
+            "replacement": "anthropic/claude-fable-5-1"
           }
         },
         {
@@ -2355,6 +2356,78 @@
                 "input_microcents_per_million": 1000000000,
                 "output_microcents_per_million": 5000000000,
                 "cached_input_microcents_per_million": 100000000,
+                "cache_creation_5m_microcents_per_million": 1250000000,
+                "cache_creation_1h_microcents_per_million": 2000000000
+              }
+            }
+          },
+          "lifecycle": {
+            "stage": "ga"
+          },
+          "attributes": [
+            {
+              "key": "inference_geo",
+              "value": "global"
+            },
+            {
+              "key": "requires_provider_data_sharing",
+              "value": "true"
+            }
+          ],
+          "derived": {
+            "price_tier": "high",
+            "replacement": "anthropic/claude-fable-5-1"
+          }
+        },
+        {
+          "id": "global.anthropic.claude-fable-5-1",
+          "model": "anthropic/claude-fable-5-1",
+          "display_name": "Claude Fable 5.1 (Global)",
+          "capabilities": {
+            "audio": false,
+            "json_mode": false,
+            "multi_turn": true,
+            "reasoning": true,
+            "streaming": true,
+            "structured_output": true,
+            "system_prompts": true,
+            "tools": true,
+            "vision": true
+          },
+          "constraints": {
+            "max_input_tokens": 1000000,
+            "max_output_tokens": 128000,
+            "supported_params": [
+              "max_tokens",
+              "stop"
+            ]
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image",
+              "document"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "reasoning": {
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ],
+            "adaptive": true
+          },
+          "pricing": {
+            "default": {
+              "base": {
+                "input_microcents_per_million": 1000000000,
+                "output_microcents_per_million": 5000000000,
+                "cached_input_microcents_per_million": 25000000,
                 "cache_creation_5m_microcents_per_million": 1250000000,
                 "cache_creation_1h_microcents_per_million": 2000000000
               }
@@ -3776,6 +3849,78 @@
                 "input_microcents_per_million": 1100000000,
                 "output_microcents_per_million": 5500000000,
                 "cached_input_microcents_per_million": 110000000,
+                "cache_creation_5m_microcents_per_million": 1375000000,
+                "cache_creation_1h_microcents_per_million": 2200000000
+              }
+            }
+          },
+          "lifecycle": {
+            "stage": "ga"
+          },
+          "attributes": [
+            {
+              "key": "inference_geo",
+              "value": "us"
+            },
+            {
+              "key": "requires_provider_data_sharing",
+              "value": "true"
+            }
+          ],
+          "derived": {
+            "price_tier": "high",
+            "replacement": "anthropic/claude-fable-5-1"
+          }
+        },
+        {
+          "id": "us.anthropic.claude-fable-5-1",
+          "model": "anthropic/claude-fable-5-1",
+          "display_name": "Claude Fable 5.1 (US)",
+          "capabilities": {
+            "audio": false,
+            "json_mode": false,
+            "multi_turn": true,
+            "reasoning": true,
+            "streaming": true,
+            "structured_output": true,
+            "system_prompts": true,
+            "tools": true,
+            "vision": true
+          },
+          "constraints": {
+            "max_input_tokens": 1000000,
+            "max_output_tokens": 128000,
+            "supported_params": [
+              "max_tokens",
+              "stop"
+            ]
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image",
+              "document"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "reasoning": {
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ],
+            "adaptive": true
+          },
+          "pricing": {
+            "default": {
+              "base": {
+                "input_microcents_per_million": 1100000000,
+                "output_microcents_per_million": 5500000000,
+                "cached_input_microcents_per_million": 27500000,
                 "cache_creation_5m_microcents_per_million": 1375000000,
                 "cache_creation_1h_microcents_per_million": 2200000000
               }

--- a/providers/bedrock/cross_region.go
+++ b/providers/bedrock/cross_region.go
@@ -64,6 +64,50 @@ func IsModelAllowedFromRegion(modelID, awsRegion string) bool {
 	return prefix == sourceRegionGeoPrefix(awsRegion)
 }
 
+// claudeFable51ProfileRegions maps every published source region to its
+// preferred profile. Fable 5.1 publishes only US and global profiles: the
+// US geo covers the US and Canada regions, and every other published
+// commercial region is global-only (GovCloud is geo-only and out of scope).
+//
+// Source: https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-fable-5-1.html
+var claudeFable51ProfileRegions = map[string]string{
+	"us-east-1":    "us",
+	"us-east-2":    "us",
+	"us-west-1":    "us",
+	"us-west-2":    "us",
+	"ca-central-1": "us",
+	"ca-west-1":    "us",
+
+	"eu-central-1": globalProfileRegion,
+	"eu-central-2": globalProfileRegion,
+	"eu-north-1":   globalProfileRegion,
+	"eu-south-1":   globalProfileRegion,
+	"eu-south-2":   globalProfileRegion,
+	"eu-west-1":    globalProfileRegion,
+	"eu-west-2":    globalProfileRegion,
+	"eu-west-3":    globalProfileRegion,
+
+	"ap-east-2":      globalProfileRegion,
+	"ap-northeast-1": globalProfileRegion,
+	"ap-northeast-2": globalProfileRegion,
+	"ap-northeast-3": globalProfileRegion,
+	"ap-south-1":     globalProfileRegion,
+	"ap-south-2":     globalProfileRegion,
+	"ap-southeast-1": globalProfileRegion,
+	"ap-southeast-2": globalProfileRegion,
+	"ap-southeast-3": globalProfileRegion,
+	"ap-southeast-4": globalProfileRegion,
+	"ap-southeast-5": globalProfileRegion,
+	"ap-southeast-6": globalProfileRegion,
+	"ap-southeast-7": globalProfileRegion,
+	"il-central-1":   globalProfileRegion,
+	"me-central-1":   globalProfileRegion,
+	"me-south-1":     globalProfileRegion,
+	"af-south-1":     globalProfileRegion,
+	"sa-east-1":      globalProfileRegion,
+	"mx-central-1":   globalProfileRegion,
+}
+
 // claudeOpus5ProfileRegions maps every published source region to its
 // preferred profile. Opus 5 publishes US, EU, AU, and global profiles, with
 // AU limited to Sydney and Melbourne. Other published commercial regions use

--- a/providers/bedrock/models.go
+++ b/providers/bedrock/models.go
@@ -51,6 +51,14 @@ const (
 	ModelClaudeFable5US     = "us." + ModelClaudeFable5
 	ModelClaudeFable5EU     = "eu." + ModelClaudeFable5
 
+	// ModelClaudeFable51 is the bare Bedrock ID for Claude Fable 5.1
+	// (inference-profile-only — invoke via one of the prefixed variants).
+	// AWS publishes only the us. and global. profiles:
+	// https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-fable-5-1.html
+	ModelClaudeFable51       = "anthropic.claude-fable-5-1"
+	ModelClaudeFable51Global = "global." + ModelClaudeFable51
+	ModelClaudeFable51US     = "us." + ModelClaudeFable51
+
 	// ModelClaudeSonnet5 is the bare Bedrock ID for Claude Sonnet 5
 	// (inference-profile-only — invoke via one of the prefixed variants).
 	// Only us. and global. profiles are published so far (verified by
@@ -584,6 +592,25 @@ func Catalog() *catalog.Catalog {
 // has an announced deprecation, and per-profile availability dates are not
 // published, so Life stays empty rather than inventing dates.
 var bedrockFamilies = []family{
+	{
+		// Claude Fable 5.1 — inference-profile-only, no bare entry. The
+		// model card publishes a US geo profile and global; EU/JP/AU
+		// regions are global-only, so the family opts into exact routing.
+		// Cache reads are 0.025x base input (matching Anthropic's
+		// first-party rate), not the 0.10x the other Claude families use.
+		BareID:         ModelClaudeFable51,
+		Model:          catalog.ModelClaudeFable51,
+		DisplayName:    "Claude Fable 5.1",
+		Profiles:       []string{"global", "us"},
+		DataSharing:    true,
+		Capabilities:   claudeStandardCaps,
+		Modalities:     claudeModalities,
+		Constraints:    claudeNoSampling1MConstraints,
+		Reasoning:      frontierClaudeThinking,
+		GlobalRates:    &pricing.RateCard{Base: pricing.NewRates(10.00, 50.00, 0.25).WithCacheCreation(12.50, 20.00, 0)},
+		Rates:          pricing.RateCard{Base: pricing.NewRates(11.00, 55.00, 0.275).WithCacheCreation(13.75, 22.00, 0)},
+		ProfileRegions: claudeFable51ProfileRegions,
+	},
 	{
 		// Claude Fable 5 — inference-profile-only, no bare entry. Geo
 		// profiles cover us and eu (jp/au are not published).

--- a/providers/bedrock/provider_test.go
+++ b/providers/bedrock/provider_test.go
@@ -182,6 +182,28 @@ func TestLookupModel(t *testing.T) {
 			wantOK: false,
 		},
 		{
+			name:   "Fable 5.1 bare ID is not in the catalog",
+			input:  ModelClaudeFable51,
+			wantOK: false,
+		},
+		{
+			name:    "Fable 5.1 US profile is its own entry",
+			input:   ModelClaudeFable51US,
+			wantOK:  true,
+			wantDef: ModelClaudeFable51US,
+		},
+		{
+			name:    "Fable 5.1 global profile is its own entry",
+			input:   ModelClaudeFable51Global,
+			wantOK:  true,
+			wantDef: ModelClaudeFable51Global,
+		},
+		{
+			name:   "Fable 5.1 EU profile is not published",
+			input:  "eu." + ModelClaudeFable51,
+			wantOK: false,
+		},
+		{
 			name:    "geo profile is its own entry",
 			input:   ModelClaudeSonnet46EU,
 			wantOK:  true,
@@ -582,6 +604,52 @@ func TestNewModel_ClaudeOpus5Routing(t *testing.T) {
 	}
 }
 
+func TestNewModel_ClaudeFable51Routing(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		region    string
+		modelName string
+		wantID    string
+		wantErr   bool
+	}{
+		{"bare defaults to US", "", ModelClaudeFable51, ModelClaudeFable51US, false},
+		{"bare from US", "us-east-1", ModelClaudeFable51, ModelClaudeFable51US, false},
+		{"bare from Canada Central", "ca-central-1", ModelClaudeFable51, ModelClaudeFable51US, false},
+		{"bare from EU routes global", "eu-west-1", ModelClaudeFable51, ModelClaudeFable51Global, false},
+		{"bare from Sydney routes global", "ap-southeast-2", ModelClaudeFable51, ModelClaudeFable51Global, false},
+		{"bare from Tokyo routes global", "ap-northeast-1", ModelClaudeFable51, ModelClaudeFable51Global, false},
+		{"bare from GovCloud", "us-gov-west-1", ModelClaudeFable51, "", true},
+		{"bare from unknown region", "unknown", ModelClaudeFable51, "", true},
+		{"explicit US from US", "us-east-1", ModelClaudeFable51US, ModelClaudeFable51US, false},
+		{"explicit global from EU", "eu-west-1", ModelClaudeFable51Global, ModelClaudeFable51Global, false},
+		{"explicit US from EU", "eu-west-1", ModelClaudeFable51US, "", true},
+		{"explicit EU is unpublished", "eu-west-1", "eu." + ModelClaudeFable51, "", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			p := &Provider{client: nil, region: tt.region}
+
+			model, err := p.NewModel(tt.modelName)
+			if tt.wantErr {
+				require.Error(t, err)
+
+				return
+			}
+
+			require.NoError(t, err)
+
+			m, ok := model.(*Model)
+			require.True(t, ok)
+			assert.Equal(t, tt.wantID, m.config.APIModelID)
+		})
+	}
+}
+
 func TestNewModel_RestrictedSamplingParametersRejected(t *testing.T) {
 	t.Parallel()
 
@@ -596,7 +664,7 @@ func TestNewModel_RestrictedSamplingParametersRejected(t *testing.T) {
 		{name: "top_p", opt: WithTopP(0.9), want: "top_p"},
 	}
 
-	for _, model := range []string{ModelClaudeFable5, ModelClaudeOpus5} {
+	for _, model := range []string{ModelClaudeFable51, ModelClaudeFable5, ModelClaudeOpus5} {
 		t.Run(model, func(t *testing.T) {
 			t.Parallel()
 
@@ -1249,7 +1317,7 @@ func TestModelsDiscovery_ProviderDataSharingMetadata(t *testing.T) {
 		metadataByName[m.ID] = m.Attributes
 	}
 
-	for _, name := range []string{ModelClaudeFable5Global, ModelClaudeFable5US, ModelClaudeFable5EU} {
+	for _, name := range []string{ModelClaudeFable51Global, ModelClaudeFable51US, ModelClaudeFable5Global, ModelClaudeFable5US, ModelClaudeFable5EU} {
 		assert.Equal(t, "true", metadataByName[name][ModelMetadataRequiresProviderDataSharing])
 	}
 

--- a/providers/bedrock/thinking_test.go
+++ b/providers/bedrock/thinking_test.go
@@ -154,6 +154,11 @@ func TestModelThinkingCapabilities(t *testing.T) {
 		supportsBudget   bool
 	}{
 		{
+			model:            ModelClaudeFable51US,
+			efforts:          []ReasoningEffort{ReasoningEffortLow, ReasoningEffortMedium, ReasoningEffortHigh, ReasoningEffortXHigh, ReasoningEffortMax},
+			supportsAdaptive: true,
+		},
+		{
 			model:            ModelClaudeFable5US,
 			efforts:          []ReasoningEffort{ReasoningEffortLow, ReasoningEffortMedium, ReasoningEffortHigh, ReasoningEffortXHigh, ReasoningEffortMax},
 			supportsAdaptive: true,


### PR DESCRIPTION
Adds `global.anthropic.claude-fable-5-1` and `us.anthropic.claude-fable-5-1` to the Bedrock catalog. Stacked on #214 (needs the `anthropic/claude-fable-5-1` facts).

- Model card publishes only US geo + global; no bare in-region endpoint, EU/JP/AU are global-only, so the family gets an exact region map (like Opus 5)
- Global $10 / $50, cache read $0.25; geo 1.10x ($11 / $55 / $0.275), per the AWS pricing data
- Requires provider data sharing (`aws_review` opt-in), same as Fable 5
- Tests: lookup, region routing, sampling rejection, data-sharing metadata, thinking capabilities

Not probed live (no AWS session); IDs and regions are from the model card.