### PR TITLE
fix(mcp): stop reconnecting when the server denies authorization

### DIFF
--- a/tool/mcp/README.md
+++ b/tool/mcp/README.md
@@ -208,6 +208,38 @@ client, err := mcp.NewClient(
 )
 ```
 
+### Reconnection and authorization denials
+
+Once a session has been established the client owns reconnection: it watches
+the session, and when it drops it reconnects with exponential backoff, capped
+at 30 seconds, for as long as the client lives.
+
+Two failure modes are deliberately not retried, because retrying makes them
+worse:
+
+- **The server denies authorization.** A 401, 403 or 424 on the handshake
+  cannot be fixed by connecting again: the credential or the grant has to
+  change first. The client stops reconnecting, unregisters its tools from the
+  registry so a model is no longer offered calls that cannot succeed, and shuts
+  itself down. Operations then fail with `ErrAuthDenied`, and `Start` reports
+  the same error when the *initial* connect is denied. Detection reads the HTTP
+  status, so it applies to the transports built by `NewStreamableTransport` and
+  `NewSSETransport`; a stdio transport, or one built by your own
+  `TransportFactory`, keeps reconnecting regardless of the reason.
+- **Waiting for a session forever.** While a reconnect is in flight the client
+  holds no session, so operations wait for one — bounded by 30 seconds, after
+  which they fail with `ErrNoSession`. Without that bound a tool call waits for
+  the caller's deadline instead, which with `WithToolTimeout(10*time.Minute)`
+  turns a reconnect into a ten-minute hang.
+
+```go
+client, err := mcp.NewClient(
+    "github-mcp",
+    transport,
+    mcp.WithSessionWaitTimeout(5*time.Second), // 0 waits for the caller's context
+)
+```
+
 ### Custom Logger
 
 Provide a custom logger for debugging:

--- a/tool/mcp/README.md
+++ b/tool/mcp/README.md
@@ -217,15 +217,26 @@ at 30 seconds, for as long as the client lives.
 Two failure modes are deliberately not retried, because retrying makes them
 worse:
 
-- **The server denies authorization.** A 401, 403 or 424 on the handshake
-  cannot be fixed by connecting again: the credential or the grant has to
-  change first. The client stops reconnecting, unregisters its tools from the
-  registry so a model is no longer offered calls that cannot succeed, and shuts
-  itself down. Operations then fail with `ErrAuthDenied`, and `Start` reports
-  the same error when the *initial* connect is denied. Detection reads the HTTP
-  status, so it applies to the transports built by `NewStreamableTransport` and
-  `NewSSETransport`; a stdio transport, or one built by your own
-  `TransportFactory`, keeps reconnecting regardless of the reason.
+- **The server denies one of the client's own requests.** A 401, 403 or 424 on
+  the handshake or on a capability listing (`tools/list` and friends) cannot be
+  fixed by connecting again: the credential or the grant has to change first.
+  The client stops reconnecting, unregisters its tools from the registry so a
+  model is no longer offered calls that cannot succeed, and shuts itself down.
+  Operations then fail with `ErrAuthDenied`, and `Start` reports the same error
+  when the *initial* connect is denied.
+
+  The distinction between the client's own requests and the rest matters
+  because one session can be shared by several callers, with the server
+  authorizing each call: a refused `tools/call` may be one caller's missing
+  permission and leaves the client alone, while a refused `tools/list` is about
+  the client itself. Without that rule a server that permits `initialize` and
+  refuses `tools/list` produces a churn instead of a spin — every reconnect
+  succeeds, every sync afterwards fails, and the backoff never engages.
+
+  Detection reads the HTTP status and the JSON-RPC method, so it applies to the
+  transports built by `NewStreamableTransport` and `NewSSETransport`; a stdio
+  transport, or one built by your own `TransportFactory`, keeps reconnecting
+  regardless of the reason.
 - **Waiting for a session forever.** While a reconnect is in flight the client
   holds no session, so operations wait for one — bounded by 30 seconds, after
   which they fail with `ErrNoSession`. Without that bound a tool call waits for

--- a/tool/mcp/client.go
+++ b/tool/mcp/client.go
@@ -196,6 +196,11 @@ type clientImpl struct {
 	// allowing waitForSession to wake up and check for a new session.
 	sessionChanged chan struct{}
 
+	// sessionTransport is the transport that built the current session. Its
+	// status probe is what tells a permanent rejection (401/403/424) from a
+	// transient disconnect once the handshake has already succeeded.
+	sessionTransport sdkmcp.Transport
+
 	// terminalErr is set when the client has given up on this server for good
 	// (an authorization denial, which reconnecting cannot fix). Operations
 	// return it immediately instead of waiting for a session that is not
@@ -463,7 +468,9 @@ func (c *clientImpl) isShutdown() bool {
 	}
 }
 
-// connect creates and connects the MCP client.
+// connect creates and connects the MCP client. The transport it built is
+// recorded as the session's, so a rejection that arrives after the handshake
+// can be classified from the status the server sent.
 func (c *clientImpl) connect(ctx context.Context) (*sdkmcp.ClientSession, *sdkmcp.Client, error) {
 	mcpClient := sdkmcp.NewClient(&sdkmcp.Implementation{
 		Name:    "redpanda-ai-agent-sdk",
@@ -483,6 +490,10 @@ func (c *clientImpl) connect(ctx context.Context) (*sdkmcp.ClientSession, *sdkmc
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create transport: %w", err)
 	}
+
+	c.mu.Lock()
+	c.sessionTransport = transport
+	c.mu.Unlock()
 
 	session, err := mcpClient.Connect(ctx, transport, nil)
 	if err != nil {
@@ -672,6 +683,15 @@ func (c *clientImpl) sessionManagerLoop() {
 
 		if waitErr != nil {
 			c.logger.Warn("MCP session closed with error", "serverID", c.serverID, "err", waitErr)
+
+			// A session that died because the server refused one of this
+			// client's own requests will die the same way after every
+			// reconnect. Give up instead of churning through sessions.
+			if denied := c.sessionDeniedErr(waitErr); denied != nil {
+				c.giveUp(denied)
+
+				return
+			}
 		} else {
 			c.logger.Info("MCP session closed", "serverID", c.serverID)
 		}
@@ -726,6 +746,13 @@ func (c *clientImpl) sessionManagerLoop() {
 			err := c.SyncTools(syncCtx)
 			if err != nil {
 				c.logger.Warn("sync after reconnect failed", "serverID", c.serverID, "err", err)
+
+				// The handshake is permitted and the listing is not: no
+				// further reconnect changes that.
+				//nolint:contextcheck // giveUp shuts down on its own goroutine with its own timeout, by design: see giveUp
+				if errors.Is(err, ErrAuthDenied) {
+					c.giveUp(err)
+				}
 			}
 		}()
 	}
@@ -749,6 +776,38 @@ func (c *clientImpl) giveUp(reason error) {
 				"serverID", c.serverID, "err", err)
 		}
 	}()
+}
+
+// sessionDeniedErr reports the error to give up with when the current
+// session's transport was rejected on authorization grounds for one of the
+// client's own requests -- the handshake, or a capability listing such as
+// tools/list. Returns nil otherwise, including for a rejection that may belong
+// to a single caller of a session several callers share.
+//
+// This is the post-handshake half of the same problem. A server may permit
+// initialize and refuse tools/list, at which point every reconnect succeeds
+// and every sync afterwards fails: the client churns through sessions at the
+// speed of the network, with the backoff never engaging, and never notices
+// that the answer will not change.
+func (c *clientImpl) sessionDeniedErr(cause error) error {
+	c.mu.RLock()
+	transport := c.sessionTransport
+	c.mu.RUnlock()
+
+	if transport == nil {
+		return nil
+	}
+
+	status := clientOwnedDenial(transport)
+	if status == 0 {
+		return nil
+	}
+
+	if cause == nil {
+		return fmt.Errorf("%w with HTTP %d", ErrAuthDenied, status)
+	}
+
+	return fmt.Errorf("%w with HTTP %d: %w", ErrAuthDenied, status, cause)
 }
 
 // terminal reports why the client has given up on the server, or nil while it

--- a/tool/mcp/client.go
+++ b/tool/mcp/client.go
@@ -39,6 +39,19 @@ var (
 
 	// ErrClosed indicates the client has been closed.
 	ErrClosed = errors.New("mcp client closed")
+
+	// ErrAuthDenied indicates the server rejected the connection on
+	// authorization grounds (401, 403 or 424). Reconnecting cannot fix it: the
+	// credential or grant it needs has to change first, and nothing the client
+	// does on its own changes it. A client denied after it was connected shuts
+	// itself down instead of reconnecting forever.
+	ErrAuthDenied = errors.New("mcp server denied authorization")
+
+	// ErrNoSession indicates no live session became available within
+	// sessionWaitTimeout because the client is reconnecting. Operations return
+	// it rather than waiting out the caller's deadline, which for a tool call
+	// can be minutes.
+	ErrNoSession = errors.New("mcp client has no live session")
 )
 
 const (
@@ -54,6 +67,15 @@ const (
 	// (xcontext.Detach in its streamable client), so cancelling after a
 	// successful connect does not kill the session.
 	reconnectAttemptTimeout = 30 * time.Second
+	// defaultSessionWaitTimeout bounds how long an operation waits for a live
+	// session while the client is reconnecting. The session manager clears the
+	// session before it reconnects, and the tools synced while the session was
+	// healthy stay registered, so the model keeps being offered them: without
+	// this bound a tool call blocks for the caller's whole deadline, which is
+	// the tool timeout (minutes, deliberately, for genuinely long calls). It
+	// matches reconnectAttemptTimeout so a call outlives one full handshake
+	// attempt and then fails with a usable error instead of hanging.
+	defaultSessionWaitTimeout = 30 * time.Second
 )
 
 // Client connects to an MCP server to discover and execute tools.
@@ -144,8 +166,11 @@ type clientImpl struct {
 	// reconnectTimeout bounds one reconnect handshake; defaults to
 	// reconnectAttemptTimeout (overridden only in tests).
 	reconnectTimeout time.Duration
-	logger           *slog.Logger
-	toolFilter       ToolFilterFunc
+	// sessionWaitTimeout bounds waiting for a live session; defaults to
+	// defaultSessionWaitTimeout, 0 waits for the caller's context instead.
+	sessionWaitTimeout time.Duration
+	logger             *slog.Logger
+	toolFilter         ToolFilterFunc
 
 	// MCP SDK components
 	mcpClient *sdkmcp.Client
@@ -170,6 +195,12 @@ type clientImpl struct {
 	// sessionChanged is closed and replaced whenever the session pointer is updated,
 	// allowing waitForSession to wake up and check for a new session.
 	sessionChanged chan struct{}
+
+	// terminalErr is set when the client has given up on this server for good
+	// (an authorization denial, which reconnecting cannot fix). Operations
+	// return it immediately instead of waiting for a session that is not
+	// coming back.
+	terminalErr atomic.Pointer[error]
 }
 
 // NewClient creates a new MCP client. The client must be started with Start()
@@ -196,14 +227,15 @@ func NewClient(serverID string, transportFactory TransportFactory, opts ...Clien
 	}
 
 	c := &clientImpl{
-		serverID:         serverID,
-		transportFactory: transportFactory,
-		reconnectTimeout: reconnectAttemptTimeout,
-		logger:           slog.Default(),
-		tools:            make(map[string]*toolWrapper),
-		notifyCh:         make(chan struct{}, 1),
-		sessionChanged:   make(chan struct{}),
-		done:             make(chan struct{}),
+		serverID:           serverID,
+		transportFactory:   transportFactory,
+		reconnectTimeout:   reconnectAttemptTimeout,
+		sessionWaitTimeout: defaultSessionWaitTimeout,
+		logger:             slog.Default(),
+		tools:              make(map[string]*toolWrapper),
+		notifyCh:           make(chan struct{}, 1),
+		sessionChanged:     make(chan struct{}),
+		done:               make(chan struct{}),
 	}
 	c.wgDone = sync.OnceValue(func() <-chan struct{} {
 		ch := make(chan struct{})
@@ -454,6 +486,15 @@ func (c *clientImpl) connect(ctx context.Context) (*sdkmcp.ClientSession, *sdkmc
 
 	session, err := mcpClient.Connect(ctx, transport, nil)
 	if err != nil {
+		// Classify from the status the server sent, not from the error text:
+		// the go-sdk renders a rejected handshake as
+		// `rejected by transport: sending "initialize": Forbidden`, which
+		// carries the status as prose only.
+		if status := authDenialStatus(transport); status != 0 {
+			return nil, nil, fmt.Errorf("failed to connect to MCP server: %w with HTTP %d: %w",
+				ErrAuthDenied, status, err)
+		}
+
 		return nil, nil, fmt.Errorf("failed to connect to MCP server: %w", err)
 	}
 
@@ -526,14 +567,33 @@ func (c *clientImpl) replaceSessionLocked(session *sdkmcp.ClientSession, client 
 	}
 }
 
-// waitForSession blocks until a live MCP session is available or the provided
-// context (or client) is cancelled. Returns ErrClosed if the client is shutting
-// down.
-func (c *clientImpl) waitForSession(ctx context.Context) (*sdkmcp.ClientSession, context.Context, error) {
+// waitForSession blocks until a live MCP session is available, the wait times
+// out, or the provided context (or client) is cancelled. Returns ErrClosed if
+// the client is shutting down, the terminal error if the client has given up on
+// the server, and ErrNoSession if sessionWaitTimeout elapses while a reconnect
+// is in progress.
+//
+// The bound matters because the session manager clears the session before it
+// reconnects while the tools stay registered: an unbounded wait turns a
+// reconnect into a hang lasting as long as the caller's deadline, and for a
+// tool call that deadline is the tool timeout.
+func (c *clientImpl) waitForSession(callerCtx context.Context) (*sdkmcp.ClientSession, context.Context, error) {
+	ctx := callerCtx
+
+	if c.sessionWaitTimeout > 0 {
+		var cancel context.CancelFunc
+
+		ctx, cancel = context.WithTimeout(callerCtx, c.sessionWaitTimeout)
+		defer cancel()
+	}
+
 	for {
-		ctxErr := ctx.Err()
-		if ctxErr != nil {
-			return nil, nil, ctxErr
+		if err := c.terminal(); err != nil {
+			return nil, nil, err
+		}
+
+		if ctx.Err() != nil {
+			return nil, nil, c.sessionWaitErr(callerCtx, ctx)
 		}
 
 		c.mu.RLock()
@@ -553,13 +613,31 @@ func (c *clientImpl) waitForSession(ctx context.Context) (*sdkmcp.ClientSession,
 
 		select {
 		case <-ctx.Done():
-			return nil, nil, ctx.Err()
+			return nil, nil, c.sessionWaitErr(callerCtx, ctx)
 		case <-bgCtx.Done():
+			// The client is shutting down. Report why if it gave up on the
+			// server, since that is the actionable reason.
+			if err := c.terminal(); err != nil {
+				return nil, nil, err
+			}
+
 			return nil, nil, ErrClosed
 		case <-ch:
 			// Session state changed; re-check.
 		}
 	}
+}
+
+// sessionWaitErr distinguishes the client's own bound on waiting for a session
+// from the caller giving up: only the former means "still reconnecting, and
+// this call cannot be served right now", which is what ErrNoSession says.
+func (c *clientImpl) sessionWaitErr(callerCtx, waitCtx context.Context) error {
+	if callerCtx.Err() == nil {
+		return fmt.Errorf("%w: none available after %s of reconnecting",
+			ErrNoSession, c.sessionWaitTimeout)
+	}
+
+	return waitCtx.Err()
 }
 
 // sessionManagerLoop monitors the active session and automatically reconnects when lost.
@@ -606,8 +684,20 @@ func (c *clientImpl) sessionManagerLoop() {
 		// Perform blocking reconnect with exponential backoff
 		newSession, newClient, err := c.performReconnect(bgCtx)
 		if err != nil {
+			if errors.Is(err, ErrAuthDenied) {
+				// Give up on this server rather than leaving a started client
+				// with no session and its tools still advertised. Shutting
+				// down unregisters those tools, so the model stops being
+				// offered calls that cannot succeed, and cancels bgCtx, so
+				// operations already waiting fail immediately.
+				c.giveUp(err)
+
+				return
+			}
+
 			// Context canceled during reconnect (client shutting down)
 			c.logger.Info("reconnect terminated", "serverID", c.serverID, "err", err)
+
 			return
 		}
 
@@ -641,7 +731,39 @@ func (c *clientImpl) sessionManagerLoop() {
 	}
 }
 
-// performReconnect attempts reconnection with exponential backoff until success or context cancellation.
+// giveUp records why the client is finished and shuts it down, so its tools
+// stop being advertised and waiting operations fail at once.
+//
+// The shutdown runs on its own goroutine because Shutdown waits for the
+// client's goroutines and the caller here is one of them: closing inline would
+// wait for itself. Callers must return immediately after.
+func (c *clientImpl) giveUp(reason error) {
+	c.terminalErr.CompareAndSwap(nil, &reason)
+
+	c.logger.Error("giving up on MCP server; unregistering its tools, calls will fail fast",
+		"serverID", c.serverID, "err", reason)
+
+	go func() {
+		if err := c.Close(); err != nil {
+			c.logger.Warn("shutting down a client that gave up failed",
+				"serverID", c.serverID, "err", err)
+		}
+	}()
+}
+
+// terminal reports why the client has given up on the server, or nil while it
+// is still expected to work.
+func (c *clientImpl) terminal() error {
+	if err := c.terminalErr.Load(); err != nil {
+		return *err
+	}
+
+	return nil
+}
+
+// performReconnect attempts reconnection with exponential backoff, stopping
+// early if the server denies authorization (ErrAuthDenied), which no number of
+// attempts can change.
 func (c *clientImpl) performReconnect(ctx context.Context) (*sdkmcp.ClientSession, *sdkmcp.Client, error) {
 	delay := reconnectInitialDelay
 	attempt := 0
@@ -668,6 +790,19 @@ func (c *clientImpl) performReconnect(ctx context.Context) (*sdkmcp.ClientSessio
 
 		if err == nil {
 			return session, mcpClient, nil
+		}
+
+		if errors.Is(err, ErrAuthDenied) {
+			// Retrying cannot mint the credential or the grant this needs, and
+			// the session manager clears the session before it reconnects, so
+			// looping here leaves the client unusable while it hammers the
+			// server: one denial otherwise produces another every
+			// reconnectMaxDelay until the process is restarted. Report it and
+			// let the caller give up on the server.
+			c.logger.Error("reconnect denied on authorization grounds; not retrying",
+				"serverID", c.serverID, "attempt", attempt, "err", err)
+
+			return nil, nil, err
 		}
 
 		c.logger.Warn("reconnect attempt failed", "serverID", c.serverID, "attempt", attempt, "err", err)
@@ -702,6 +837,12 @@ func (c *clientImpl) beginOp() (func(), error) {
 	// Fast checks without lock
 	if c.closing.Load() {
 		return nil, ErrClosed
+	}
+
+	// A client that gave up on its server reports why, rather than the bare
+	// ErrClosed its imminent shutdown would produce.
+	if err := c.terminal(); err != nil {
+		return nil, err
 	}
 
 	c.mu.RLock()

--- a/tool/mcp/client_options.go
+++ b/tool/mcp/client_options.go
@@ -88,6 +88,21 @@ func WithShutdownTimeout(timeout time.Duration) ClientOption {
 	}
 }
 
+// WithSessionWaitTimeout bounds how long an operation waits for a live session
+// while the client is reconnecting, before failing with ErrNoSession.
+// Defaults to 30 seconds. Setting 0 waits for the caller's context instead,
+// which for a tool call means the tool timeout: a reconnect then presents to
+// the caller as a hang rather than an error.
+//
+// Example:
+//
+//	client, err := NewClient(serverID, transport, WithSessionWaitTimeout(5*time.Second))
+func WithSessionWaitTimeout(timeout time.Duration) ClientOption {
+	return func(c *clientImpl) {
+		c.sessionWaitTimeout = timeout
+	}
+}
+
 // WithToolTimeout sets the execution timeout for all tools registered by this MCP client.
 // This overrides the default 30-second timeout from the tool registry.
 // Setting to 0 uses the tool registry's default timeout.

--- a/tool/mcp/reconnect_auth_test.go
+++ b/tool/mcp/reconnect_auth_test.go
@@ -15,10 +15,13 @@
 package mcp
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -273,10 +276,14 @@ func TestAuthStatusProbe(t *testing.T) {
 
 			probe := &authStatusProbe{}
 			for _, code := range tc.codes {
-				probe.observe(code)
+				probe.observe(code, "tools/list")
 			}
 
 			assert.Equal(t, tc.want, probe.denialStatus())
+
+			if tc.want != 0 {
+				assert.Equal(t, "tools/list", probe.denialMethod())
+			}
 		})
 	}
 }
@@ -309,10 +316,247 @@ func TestAuthDenialStatusFromTransport(t *testing.T) {
 		assert.Equal(t, http.StatusForbidden, authDenialStatus(transport))
 	})
 
+	t.Run("a denial is attributed to its method", func(t *testing.T) {
+		t.Parallel()
+
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusForbidden)
+		}))
+		t.Cleanup(srv.Close)
+
+		post := func(transport sdkmcp.Transport, body string) {
+			streamable, ok := transport.(*sdkmcp.StreamableClientTransport)
+			require.True(t, ok)
+
+			req, err := http.NewRequestWithContext(context.Background(), http.MethodPost,
+				srv.URL, strings.NewReader(body))
+			require.NoError(t, err)
+
+			resp, err := streamable.HTTPClient.Do(req)
+			require.NoError(t, err)
+			require.NoError(t, resp.Body.Close())
+		}
+
+		// A refused listing is the client's own access.
+		listing, err := NewStreamableTransport(srv.URL)()
+		require.NoError(t, err)
+
+		post(listing, `{"jsonrpc":"2.0","id":1,"method":"tools/list"}`)
+		assert.Equal(t, http.StatusForbidden, clientOwnedDenial(listing))
+
+		// A refused call may belong to one caller of a shared session.
+		call, err := NewStreamableTransport(srv.URL)()
+		require.NoError(t, err)
+
+		post(call, `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"x"}}`)
+		assert.Equal(t, http.StatusForbidden, authDenialStatus(call), "the denial is still recorded")
+		assert.Equal(t, 0, clientOwnedDenial(call), "but it is not the client's own")
+	})
+
 	t.Run("a transport that cannot observe status reports none", func(t *testing.T) {
 		t.Parallel()
 
 		assert.Equal(t, 0, authDenialStatus(&mockTransport{}),
 			"a caller's own transport keeps the retry-regardless behaviour")
 	})
+}
+
+// listDenyingMCPServer permits the handshake and refuses tools/list.
+type listDenyingMCPServer struct {
+	*httptest.Server
+
+	denyList   atomic.Bool
+	denyCode   int
+	handshakes atomic.Int64
+	listDenied atomic.Int64
+	callsOK    atomic.Int64
+}
+
+func newListDenyingMCPServer(t *testing.T, denyCode int) *listDenyingMCPServer {
+	t.Helper()
+
+	srv := &listDenyingMCPServer{denyCode: denyCode}
+
+	mcpServer := sdkmcp.NewServer(&sdkmcp.Implementation{
+		Name:    "list-deny-test-server",
+		Version: "1.0.0",
+	}, &sdkmcp.ServerOptions{HasTools: true})
+
+	mcpServer.AddTool(&sdkmcp.Tool{
+		Name:        "ping",
+		Description: "Answers pong",
+		InputSchema: map[string]any{"type": "object"},
+	}, func(context.Context, *sdkmcp.CallToolRequest) (*sdkmcp.CallToolResult, error) {
+		srv.callsOK.Add(1)
+
+		return &sdkmcp.CallToolResult{
+			Content: []sdkmcp.Content{&sdkmcp.TextContent{Text: "pong"}},
+		}, nil
+	})
+
+	handler := sdkmcp.NewStreamableHTTPHandler(
+		func(*http.Request) *sdkmcp.Server { return mcpServer },
+		&sdkmcp.StreamableHTTPOptions{},
+	)
+
+	srv.Server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		r.Body = io.NopCloser(bytes.NewReader(body))
+
+		switch {
+		case bytes.Contains(body, []byte(`"method":"initialize"`)):
+			srv.handshakes.Add(1)
+		case srv.denyList.Load() && bytes.Contains(body, []byte(`"method":"tools/list"`)):
+			srv.listDenied.Add(1)
+			w.WriteHeader(srv.denyCode)
+
+			return
+		}
+
+		handler.ServeHTTP(w, r)
+	}))
+	t.Cleanup(srv.Close)
+
+	return srv
+}
+
+// TestDeniedListingRetiresClient covers the manifestation that survives a fix
+// aimed only at the handshake: initialize is permitted, so every reconnect
+// succeeds, and it is tools/list that is refused.
+//
+// The result is a churn rather than a spin. The refused listing fails the
+// connection, the session manager reconnects successfully, the post-reconnect
+// sync is refused again, and round it goes with attempt=1 every time -- so the
+// backoff never engages and the loop is tighter than a backed-off one. A
+// client that may not list a server's tools cannot use that server, so the
+// rejection has to retire it.
+func TestDeniedListingRetiresClient(t *testing.T) {
+	t.Parallel()
+
+	for _, code := range []int{http.StatusFailedDependency, http.StatusForbidden} {
+		t.Run(http.StatusText(code), func(t *testing.T) {
+			t.Parallel()
+
+			ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+			defer cancel()
+
+			srv := newListDenyingMCPServer(t, code)
+			registry := newMockRegistry()
+
+			client, err := NewClient("denied-listing", NewStreamableTransport(srv.URL),
+				WithRegistry(registry),
+				WithAutoSync(100*time.Millisecond),
+			)
+			require.NoError(t, err)
+
+			t.Cleanup(func() { _ = client.Close() })
+
+			require.NoError(t, client.Start(ctx))
+			require.Equal(t, 1, registry.count())
+
+			srv.denyList.Store(true)
+
+			require.Eventually(t, func() bool { return registry.count() == 0 },
+				30*time.Second, 25*time.Millisecond,
+				"a client that may not list tools must unregister them, not churn through sessions")
+
+			handshakes, denials := srv.handshakes.Load(), srv.listDenied.Load()
+
+			time.Sleep(time.Second)
+
+			assert.LessOrEqual(t, srv.handshakes.Load(), handshakes+1,
+				"a retired client must stop reconnecting")
+			assert.LessOrEqual(t, srv.listDenied.Load(), denials+1,
+				"a retired client must stop asking for the tool list")
+
+			_, err = client.ExecuteTool(ctx, "denied-listing__ping", nil)
+			require.Error(t, err)
+			assert.True(t, errors.Is(err, ErrAuthDenied) || errors.Is(err, ErrClosed),
+				"want ErrAuthDenied or ErrClosed, got %v", err)
+		})
+	}
+}
+
+// TestDeniedToolCallDoesNotRetireClient is the counterpart, and the reason the
+// classification is method-aware: one session can be shared by several callers,
+// with the server authorizing each call. A refused tools/call may be one
+// caller's missing permission, which must not retire a client that works for
+// everyone else.
+func TestDeniedToolCallDoesNotRetireClient(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	var denyCalls atomic.Bool
+
+	mcpServer := sdkmcp.NewServer(&sdkmcp.Implementation{
+		Name:    "call-deny-test-server",
+		Version: "1.0.0",
+	}, &sdkmcp.ServerOptions{HasTools: true})
+
+	mcpServer.AddTool(&sdkmcp.Tool{
+		Name:        "ping",
+		Description: "Answers pong",
+		InputSchema: map[string]any{"type": "object"},
+	}, func(context.Context, *sdkmcp.CallToolRequest) (*sdkmcp.CallToolResult, error) {
+		return &sdkmcp.CallToolResult{
+			Content: []sdkmcp.Content{&sdkmcp.TextContent{Text: "pong"}},
+		}, nil
+	})
+
+	handler := sdkmcp.NewStreamableHTTPHandler(
+		func(*http.Request) *sdkmcp.Server { return mcpServer },
+		&sdkmcp.StreamableHTTPOptions{},
+	)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		r.Body = io.NopCloser(bytes.NewReader(body))
+
+		if denyCalls.Load() && bytes.Contains(body, []byte(`"method":"tools/call"`)) {
+			w.WriteHeader(http.StatusForbidden)
+
+			return
+		}
+
+		handler.ServeHTTP(w, r)
+	}))
+	t.Cleanup(ts.Close)
+
+	registry := newMockRegistry()
+
+	client, err := NewClient("denied-call", NewStreamableTransport(ts.URL),
+		WithRegistry(registry))
+	require.NoError(t, err)
+
+	t.Cleanup(func() { _ = client.Close() })
+
+	require.NoError(t, client.Start(ctx))
+	require.Equal(t, 1, registry.count())
+
+	denyCalls.Store(true)
+
+	_, err = client.ExecuteTool(ctx, "denied-call__ping", nil)
+	require.Error(t, err, "the refused call must fail")
+
+	// The client itself is not implicated: nothing says it may not use the
+	// server, only that this call was refused.
+	require.NotErrorIs(t, err, ErrAuthDenied,
+		"a refused tools/call must not be reported as the client being denied")
+
+	impl, ok := client.(*clientImpl)
+	require.True(t, ok)
+	require.NoError(t, impl.terminal(), "a refused tools/call must not retire the client")
+
+	denyCalls.Store(false)
+
+	// And the client recovers on its own: the session manager reconnects the
+	// connection that the refusal killed.
+	require.Eventually(t, func() bool {
+		_, err := client.ExecuteTool(ctx, "denied-call__ping", nil)
+
+		return err == nil
+	}, 30*time.Second, 100*time.Millisecond,
+		"the client must keep working once the refusal stops")
 }

--- a/tool/mcp/reconnect_auth_test.go
+++ b/tool/mcp/reconnect_auth_test.go
@@ -1,0 +1,318 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mcp
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// denyingMCPServer is a real MCP server over streamable HTTP that can be
+// flipped to deny every request, the way a gateway does once a policy stops
+// permitting the caller.
+type denyingMCPServer struct {
+	*httptest.Server
+
+	denying  atomic.Bool
+	denials  atomic.Int64
+	denyCode int
+}
+
+func newDenyingMCPServer(t *testing.T, denyCode int) *denyingMCPServer {
+	t.Helper()
+
+	srv := &denyingMCPServer{denyCode: denyCode}
+
+	mcpServer := sdkmcp.NewServer(&sdkmcp.Implementation{
+		Name:    "deny-test-server",
+		Version: "1.0.0",
+	}, &sdkmcp.ServerOptions{HasTools: true})
+
+	mcpServer.AddTool(&sdkmcp.Tool{
+		Name:        "ping",
+		Description: "Answers pong",
+		InputSchema: map[string]any{"type": "object"},
+	}, func(context.Context, *sdkmcp.CallToolRequest) (*sdkmcp.CallToolResult, error) {
+		return &sdkmcp.CallToolResult{
+			Content: []sdkmcp.Content{&sdkmcp.TextContent{Text: "pong"}},
+		}, nil
+	})
+
+	handler := sdkmcp.NewStreamableHTTPHandler(
+		func(*http.Request) *sdkmcp.Server { return mcpServer },
+		&sdkmcp.StreamableHTTPOptions{},
+	)
+
+	srv.Server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if srv.denying.Load() {
+			srv.denials.Add(1)
+			w.WriteHeader(srv.denyCode)
+
+			return
+		}
+
+		handler.ServeHTTP(w, r)
+	}))
+	t.Cleanup(srv.Close)
+
+	return srv
+}
+
+// deny starts refusing every request and severs the established session, so
+// the client notices the loss and reconnects into the denial.
+func (s *denyingMCPServer) deny() {
+	s.denying.Store(true)
+	s.CloseClientConnections()
+}
+
+// inMemoryTransport serves one connect attempt from an in-process MCP server,
+// for tests that only need a client that started successfully.
+func inMemoryTransport(ctx context.Context, t *testing.T) TransportFactory {
+	t.Helper()
+
+	server := newMockMCPServer()
+
+	t.Cleanup(func() { _ = server.stop() })
+
+	return func() (sdkmcp.Transport, error) {
+		return server.start(ctx)
+	}
+}
+
+// TestReconnectStopsWhenServerDeniesAuthorization is the regression test for a
+// client that spun on a permission error: the reconnect loop retried a 403
+// handshake like a network blip, at its 30 second cap, indefinitely, while the
+// session it had already cleared left every tool call waiting for the caller's
+// deadline.
+func TestReconnectStopsWhenServerDeniesAuthorization(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	srv := newDenyingMCPServer(t, http.StatusForbidden)
+	registry := newMockRegistry()
+
+	client, err := NewClient("denied-server", NewStreamableTransport(srv.URL),
+		WithRegistry(registry),
+		// A generous tool timeout is the realistic setting, and the point:
+		// without the fix a call waits it out instead of failing.
+		WithToolTimeout(10*time.Minute),
+	)
+	require.NoError(t, err)
+
+	t.Cleanup(func() { _ = client.Close() })
+
+	require.NoError(t, client.Start(ctx))
+	require.Equal(t, 1, registry.count(), "the healthy session must register its tools")
+
+	srv.deny()
+
+	// The client gives up: tools unregistered, so a model is no longer offered
+	// calls that cannot succeed.
+	require.Eventually(t, func() bool { return registry.count() == 0 },
+		30*time.Second, 25*time.Millisecond,
+		"a denied client must unregister its tools instead of advertising them while it reconnects")
+
+	// And it stops asking. Sample after it settles: the old behaviour kept
+	// producing one denial per reconnectMaxDelay forever.
+	settled := srv.denials.Load()
+
+	time.Sleep(time.Second)
+	assert.LessOrEqual(t, srv.denials.Load(), settled,
+		"a denied client must stop reconnecting")
+
+	// Calls fail immediately with a reason, not after the tool timeout.
+	start := time.Now()
+	_, err = client.ExecuteTool(ctx, "denied-server__ping", nil)
+	require.Error(t, err)
+	assert.Less(t, time.Since(start), 5*time.Second,
+		"a call on a denied client must fail fast, not wait out the tool timeout")
+	assert.True(t, errors.Is(err, ErrAuthDenied) || errors.Is(err, ErrClosed),
+		"want ErrAuthDenied or ErrClosed, got %v", err)
+}
+
+// TestStartReportsAuthDenial covers the same classification on the initial
+// connect, where it lets a caller tell "this server is unreachable, retry
+// later" from "this server will not let me in".
+func TestStartReportsAuthDenial(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	srv := newDenyingMCPServer(t, http.StatusForbidden)
+	srv.denying.Store(true)
+
+	client, err := NewClient("denied-at-start", NewStreamableTransport(srv.URL))
+	require.NoError(t, err)
+
+	t.Cleanup(func() { _ = client.Close() })
+
+	err = client.Start(ctx)
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrAuthDenied)
+	assert.Contains(t, err.Error(), "403")
+}
+
+// TestWaitForSessionIsBounded pins the second half of the hang: while the
+// session manager holds no session, an operation must fail with ErrNoSession
+// rather than block for the caller's whole deadline.
+func TestWaitForSessionIsBounded(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	client, err := NewClient("no-session", inMemoryTransport(ctx, t),
+		WithSessionWaitTimeout(200*time.Millisecond))
+	require.NoError(t, err)
+
+	impl, ok := client.(*clientImpl)
+	require.True(t, ok)
+
+	require.NoError(t, client.Start(ctx))
+
+	t.Cleanup(func() { _ = client.Close() })
+
+	// Stand in for a reconnect in progress: the session manager clears the
+	// session before it starts reconnecting.
+	impl.mu.Lock()
+	impl.replaceSessionLocked(nil, nil)
+	impl.mu.Unlock()
+
+	// The caller's deadline is long, as a tool call's is.
+	callCtx, cancelCall := context.WithTimeout(ctx, 10*time.Minute)
+	defer cancelCall()
+
+	start := time.Now()
+	_, _, err = impl.waitForSession(callCtx)
+	elapsed := time.Since(start)
+
+	require.ErrorIs(t, err, ErrNoSession)
+	assert.Less(t, elapsed, 5*time.Second, "the wait must be bounded by sessionWaitTimeout")
+	assert.NoError(t, callCtx.Err(), "the caller's context must be left usable")
+}
+
+// TestWaitForSessionUnboundedWhenDisabled keeps the escape hatch honest: with
+// the bound switched off the wait belongs to the caller's context again.
+func TestWaitForSessionUnboundedWhenDisabled(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	client, err := NewClient("no-session-unbounded", inMemoryTransport(ctx, t),
+		WithSessionWaitTimeout(0))
+	require.NoError(t, err)
+
+	impl, ok := client.(*clientImpl)
+	require.True(t, ok)
+
+	require.NoError(t, client.Start(ctx))
+
+	t.Cleanup(func() { _ = client.Close() })
+
+	impl.mu.Lock()
+	impl.replaceSessionLocked(nil, nil)
+	impl.mu.Unlock()
+
+	callCtx, cancelCall := context.WithTimeout(ctx, 200*time.Millisecond)
+	defer cancelCall()
+
+	_, _, err = impl.waitForSession(callCtx)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	assert.NotErrorIs(t, err, ErrNoSession)
+}
+
+func TestAuthStatusProbe(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		codes   []int
+		want    int
+		wantAny bool
+	}{
+		{name: "success", codes: []int{http.StatusOK}, want: 0},
+		{name: "server error is not a denial", codes: []int{http.StatusServiceUnavailable}, want: 0},
+		{name: "unauthorized", codes: []int{http.StatusUnauthorized}, want: http.StatusUnauthorized},
+		{name: "forbidden", codes: []int{http.StatusForbidden}, want: http.StatusForbidden},
+		{name: "failed dependency", codes: []int{http.StatusFailedDependency}, want: http.StatusFailedDependency},
+		{
+			name:  "first denial wins",
+			codes: []int{http.StatusOK, http.StatusForbidden, http.StatusUnauthorized},
+			want:  http.StatusForbidden,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			probe := &authStatusProbe{}
+			for _, code := range tc.codes {
+				probe.observe(code)
+			}
+
+			assert.Equal(t, tc.want, probe.denialStatus())
+		})
+	}
+}
+
+func TestAuthDenialStatusFromTransport(t *testing.T) {
+	t.Parallel()
+
+	t.Run("streamable transport reports the denial", func(t *testing.T) {
+		t.Parallel()
+
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusForbidden)
+		}))
+		t.Cleanup(srv.Close)
+
+		transport, err := NewStreamableTransport(srv.URL)()
+		require.NoError(t, err)
+		require.Equal(t, 0, authDenialStatus(transport), "nothing has been sent yet")
+
+		streamable, ok := transport.(*sdkmcp.StreamableClientTransport)
+		require.True(t, ok)
+
+		req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
+		require.NoError(t, err)
+
+		resp, err := streamable.HTTPClient.Do(req)
+		require.NoError(t, err)
+		require.NoError(t, resp.Body.Close())
+
+		assert.Equal(t, http.StatusForbidden, authDenialStatus(transport))
+	})
+
+	t.Run("a transport that cannot observe status reports none", func(t *testing.T) {
+		t.Parallel()
+
+		assert.Equal(t, 0, authDenialStatus(&mockTransport{}),
+			"a caller's own transport keeps the retry-regardless behaviour")
+	})
+}

--- a/tool/mcp/tools.go
+++ b/tool/mcp/tools.go
@@ -170,6 +170,13 @@ func (c *clientImpl) SyncTools(ctx context.Context) error {
 		// Fetch tools from server (network I/O, outside lock)
 		fetched, err := c.fetchTools(opCtx, session)
 		if err != nil {
+			// A listing the server refuses on authorization grounds is not a
+			// transient failure: report it as such so callers, and the session
+			// manager, stop treating it as one.
+			if denied := c.sessionDeniedErr(err); denied != nil {
+				return nil, denied
+			}
+
 			return nil, err
 		}
 
@@ -378,6 +385,16 @@ func (c *clientImpl) autoSyncLoop() {
 				c.logger.Warn("auto-sync failed",
 					"serverID", c.serverID,
 					"err", err)
+
+				// A refused listing will be refused again on the next tick,
+				// and its failure closes the session, so the client would
+				// otherwise churn: reconnect, sync, fail, repeat.
+				if errors.Is(err, ErrAuthDenied) {
+					cancel()
+					c.giveUp(err)
+
+					return
+				}
 			}
 
 			cancel()
@@ -400,6 +417,13 @@ func (c *clientImpl) autoSyncLoop() {
 				c.logger.Warn("sync after notification failed",
 					"serverID", c.serverID,
 					"err", err)
+
+				if errors.Is(err, ErrAuthDenied) {
+					cancel()
+					c.giveUp(err)
+
+					return
+				}
 			}
 
 			cancel()

--- a/tool/mcp/transport.go
+++ b/tool/mcp/transport.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sync/atomic"
 	"time"
 
 	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
@@ -150,6 +151,100 @@ func WithResourceIndicator(resource string) oauth2.AuthCodeOption {
 	return oauth2.SetAuthURLParam("resource", resource)
 }
 
+// authStatusProbe records whether an HTTP response rejected a request on
+// authorization grounds. It exists so the client can classify a failed connect
+// from the status the server actually sent, rather than by parsing the error
+// text: the go-sdk reports a rejected handshake as
+// "rejected by transport: sending \"initialize\": Forbidden", which carries the
+// status only as prose.
+//
+// One probe belongs to one transport, and the client builds a fresh transport
+// for every connect attempt, so a recorded denial always describes the attempt
+// that just failed.
+type authStatusProbe struct {
+	// status holds the first denial status seen, 0 if none.
+	status atomic.Int64
+}
+
+// observe records code if it denies the request in a way reconnecting cannot
+// fix: 401 (unauthenticated), 403 (authenticated but not permitted) and 424
+// (the gateway needs a user OAuth connection first).
+func (p *authStatusProbe) observe(code int) {
+	switch code {
+	case http.StatusUnauthorized, http.StatusForbidden, http.StatusFailedDependency:
+		p.status.CompareAndSwap(0, int64(code))
+	}
+}
+
+// denialStatus returns the recorded status, or 0 if no request was denied.
+func (p *authStatusProbe) denialStatus() int {
+	return int(p.status.Load())
+}
+
+// authProbeRoundTripper reports response status to a probe. It only observes:
+// the response and error pass through unchanged.
+type authProbeRoundTripper struct {
+	base  http.RoundTripper
+	probe *authStatusProbe
+}
+
+func (t *authProbeRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	resp, err := t.base.RoundTrip(req)
+	if err == nil && resp != nil {
+		t.probe.observe(resp.StatusCode)
+	}
+
+	return resp, err
+}
+
+// authDenialStatus reports the status with which the server denied a request on
+// this transport, or 0 if none did.
+//
+// It returns 0 for any transport that cannot observe HTTP status: a stdio
+// subprocess, or one built by a caller's own TransportFactory rather than by
+// NewStreamableTransport or NewSSETransport. Those clients keep the old
+// behaviour of reconnecting regardless of the reason.
+func authDenialStatus(transport sdkmcp.Transport) int {
+	var httpClient *http.Client
+
+	switch t := transport.(type) {
+	case *sdkmcp.StreamableClientTransport:
+		httpClient = t.HTTPClient
+	case *sdkmcp.SSEClientTransport:
+		httpClient = t.HTTPClient
+	}
+
+	if httpClient == nil {
+		return 0
+	}
+
+	// The probe is installed outermost by newProbedHTTPClient, so one
+	// assertion finds it without unwrapping whatever it wraps.
+	probed, ok := httpClient.Transport.(*authProbeRoundTripper)
+	if !ok {
+		return 0
+	}
+
+	return probed.probe.denialStatus()
+}
+
+// newProbedHTTPClient builds the transport's HTTP client with its responses
+// observed by an authStatusProbe, installed as the outermost round tripper so
+// authDenialStatus can find it again.
+func newProbedHTTPClient(opts []HTTPTransportOption) *http.Client {
+	client := newHTTPTransportClient(opts)
+
+	base := client.Transport
+	if base == nil {
+		base = http.DefaultTransport
+	}
+
+	probed := *client
+	probed.Transport = &authProbeRoundTripper{base: base, probe: &authStatusProbe{}}
+
+	return &probed
+}
+
 // headerRoundTripper wraps an http.RoundTripper to inject custom headers.
 type headerRoundTripper struct {
 	base    http.RoundTripper
@@ -217,7 +312,7 @@ func NewStreamableTransport(endpoint string, opts ...HTTPTransportOption) Transp
 	return func() (sdkmcp.Transport, error) {
 		return &sdkmcp.StreamableClientTransport{
 			Endpoint:   endpoint,
-			HTTPClient: newHTTPTransportClient(opts),
+			HTTPClient: newProbedHTTPClient(opts),
 		}, nil
 	}
 }
@@ -230,7 +325,7 @@ func NewSSETransport(endpoint string, opts ...HTTPTransportOption) TransportFact
 	return func() (sdkmcp.Transport, error) {
 		return &sdkmcp.SSEClientTransport{
 			Endpoint:   endpoint,
-			HTTPClient: newHTTPTransportClient(opts),
+			HTTPClient: newProbedHTTPClient(opts),
 		}, nil
 	}
 }

--- a/tool/mcp/transport.go
+++ b/tool/mcp/transport.go
@@ -15,8 +15,11 @@
 package mcp
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
 	"maps"
 	"net/http"
 	"os"
@@ -152,27 +155,36 @@ func WithResourceIndicator(resource string) oauth2.AuthCodeOption {
 }
 
 // authStatusProbe records whether an HTTP response rejected a request on
-// authorization grounds. It exists so the client can classify a failed connect
-// from the status the server actually sent, rather than by parsing the error
-// text: the go-sdk reports a rejected handshake as
-// "rejected by transport: sending \"initialize\": Forbidden", which carries the
-// status only as prose.
+// authorization grounds, and which JSON-RPC method was rejected. It exists so
+// the client can classify a rejection from the status the server actually sent,
+// rather than by parsing the error text: the go-sdk reports a rejected
+// handshake as `rejected by transport: sending "initialize": Forbidden`, which
+// carries the status only as prose.
 //
 // One probe belongs to one transport, and the client builds a fresh transport
-// for every connect attempt, so a recorded denial always describes the attempt
-// that just failed.
+// for every connect attempt, so a recorded denial always describes the session
+// (or the failed attempt) that transport served.
 type authStatusProbe struct {
 	// status holds the first denial status seen, 0 if none.
 	status atomic.Int64
+	// method holds the JSON-RPC method that first denial was for, empty when
+	// it could not be determined.
+	method atomic.Value // string
 }
 
 // observe records code if it denies the request in a way reconnecting cannot
 // fix: 401 (unauthenticated), 403 (authenticated but not permitted) and 424
-// (the gateway needs a user OAuth connection first).
-func (p *authStatusProbe) observe(code int) {
+// (the gateway needs a user OAuth connection first). method is the JSON-RPC
+// method of the denied request, empty if unknown.
+func (p *authStatusProbe) observe(code int, method string) {
 	switch code {
 	case http.StatusUnauthorized, http.StatusForbidden, http.StatusFailedDependency:
-		p.status.CompareAndSwap(0, int64(code))
+	default:
+		return
+	}
+
+	if p.status.CompareAndSwap(0, int64(code)) {
+		p.method.Store(method)
 	}
 }
 
@@ -181,20 +193,90 @@ func (p *authStatusProbe) denialStatus() int {
 	return int(p.status.Load())
 }
 
-// authProbeRoundTripper reports response status to a probe. It only observes:
-// the response and error pass through unchanged.
+// denialMethod returns the JSON-RPC method of the recorded denial, or "".
+func (p *authStatusProbe) denialMethod() string {
+	method, _ := p.method.Load().(string)
+
+	return method
+}
+
+// clientOwnedMethods are the requests a client makes for itself rather than for
+// whoever asked it to do something: the handshake and the capability listings.
+// A denial of one of these describes the client's own access, so it retires the
+// client. A denial of anything else -- tools/call above all -- may belong to one
+// caller of a session that several share, and must not.
+var clientOwnedMethods = map[string]bool{
+	"initialize":               true,
+	"tools/list":               true,
+	"prompts/list":             true,
+	"resources/list":           true,
+	"resources/templates/list": true,
+	"ping":                     true,
+}
+
+// authProbeRoundTripper reports response status to a probe, together with the
+// JSON-RPC method it was answering. It only observes: the response and error
+// pass through unchanged.
 type authProbeRoundTripper struct {
 	base  http.RoundTripper
 	probe *authStatusProbe
 }
 
 func (t *authProbeRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	// Read the method before the body is consumed by the send, and only when a
+	// denial could be recorded from it.
+	method, body, buffered := rpcMethod(req)
+	if buffered {
+		req = req.Clone(req.Context())
+		req.Body = io.NopCloser(bytes.NewReader(body))
+		req.ContentLength = int64(len(body))
+		req.GetBody = func() (io.ReadCloser, error) {
+			return io.NopCloser(bytes.NewReader(body)), nil
+		}
+	}
+
 	resp, err := t.base.RoundTrip(req)
 	if err == nil && resp != nil {
-		t.probe.observe(resp.StatusCode)
+		t.probe.observe(resp.StatusCode, method)
 	}
 
 	return resp, err
+}
+
+// maxBufferedRPCBody caps how much of a request body is read to recover its
+// JSON-RPC method. MCP messages are small; a larger body is left alone.
+const maxBufferedRPCBody = 1 << 20
+
+// rpcMethod reads the JSON-RPC method of an outgoing request, returning it
+// with the buffered body when it had to consume one, so the caller can replace
+// it, and whether it did.
+func rpcMethod(req *http.Request) (string, []byte, bool) {
+	if req.Method != http.MethodPost || req.Body == nil || req.Body == http.NoBody {
+		return "", nil, false
+	}
+
+	if req.ContentLength > maxBufferedRPCBody {
+		return "", nil, false
+	}
+
+	body, err := io.ReadAll(io.LimitReader(req.Body, maxBufferedRPCBody+1))
+	_ = req.Body.Close()
+
+	if err != nil || len(body) == 0 || len(body) > maxBufferedRPCBody {
+		// The body cannot be restored, so the request has to go out as it is;
+		// an empty reader is the honest representation of what is left.
+		return "", body, len(body) <= maxBufferedRPCBody
+	}
+
+	var msg struct {
+		Method string `json:"method"`
+	}
+
+	if err := json.Unmarshal(body, &msg); err != nil {
+		return "", body, true
+	}
+
+	return msg.Method, body, true
 }
 
 // authDenialStatus reports the status with which the server denied a request on
@@ -205,6 +287,35 @@ func (t *authProbeRoundTripper) RoundTrip(req *http.Request) (*http.Response, er
 // NewStreamableTransport or NewSSETransport. Those clients keep the old
 // behaviour of reconnecting regardless of the reason.
 func authDenialStatus(transport sdkmcp.Transport) int {
+	probe := transportProbe(transport)
+	if probe == nil {
+		return 0
+	}
+
+	return probe.denialStatus()
+}
+
+// clientOwnedDenial reports the status of a denial of one of the client's own
+// requests on this transport -- the handshake or a capability listing -- and 0
+// for no denial, an unknown method, or a denial that may belong to a single
+// caller of a shared session.
+func clientOwnedDenial(transport sdkmcp.Transport) int {
+	probe := transportProbe(transport)
+	if probe == nil {
+		return 0
+	}
+
+	status := probe.denialStatus()
+	if status == 0 || !clientOwnedMethods[probe.denialMethod()] {
+		return 0
+	}
+
+	return status
+}
+
+// transportProbe finds the status probe of a transport built here, or nil for
+// one that cannot observe HTTP status.
+func transportProbe(transport sdkmcp.Transport) *authStatusProbe {
 	var httpClient *http.Client
 
 	switch t := transport.(type) {
@@ -215,17 +326,17 @@ func authDenialStatus(transport sdkmcp.Transport) int {
 	}
 
 	if httpClient == nil {
-		return 0
+		return nil
 	}
 
 	// The probe is installed outermost by newProbedHTTPClient, so one
 	// assertion finds it without unwrapping whatever it wraps.
 	probed, ok := httpClient.Transport.(*authProbeRoundTripper)
 	if !ok {
-		return 0
+		return nil
 	}
 
-	return probed.probe.denialStatus()
+	return probed.probe
 }
 
 // newProbedHTTPClient builds the transport's HTTP client with its responses

--- a/tool/mcp/transport_test.go
+++ b/tool/mcp/transport_test.go
@@ -123,6 +123,21 @@ func TestNewSSETransport(t *testing.T) {
 	})
 }
 
+// headerRT returns the header-injecting round tripper of an HTTP transport,
+// unwrapping the auth-status probe that NewStreamableTransport and
+// NewSSETransport install outermost.
+func headerRT(t *testing.T, rt http.RoundTripper) *headerRoundTripper {
+	t.Helper()
+
+	probed, ok := rt.(*authProbeRoundTripper)
+	require.True(t, ok, "expected the auth-status probe outermost")
+
+	hrt, ok := probed.base.(*headerRoundTripper)
+	require.True(t, ok, "expected headerRoundTripper under the probe")
+
+	return hrt
+}
+
 func TestWithHTTPHeaders(t *testing.T) {
 	t.Parallel()
 
@@ -146,8 +161,7 @@ func TestWithHTTPHeaders(t *testing.T) {
 		// Test that headers are injected via RoundTripper
 		rt := streamable.HTTPClient.Transport
 		require.NotNil(t, rt)
-		hrt, ok := rt.(*headerRoundTripper)
-		require.True(t, ok, "transport should be wrapped with headerRoundTripper")
+		hrt := headerRT(t, rt)
 		assert.Equal(t, "test-key", hrt.headers["X-API-Key"])
 		assert.Equal(t, "custom", hrt.headers["X-Custom-Value"])
 	})
@@ -164,8 +178,7 @@ func TestWithHTTPHeaders(t *testing.T) {
 
 		streamable, ok := transport.(*sdkmcp.StreamableClientTransport)
 		require.True(t, ok, "expected StreamableClientTransport")
-		hrt, ok := streamable.HTTPClient.Transport.(*headerRoundTripper)
-		require.True(t, ok, "expected headerRoundTripper")
+		hrt := headerRT(t, streamable.HTTPClient.Transport)
 		assert.Equal(t, "value1", hrt.headers["X-Key-1"])
 		assert.Equal(t, "value2", hrt.headers["X-Key-2"])
 	})
@@ -186,8 +199,7 @@ func TestWithHTTPHeaders(t *testing.T) {
 		assert.Equal(t, 5*time.Second, streamable.HTTPClient.Timeout)
 
 		// Verify headers are wrapped
-		hrt, ok := streamable.HTTPClient.Transport.(*headerRoundTripper)
-		require.True(t, ok)
+		hrt := headerRT(t, streamable.HTTPClient.Transport)
 		assert.Equal(t, "test", hrt.headers["X-API-Key"])
 	})
 
@@ -202,8 +214,7 @@ func TestWithHTTPHeaders(t *testing.T) {
 
 		sse, ok := transport.(*sdkmcp.SSEClientTransport)
 		require.True(t, ok, "expected SSEClientTransport")
-		hrt, ok := sse.HTTPClient.Transport.(*headerRoundTripper)
-		require.True(t, ok, "expected headerRoundTripper")
+		hrt := headerRT(t, sse.HTTPClient.Transport)
 		assert.Equal(t, "Bearer token", hrt.headers["Authorization"])
 	})
 
@@ -219,8 +230,7 @@ func TestWithHTTPHeaders(t *testing.T) {
 
 		streamable, ok := transport.(*sdkmcp.StreamableClientTransport)
 		require.True(t, ok, "expected StreamableClientTransport")
-		hrt, ok := streamable.HTTPClient.Transport.(*headerRoundTripper)
-		require.True(t, ok, "expected headerRoundTripper")
+		hrt := headerRT(t, streamable.HTTPClient.Transport)
 		assert.Equal(t, "second", hrt.headers["X-Key"])
 	})
 }


### PR DESCRIPTION
## What

An MCP client no longer reconnects forever when the server refuses to let it
in, and an operation no longer waits indefinitely for a session that a
reconnect is trying to restore.

- A connect attempt rejected with 401, 403 or 424 fails with `ErrAuthDenied`.
  `performReconnect` returns that error instead of retrying, and the client
  gives up on the server: it unregisters its tools and shuts itself down.
  `Start` reports the same error when the initial connect is denied.
- Waiting for a live session is bounded by `WithSessionWaitTimeout` (30s by
  default, `0` restores the previous unbounded behaviour). Past the bound an
  operation fails with `ErrNoSession`.

## Why

Reconnection was unconditional: `performReconnect` looped "until success or
context cancellation" and classified nothing. An authorization denial is not a
transient condition — the credential or the grant has to change before another
attempt can succeed — so a denied client backed off to the 30 second cap and
stayed there for the life of the process, denial after denial, until it was
restarted.

The same loop turned that into a hang rather than a visible failure:

- the session manager clears the session *before* it reconnects, and blocks
  until it succeeds;
- nothing unregisters the tools synced while the session was healthy, so a
  model keeps being offered them;
- `ExecuteTool` begins with `waitForSession`, whose only bound was the caller's
  context — for a tool call, the tool timeout, which is deliberately minutes.

So a request that touched such a server did not fail, it stopped answering.
For a process that shares one client across all of its callers, that is
everyone's request, not just the caller whose permission was missing.

## The second shape: a refused capability listing

Classifying only the handshake leaves a churn rather than a spin. A server may
permit `initialize` and refuse `tools/list` — a gateway that gates listing
separately does exactly that — and then every reconnect succeeds and every sync
afterwards fails: `attempt=1` every time, so the backoff never engages.

A client that may not list a server's tools cannot use that server, so a
refused listing retires it too. The denial is caught wherever it surfaces: the
session's own failure in `sessionManagerLoop`, the sync that follows a
reconnect, and the auto-sync tick.

**The classification is method-aware, and has to be.** One session can be
shared by several callers with the server authorizing each call, so a refused
`tools/call` may be a single caller's missing permission; retiring the client on
that evidence would be worse than the bug. Only requests a client makes for
itself count — `initialize`, the capability listings, `ping` — so the probe
records which JSON-RPC method was denied, reading it from the outgoing body
before the send and restoring the body afterwards.

## Implementation details

- Classification reads the HTTP status the server sent, not the error text: the
  go-sdk renders a rejected handshake as
  `rejected by transport: sending "initialize": Forbidden`, which carries the
  status as prose only. `NewStreamableTransport` and `NewSSETransport` install
  an `authProbeRoundTripper` outermost in the transport's HTTP client, and
  `authDenialStatus` finds it again from the transport. A fresh transport is
  built per connect attempt, so a recorded denial always describes the attempt
  that just failed.
- A stdio transport, or one built by a caller's own `TransportFactory`, reports
  no status and keeps the previous retry-regardless behaviour.
- `giveUp` records the terminal error and shuts down on a separate goroutine:
  `Shutdown` waits for the client's goroutines and the caller is one of them,
  so closing inline would wait for itself.
- `beginOp` and `waitForSession` report the terminal error rather than the bare
  `ErrClosed` the imminent shutdown would produce, so callers see why.
- `ErrNoSession` is only returned for the client's own bound; if the caller's
  context expired, that error is returned unchanged.

## Compatibility

- New behaviour for HTTP transports: a 401/403/424 now ends the client instead
  of being retried. A server that answers those transiently and expects a
  retry is affected.
- New default bound on waiting for a session (30s), overridable with
  `WithSessionWaitTimeout`, including `0` for the old behaviour.
- `NewStreamableTransport` and `NewSSETransport` still return
  `*mcp.StreamableClientTransport` / `*mcp.SSEClientTransport`; only the HTTP
  client's round tripper chain gained a layer.

## Tests

- `TestReconnectStopsWhenServerDeniesAuthorization`: a real MCP server over
  streamable HTTP, flipped to deny every request mid-session; asserts the tools
  are unregistered, the reconnect attempts stop, and a call fails in
  milliseconds with a 10 minute tool timeout configured.
- `TestDeniedListingRetiresClient`: `initialize` permitted, `tools/list`
  refused (424 and 403); the client must unregister its tools and stop asking.
- `TestDeniedToolCallDoesNotRetireClient`: a refused `tools/call` must not
  retire the client, must not surface as `ErrAuthDenied`, and the client must
  recover once the refusal stops.
- `TestStartReportsAuthDenial`, `TestWaitForSessionIsBounded`,
  `TestWaitForSessionUnboundedWhenDisabled`, `TestAuthStatusProbe`,
  `TestAuthDenialStatusFromTransport`.
- `go test ./tool/... -race` passes; `golangci-lint --new-from-rev=origin/main`
  reports no new issues.
