### PR TITLE
feat(openai): add gpt-6 astra

### DIFF
--- a/catalog/facts_data.go
+++ b/catalog/facts_data.go
@@ -36,6 +36,7 @@ const (
 
 	// OpenAI models.
 
+	ModelGPT6Astra     ModelID = "openai/gpt-6-astra"
 	ModelGPT5          ModelID = "openai/gpt-5"
 	ModelGPT5Mini      ModelID = "openai/gpt-5-mini"
 	ModelGPT5Nano      ModelID = "openai/gpt-5-nano"
@@ -228,6 +229,13 @@ var defaultRegistry = Registry{
 		DisplayName: "GPT-5.5", Series: "gpt",
 		Released: MustDate("2026-04-23"), Knowledge: MustDate("2025-12-01"),
 		Description: "GPT-5.5 is OpenAI’s frontier model designed for complex professional workloads, building on GPT-5.4 with stronger reasoning, higher reliability, and improved token efficiency on hard tasks.",
+	},
+	// Announcement: https://openai.com/index/gpt-6-astra/
+	// Cutoff: https://developers.openai.com/api/docs/models/gpt-6-astra
+	ModelGPT6Astra: {
+		DisplayName: "GPT-6 Astra", Series: "gpt",
+		Released: MustDate("2026-09-03"), Knowledge: MustDate("2026-04-30"),
+		Description: "GPT-6 Astra is OpenAI's flagship model for complex reasoning, coding, and long-running professional work.",
 	},
 	ModelGPT5_6Sol: {
 		DisplayName: "GPT-5.6 Sol", Series: "gpt",

--- a/catalog/facts_data.go
+++ b/catalog/facts_data.go
@@ -245,14 +245,14 @@ var defaultRegistry = Registry{
 		Released: MustDate("2026-07-09"), Knowledge: MustDate("2026-02-16"),
 		Description: "GPT-5.6 Luna is a fast, cost-efficient model in OpenAI's GPT-5.6 series.",
 	},
-
 	// Announcement: https://openai.com/index/gpt-6-astra/
 	// Cutoff: https://developers.openai.com/api/docs/models/gpt-6-astra
 	ModelGPT6Astra: {
 		DisplayName: "GPT-6 Astra", Series: "gpt",
 		Released: MustDate("2026-09-03"), Knowledge: MustDate("2026-04-30"),
 		Description: "GPT-6 Astra is OpenAI's flagship model for complex reasoning, coding, and long-running professional work.",
-	}, ModelGPT4o: {
+	},
+	ModelGPT4o: {
 		DisplayName: "GPT-4o", Series: "gpt",
 		Released: MustDate("2024-05-13"), Knowledge: MustDate("2023-09-30"),
 		Description: "GPT-4o (\"o\" for \"omni\") is OpenAI's latest AI model, supporting both text and image inputs with text outputs.",

--- a/catalog/facts_data.go
+++ b/catalog/facts_data.go
@@ -36,7 +36,6 @@ const (
 
 	// OpenAI models.
 
-	ModelGPT6Astra     ModelID = "openai/gpt-6-astra"
 	ModelGPT5          ModelID = "openai/gpt-5"
 	ModelGPT5Mini      ModelID = "openai/gpt-5-mini"
 	ModelGPT5Nano      ModelID = "openai/gpt-5-nano"
@@ -52,6 +51,7 @@ const (
 	ModelGPT5_6Sol     ModelID = "openai/gpt-5.6-sol"
 	ModelGPT5_6Terra   ModelID = "openai/gpt-5.6-terra"
 	ModelGPT5_6Luna    ModelID = "openai/gpt-5.6-luna"
+	ModelGPT6Astra     ModelID = "openai/gpt-6-astra"
 	ModelGPT4o         ModelID = "openai/gpt-4o"
 	ModelGPT4oMini     ModelID = "openai/gpt-4o-mini"
 	ModelGPT4Turbo     ModelID = "openai/gpt-4-turbo"
@@ -168,7 +168,7 @@ var defaultRegistry = Registry{
 	// ---- OpenAI ----
 	//
 	// The flagship line runs gpt-3.5-turbo → gpt-4-turbo → gpt-4o →
-	// gpt-4.1 → gpt-5 → 5.1 → 5.2 → 5.4 → 5.5 → gpt-5.6-sol; the -mini
+	// gpt-4.1 → gpt-5 → 5.1 → 5.2 → 5.4 → 5.5 → gpt-5.6-sol → gpt-6-astra; the -mini
 	// ladder ends in terra, the -nano ladder in luna. The chat-tuned
 	// "instant" models and the pro models are their own lines.
 	ModelGPT5: {
@@ -230,13 +230,6 @@ var defaultRegistry = Registry{
 		Released: MustDate("2026-04-23"), Knowledge: MustDate("2025-12-01"),
 		Description: "GPT-5.5 is OpenAI’s frontier model designed for complex professional workloads, building on GPT-5.4 with stronger reasoning, higher reliability, and improved token efficiency on hard tasks.",
 	},
-	// Announcement: https://openai.com/index/gpt-6-astra/
-	// Cutoff: https://developers.openai.com/api/docs/models/gpt-6-astra
-	ModelGPT6Astra: {
-		DisplayName: "GPT-6 Astra", Series: "gpt",
-		Released: MustDate("2026-09-03"), Knowledge: MustDate("2026-04-30"),
-		Description: "GPT-6 Astra is OpenAI's flagship model for complex reasoning, coding, and long-running professional work.",
-	},
 	ModelGPT5_6Sol: {
 		DisplayName: "GPT-5.6 Sol", Series: "gpt",
 		Released: MustDate("2026-07-09"), Knowledge: MustDate("2026-02-16"),
@@ -252,7 +245,14 @@ var defaultRegistry = Registry{
 		Released: MustDate("2026-07-09"), Knowledge: MustDate("2026-02-16"),
 		Description: "GPT-5.6 Luna is a fast, cost-efficient model in OpenAI's GPT-5.6 series.",
 	},
-	ModelGPT4o: {
+
+	// Announcement: https://openai.com/index/gpt-6-astra/
+	// Cutoff: https://developers.openai.com/api/docs/models/gpt-6-astra
+	ModelGPT6Astra: {
+		DisplayName: "GPT-6 Astra", Series: "gpt",
+		Released: MustDate("2026-09-03"), Knowledge: MustDate("2026-04-30"),
+		Description: "GPT-6 Astra is OpenAI's flagship model for complex reasoning, coding, and long-running professional work.",
+	}, ModelGPT4o: {
 		DisplayName: "GPT-4o", Series: "gpt",
 		Released: MustDate("2024-05-13"), Knowledge: MustDate("2023-09-30"),
 		Description: "GPT-4o (\"o\" for \"omni\") is OpenAI's latest AI model, supporting both text and image inputs with text outputs.",

--- a/catalog/snapshot.json
+++ b/catalog/snapshot.json
@@ -339,6 +339,13 @@
       "released": "2026-07-09",
       "knowledge": "2026-02-16"
     },
+    "openai/gpt-6-astra": {
+      "display_name": "GPT-6 Astra",
+      "description": "GPT-6 Astra is OpenAI's flagship model for complex reasoning, coding, and long-running professional work.",
+      "series": "gpt",
+      "released": "2026-09-03",
+      "knowledge": "2026-04-30"
+    },
     "openai/o1-pro": {
       "display_name": "o1-pro",
       "description": "The o1 series of models are trained with reinforcement learning to think before they answer and perform complex reasoning.",
@@ -6868,7 +6875,8 @@
             "available": "2026-07-09"
           },
           "derived": {
-            "price_tier": "medium"
+            "price_tier": "medium",
+            "replacement": "openai/gpt-6-astra"
           }
         },
         {
@@ -6956,6 +6964,77 @@
           },
           "derived": {
             "price_tier": "medium"
+          }
+        },
+        {
+          "id": "gpt-6-astra",
+          "model": "openai/gpt-6-astra",
+          "display_name": "GPT-6 Astra",
+          "capabilities": {
+            "audio": false,
+            "json_mode": true,
+            "multi_turn": true,
+            "reasoning": true,
+            "streaming": true,
+            "structured_output": true,
+            "system_prompts": true,
+            "tools": true,
+            "vision": true
+          },
+          "constraints": {
+            "max_input_tokens": 1050000,
+            "max_output_tokens": 128000,
+            "supported_params": [
+              "max_tokens",
+              "reasoning_effort",
+              "reasoning_summary"
+            ]
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "reasoning": {
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          },
+          "pricing": {
+            "default": {
+              "base": {
+                "input_microcents_per_million": 1000000000,
+                "output_microcents_per_million": 5000000000,
+                "cached_input_microcents_per_million": 100000000,
+                "cache_creation_unknown_ttl_microcents_per_million": 1250000000
+              },
+              "brackets": [
+                {
+                  "min_context_tokens": 272001,
+                  "rates": {
+                    "input_microcents_per_million": 2000000000,
+                    "output_microcents_per_million": 7500000000,
+                    "cached_input_microcents_per_million": 200000000,
+                    "cache_creation_unknown_ttl_microcents_per_million": 2500000000
+                  }
+                }
+              ]
+            }
+          },
+          "lifecycle": {
+            "stage": "ga",
+            "available": "2026-09-03"
+          },
+          "derived": {
+            "price_tier": "high"
           }
         },
         {

--- a/providers/openai/astra_test.go
+++ b/providers/openai/astra_test.go
@@ -1,0 +1,87 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package openai
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/redpanda-data/ai-sdk-go/catalog"
+	"github.com/redpanda-data/ai-sdk-go/llm"
+	"github.com/redpanda-data/ai-sdk-go/pricing"
+)
+
+func TestGPT6AstraCatalog(t *testing.T) {
+	t.Parallel()
+
+	offering, ok := Catalog().Lookup("gpt-6-astra")
+	require.True(t, ok)
+	assert.Equal(t, catalog.ModelID("openai/gpt-6-astra"), offering.Model)
+	assert.Equal(t, "GPT-6 Astra", offering.DisplayName)
+	assert.Equal(t, 1_050_000, offering.Constraints.MaxInputTokens)
+	assert.Equal(t, 128_000, offering.Constraints.MaxOutputTokens)
+	assert.Equal(t, []llm.ReasoningEffort{ReasoningEffortLow, ReasoningEffortMedium, ReasoningEffortHigh, ReasoningEffortXHigh, ReasoningEffortMax}, offering.Reasoning.Efforts)
+	assert.Equal(t, []catalog.Modality{catalog.ModalityText, catalog.ModalityImage}, offering.Modalities.Input)
+	assert.Equal(t, []catalog.Modality{catalog.ModalityText}, offering.Modalities.Output)
+	assert.True(t, offering.Capabilities.Tools)
+	assert.True(t, offering.Capabilities.StructuredOutput)
+	assert.True(t, offering.Capabilities.Streaming)
+
+	provider, err := NewProvider("test-key")
+	require.NoError(t, err)
+
+	for _, effort := range offering.Reasoning.Efforts {
+		model, err := provider.NewModel("gpt-6-astra", WithReasoningEffort(effort))
+		require.NoError(t, err)
+		assert.Equal(t, "gpt-6-astra", model.Name())
+	}
+
+	for _, option := range []Option{WithReasoningEffort(ReasoningEffortNone), WithReasoningEffort(ReasoningEffortMinimal), WithTemperature(0.5), WithTopP(0.9)} {
+		_, err := provider.NewModel("gpt-6-astra", option)
+		require.Error(t, err)
+	}
+}
+
+func TestGPT6AstraPricing(t *testing.T) {
+	t.Parallel()
+
+	prices, err := pricing.NewCatalog(pricing.WithProvider("openai", Catalog().PricingByID()))
+	require.NoError(t, err)
+
+	usage := &llm.TokenUsage{InputTokens: 1_000_000, CachedInputTokens: 1_000_000, CacheCreationUnknownTTLTokens: 1_000_000, OutputTokens: 1_000_000}
+
+	for _, tt := range []struct {
+		name                         string
+		context                      int64
+		input, cached, write, output int64
+	}{
+		{"standard at threshold", 272_000, 1_000_000_000, 100_000_000, 1_250_000_000, 5_000_000_000},
+		{"long context above threshold", 272_001, 2_000_000_000, 200_000_000, 2_500_000_000, 7_500_000_000},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cost, err := prices.Calculate("gpt-6-astra", usage, pricing.CalcRequest{ContextTokens: tt.context})
+			require.NoError(t, err)
+			assert.Empty(t, cost.Unpriced)
+			assert.Equal(t, tt.input, cost.Breakdown[pricing.UsageFieldInput])
+			assert.Equal(t, tt.cached, cost.Breakdown[pricing.UsageFieldCachedInput])
+			assert.Equal(t, tt.write, cost.Breakdown[pricing.UsageFieldCacheCreationUnknownTTL])
+			assert.Equal(t, tt.output, cost.Breakdown[pricing.UsageFieldOutput])
+		})
+	}
+}

--- a/providers/openai/astra_test.go
+++ b/providers/openai/astra_test.go
@@ -28,7 +28,7 @@ import (
 func TestGPT6AstraCatalog(t *testing.T) {
 	t.Parallel()
 
-	offering, ok := Catalog().Lookup("gpt-6-astra")
+	offering, ok := Catalog().Lookup(ModelGPT6Astra)
 	require.True(t, ok)
 	assert.Equal(t, catalog.ModelID("openai/gpt-6-astra"), offering.Model)
 	assert.Equal(t, "GPT-6 Astra", offering.DisplayName)
@@ -45,13 +45,20 @@ func TestGPT6AstraCatalog(t *testing.T) {
 	require.NoError(t, err)
 
 	for _, effort := range offering.Reasoning.Efforts {
-		model, err := provider.NewModel("gpt-6-astra", WithReasoningEffort(effort))
+		model, err := provider.NewModel(ModelGPT6Astra, WithReasoningEffort(effort))
 		require.NoError(t, err)
-		assert.Equal(t, "gpt-6-astra", model.Name())
+		assert.Equal(t, ModelGPT6Astra, model.Name())
+		concrete, ok := model.(*Model)
+		require.True(t, ok)
+
+		request, err := concrete.requestMapper.ToProvider(&llm.Request{Messages: []llm.Message{{Role: llm.RoleUser, Content: []llm.Part{llm.NewTextPart("hello")}}}})
+		require.NoError(t, err)
+		assert.Equal(t, ModelGPT6Astra, request.Model)
+		assert.Equal(t, string(effort), string(request.Reasoning.Effort))
 	}
 
 	for _, option := range []Option{WithReasoningEffort(ReasoningEffortNone), WithReasoningEffort(ReasoningEffortMinimal), WithTemperature(0.5), WithTopP(0.9)} {
-		_, err := provider.NewModel("gpt-6-astra", option)
+		_, err := provider.NewModel(ModelGPT6Astra, option)
 		require.Error(t, err)
 	}
 }
@@ -75,7 +82,7 @@ func TestGPT6AstraPricing(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			cost, err := prices.Calculate("gpt-6-astra", usage, pricing.CalcRequest{ContextTokens: tt.context})
+			cost, err := prices.Calculate(ModelGPT6Astra, usage, pricing.CalcRequest{ContextTokens: tt.context})
 			require.NoError(t, err)
 			assert.Empty(t, cost.Unpriced)
 			assert.Equal(t, tt.input, cost.Breakdown[pricing.UsageFieldInput])

--- a/providers/openai/constants.go
+++ b/providers/openai/constants.go
@@ -63,6 +63,9 @@ const (
 	// stays priceable.
 	ModelGPT5_3ChatLatest = shared.ChatModelGPT5_3ChatLatest
 
+	// ModelGPT6Astra is OpenAI's GPT-6 flagship reasoning model.
+	ModelGPT6Astra = "gpt-6-astra"
+
 	// ModelGPT5_6Luna is the cost-optimized GPT-5.6 model.
 	ModelGPT5_6Luna = shared.ChatModelGPT5_6Luna
 	// ModelGPT5_6Terra balances capability and cost in the GPT-5.6 family.

--- a/providers/openai/constants.go
+++ b/providers/openai/constants.go
@@ -64,6 +64,7 @@ const (
 	ModelGPT5_3ChatLatest = shared.ChatModelGPT5_3ChatLatest
 
 	// ModelGPT6Astra is OpenAI's GPT-6 flagship reasoning model.
+	// Raw string until the OpenAI SDK adds the constant.
 	ModelGPT6Astra = "gpt-6-astra"
 
 	// ModelGPT5_6Luna is the cost-optimized GPT-5.6 model.

--- a/providers/openai/models.go
+++ b/providers/openai/models.go
@@ -311,6 +311,27 @@ func entries() []catalog.Entry {
 			Pricing: pricing.FlatInfo(1.75, 14.00, 0.175),
 		},
 
+		// https://developers.openai.com/api/docs/models/gpt-6-astra
+		// Parameter restrictions: /api/docs/guides/latest-model
+		{
+			ID:           ModelGPT6Astra,
+			Model:        catalog.ModelGPT6Astra,
+			Capabilities: llm.ModelCapabilities{Streaming: true, Tools: true, JSONMode: true, StructuredOutput: true, Vision: true, MultiTurn: true, SystemPrompts: true, Reasoning: true},
+			Modalities:   textImage,
+			Constraints: llm.ModelConstraints{
+				MaxInputTokens:  1_050_000,
+				MaxOutputTokens: 128_000,
+				SupportedParams: []string{"max_tokens", "reasoning_effort", "reasoning_summary"},
+			},
+			Reasoning: catalog.ReasoningSupport{Efforts: []ReasoningEffort{ReasoningEffortLow, ReasoningEffortMedium, ReasoningEffortHigh, ReasoningEffortXHigh, ReasoningEffortMax}},
+			Life:      catalog.Lifecycle{Available: catalog.MustDate("2026-09-03")},
+			// Standard processing; above 272K, the full request uses long-context rates.
+			Pricing: pricing.TieredInfo(
+				pricing.NewRates(10, 50, 1).WithCacheCreation(0, 0, 12.50),
+				pricing.Bracket{MinContextTokens: 272_001, Rates: pricing.NewRates(20, 75, 2).WithCacheCreation(0, 0, 25)},
+			),
+		},
+
 		// GPT-5.6 Series
 		gpt56Entry(ModelGPT5_6Luna, catalog.ModelGPT5_6Luna, nil,
 			// Per M tokens: $0.20 input, $1.20 output, $0.02 cached input, $0.25 cache write.


### PR DESCRIPTION
## Summary
- Register `openai.ModelGPT6Astra` / `catalog.ModelGPT6Astra` with official limits, modalities, release date and cutoff.
- Accept low/medium/high/xhigh/max reasoning; reject none/minimal and unsupported temperature/top-p through existing validation.
- Encode Standard input/output/cache-read/cache-write pricing on both sides of the 272K threshold.
- Regenerate catalog snapshot; GPT-5.6 Sol's derived successor becomes Astra without changing its authored entry.

## Sources
- https://developers.openai.com/api/docs/models/gpt-6-astra
- https://developers.openai.com/api/docs/guides/latest-model
- https://openai.com/index/safety-overview-gpt-6-astra/

## Scope
OpenAI Responses provider registration only. No dependency changes, Bedrock offering, new async/steering APIs, or Fast/Batch/Flex pricing modes. Vendor access is subject to rollout.

## Verification
- RED: new catalog/pricing tests failed for missing Astra registration.
- PASS: `go test -short ./providers/openai ./catalog/... ./pricing/...`.
- PASS: `task catalog:check`, `task license:check`, `git diff --check`.
- PASS: golangci-lint with `--new-from-rev=origin/main`: 0 new issues.
- Full `task lint`: 35 existing issues outside this change.
- Full `task test:unit`: Docker-backed schema-registry tests fail because Docker is unavailable; focused packages pass.
- Go repository; Bun lint/type-check commands do not apply.

## Dogfood evidence
- PASS: standalone consumer calls the public provider/catalog/pricing APIs; creates Astra at max effort, rejects none/temperature/top-p, and calculates both pricing brackets.
- Limits: no live inference or 1M-context probe; no OpenAI API key configured. No transport code changed.
