### PR TITLE
feat(vertex): add the Google Vertex AI model catalog

### DIFF
--- a/catalog/snapshot.json
+++ b/catalog/snapshot.json
@@ -4595,6 +4595,253 @@
       ]
     },
     {
+      "provider": "gcp.vertex",
+      "offerings": [
+        {
+          "id": "vertex.claude-haiku-4-5",
+          "model": "anthropic/claude-haiku-4-5",
+          "display_name": "Claude Haiku 4.5",
+          "capabilities": {
+            "audio": false,
+            "json_mode": false,
+            "multi_turn": true,
+            "reasoning": true,
+            "streaming": true,
+            "structured_output": true,
+            "system_prompts": true,
+            "tools": true,
+            "vision": true
+          },
+          "constraints": {
+            "max_input_tokens": 200000,
+            "max_output_tokens": 64000,
+            "supported_params": [
+              "temperature",
+              "top_p",
+              "top_k",
+              "max_tokens"
+            ],
+            "temperature_range": [
+              0,
+              1
+            ]
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image",
+              "document"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "reasoning": {},
+          "pricing": {
+            "default": {
+              "base": {
+                "input_microcents_per_million": 100000000,
+                "output_microcents_per_million": 500000000,
+                "cached_input_microcents_per_million": 10000000,
+                "cache_creation_5m_microcents_per_million": 125000000,
+                "cache_creation_1h_microcents_per_million": 200000000
+              }
+            }
+          },
+          "lifecycle": {
+            "stage": "ga",
+            "available": "2025-10-15"
+          },
+          "attributes": [
+            {
+              "key": "publisher",
+              "value": "anthropic"
+            },
+            {
+              "key": "vertex_model",
+              "value": "claude-haiku-4-5"
+            }
+          ],
+          "derived": {
+            "price_tier": "low"
+          }
+        },
+        {
+          "id": "vertex.claude-sonnet-5",
+          "model": "anthropic/claude-sonnet-5",
+          "display_name": "Claude Sonnet 5",
+          "capabilities": {
+            "audio": false,
+            "json_mode": false,
+            "multi_turn": true,
+            "reasoning": true,
+            "streaming": true,
+            "structured_output": true,
+            "system_prompts": true,
+            "tools": true,
+            "vision": true
+          },
+          "constraints": {
+            "max_input_tokens": 1000000,
+            "max_output_tokens": 128000,
+            "supported_params": [
+              "temperature",
+              "top_p",
+              "top_k",
+              "max_tokens",
+              "reasoning_effort"
+            ],
+            "temperature_range": [
+              0,
+              1
+            ]
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image",
+              "document"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "reasoning": {
+            "efforts": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ],
+            "adaptive": true
+          },
+          "pricing": {
+            "default": {
+              "base": {
+                "input_microcents_per_million": 200000000,
+                "output_microcents_per_million": 1000000000,
+                "cached_input_microcents_per_million": 20000000,
+                "cache_creation_5m_microcents_per_million": 250000000,
+                "cache_creation_1h_microcents_per_million": 400000000
+              }
+            }
+          },
+          "lifecycle": {
+            "stage": "ga",
+            "available": "2026-06-29"
+          },
+          "attributes": [
+            {
+              "key": "publisher",
+              "value": "anthropic"
+            },
+            {
+              "key": "vertex_model",
+              "value": "claude-sonnet-5"
+            }
+          ],
+          "derived": {
+            "price_tier": "medium"
+          }
+        },
+        {
+          "id": "vertex.gemini-3.6-flash",
+          "model": "google/gemini-3.6-flash",
+          "display_name": "Gemini 3.6 Flash",
+          "capabilities": {
+            "audio": true,
+            "json_mode": true,
+            "multi_turn": true,
+            "reasoning": true,
+            "streaming": true,
+            "structured_output": true,
+            "system_prompts": true,
+            "tools": true,
+            "vision": true
+          },
+          "constraints": {
+            "max_input_tokens": 1048576,
+            "max_output_tokens": 65536,
+            "supported_params": [
+              "temperature",
+              "top_p",
+              "top_k",
+              "max_tokens",
+              "stop",
+              "presence_penalty",
+              "frequency_penalty"
+            ],
+            "temperature_range": [
+              0,
+              2
+            ]
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image",
+              "audio",
+              "video",
+              "document"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "reasoning": {},
+          "pricing": {
+            "default": {
+              "base": {
+                "input_microcents_per_million": 150000000,
+                "output_microcents_per_million": 750000000,
+                "cached_input_microcents_per_million": 15000000
+              }
+            },
+            "overrides": [
+              {
+                "region": "us",
+                "rate_card": {
+                  "base": {
+                    "input_microcents_per_million": 165000000,
+                    "output_microcents_per_million": 825000000,
+                    "cached_input_microcents_per_million": 16500000
+                  }
+                }
+              },
+              {
+                "region": "eu",
+                "rate_card": {
+                  "base": {
+                    "input_microcents_per_million": 165000000,
+                    "output_microcents_per_million": 825000000,
+                    "cached_input_microcents_per_million": 16500000
+                  }
+                }
+              }
+            ]
+          },
+          "lifecycle": {
+            "stage": "ga",
+            "available": "2026-07-21"
+          },
+          "attributes": [
+            {
+              "key": "publisher",
+              "value": "google"
+            },
+            {
+              "key": "vertex_model",
+              "value": "gemini-3.6-flash"
+            }
+          ],
+          "derived": {
+            "price_tier": "medium"
+          }
+        }
+      ]
+    },
+    {
       "provider": "google",
       "offerings": [
         {

--- a/catalog/snapshot.json
+++ b/catalog/snapshot.json
@@ -4845,9 +4845,9 @@
           "pricing": {
             "default": {
               "base": {
-                "input_microcents_per_million": 150000000,
-                "output_microcents_per_million": 750000000,
-                "cached_input_microcents_per_million": 15000000
+                "input_microcents_per_million": 75000000,
+                "output_microcents_per_million": 375000000,
+                "cached_input_microcents_per_million": 7500000
               }
             },
             "overrides": [
@@ -4855,9 +4855,9 @@
                 "region": "us",
                 "rate_card": {
                   "base": {
-                    "input_microcents_per_million": 165000000,
-                    "output_microcents_per_million": 825000000,
-                    "cached_input_microcents_per_million": 16500000
+                    "input_microcents_per_million": 82500000,
+                    "output_microcents_per_million": 412500000,
+                    "cached_input_microcents_per_million": 8250000
                   }
                 }
               },
@@ -4865,9 +4865,9 @@
                 "region": "eu",
                 "rate_card": {
                   "base": {
-                    "input_microcents_per_million": 165000000,
-                    "output_microcents_per_million": 825000000,
-                    "cached_input_microcents_per_million": 16500000
+                    "input_microcents_per_million": 82500000,
+                    "output_microcents_per_million": 412500000,
+                    "cached_input_microcents_per_million": 8250000
                   }
                 }
               }
@@ -4888,7 +4888,7 @@
             }
           ],
           "derived": {
-            "price_tier": "medium"
+            "price_tier": "low"
           }
         }
       ]

--- a/catalog/snapshot.json
+++ b/catalog/snapshot.json
@@ -4646,7 +4646,33 @@
                 "cache_creation_5m_microcents_per_million": 125000000,
                 "cache_creation_1h_microcents_per_million": 200000000
               }
-            }
+            },
+            "overrides": [
+              {
+                "region": "us-east5",
+                "rate_card": {
+                  "base": {
+                    "input_microcents_per_million": 110000000,
+                    "output_microcents_per_million": 550000000,
+                    "cached_input_microcents_per_million": 11000000,
+                    "cache_creation_5m_microcents_per_million": 137500000,
+                    "cache_creation_1h_microcents_per_million": 220000000
+                  }
+                }
+              },
+              {
+                "region": "europe-west1",
+                "rate_card": {
+                  "base": {
+                    "input_microcents_per_million": 110000000,
+                    "output_microcents_per_million": 550000000,
+                    "cached_input_microcents_per_million": 11000000,
+                    "cache_creation_5m_microcents_per_million": 137500000,
+                    "cache_creation_1h_microcents_per_million": 220000000
+                  }
+                }
+              }
+            ]
           },
           "lifecycle": {
             "stage": "ga",
@@ -4725,7 +4751,33 @@
                 "cache_creation_5m_microcents_per_million": 250000000,
                 "cache_creation_1h_microcents_per_million": 400000000
               }
-            }
+            },
+            "overrides": [
+              {
+                "region": "us",
+                "rate_card": {
+                  "base": {
+                    "input_microcents_per_million": 220000000,
+                    "output_microcents_per_million": 1100000000,
+                    "cached_input_microcents_per_million": 22000000,
+                    "cache_creation_5m_microcents_per_million": 275000000,
+                    "cache_creation_1h_microcents_per_million": 440000000
+                  }
+                }
+              },
+              {
+                "region": "eu",
+                "rate_card": {
+                  "base": {
+                    "input_microcents_per_million": 220000000,
+                    "output_microcents_per_million": 1100000000,
+                    "cached_input_microcents_per_million": 22000000,
+                    "cache_creation_5m_microcents_per_million": 275000000,
+                    "cache_creation_1h_microcents_per_million": 440000000
+                  }
+                }
+              }
+            ]
           },
           "lifecycle": {
             "stage": "ga",

--- a/catalog/snapshot.json
+++ b/catalog/snapshot.json
@@ -4671,6 +4671,18 @@
                     "cache_creation_1h_microcents_per_million": 220000000
                   }
                 }
+              },
+              {
+                "region": "asia-east1",
+                "rate_card": {
+                  "base": {
+                    "input_microcents_per_million": 110000000,
+                    "output_microcents_per_million": 550000000,
+                    "cached_input_microcents_per_million": 11000000,
+                    "cache_creation_5m_microcents_per_million": 137500000,
+                    "cache_creation_1h_microcents_per_million": 220000000
+                  }
+                }
               }
             ]
           },
@@ -4767,6 +4779,18 @@
               },
               {
                 "region": "eu",
+                "rate_card": {
+                  "base": {
+                    "input_microcents_per_million": 220000000,
+                    "output_microcents_per_million": 1100000000,
+                    "cached_input_microcents_per_million": 22000000,
+                    "cache_creation_5m_microcents_per_million": 275000000,
+                    "cache_creation_1h_microcents_per_million": 440000000
+                  }
+                }
+              },
+              {
+                "region": "asia-southeast1",
                 "rate_card": {
                   "base": {
                     "input_microcents_per_million": 220000000,

--- a/cmd/catalog-snapshot/lifecycle_test.go
+++ b/cmd/catalog-snapshot/lifecycle_test.go
@@ -25,14 +25,15 @@ import (
 	"github.com/redpanda-data/ai-sdk-go/providers/bedrock"
 	"github.com/redpanda-data/ai-sdk-go/providers/google"
 	"github.com/redpanda-data/ai-sdk-go/providers/openai"
+	"github.com/redpanda-data/ai-sdk-go/providers/vertex"
 )
 
 // allCatalogs is every provider catalog the snapshot covers. This is the
-// only package that may import all four (catalog's architecture test
+// only package that may import them all (catalog's architecture test
 // forbids it there), so cross-provider invariants live here.
 func allCatalogs() []*catalog.Catalog {
 	return []*catalog.Catalog{
-		anthropic.Catalog(), bedrock.Catalog(), google.Catalog(), openai.Catalog(),
+		anthropic.Catalog(), bedrock.Catalog(), google.Catalog(), openai.Catalog(), vertex.Catalog(),
 	}
 }
 
@@ -42,7 +43,7 @@ func allCatalogs() []*catalog.Catalog {
 // target.
 //
 // If a vendor's recommended replacement is genuinely not an offering we
-// carry, CLAUDE.md says to skip ReplacedBy — add the ID here with a comment
+// carry, CLAUDE.md says to skip ReplacedBy - add the ID here with a comment
 // naming the uncarried replacement rather than deleting the assertion.
 func TestDeprecatedOfferingsNameAReplacement(t *testing.T) {
 	t.Parallel()

--- a/cmd/catalog-snapshot/lifecycle_test.go
+++ b/cmd/catalog-snapshot/lifecycle_test.go
@@ -19,8 +19,10 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/redpanda-data/ai-sdk-go/catalog"
+	"github.com/redpanda-data/ai-sdk-go/pricing"
 	"github.com/redpanda-data/ai-sdk-go/providers/anthropic"
 	"github.com/redpanda-data/ai-sdk-go/providers/bedrock"
 	"github.com/redpanda-data/ai-sdk-go/providers/google"
@@ -34,6 +36,34 @@ import (
 func allCatalogs() []*catalog.Catalog {
 	return []*catalog.Catalog{
 		anthropic.Catalog(), bedrock.Catalog(), google.Catalog(), openai.Catalog(), vertex.Catalog(),
+	}
+}
+
+// TestVertexPricingDoesNotCollide is the namespacing guard. Vertex model
+// names are byte-identical to the Gemini-API and Anthropic-direct
+// providers', so a merged pricing catalog would reject the shared bare IDs.
+// Vertex keys every offering vertex.<model> to keep them distinct.
+//
+// It pairs Vertex against each other provider in turn (rather than merging
+// all five at once) so the check isolates Vertex: a pre-existing collision
+// between two other providers, which production never merges, cannot fail
+// this test. pricing.NewCatalog returns a duplicate-pricing error on any
+// shared key, so a NoError result proves the prefix does its job.
+func TestVertexPricingDoesNotCollide(t *testing.T) {
+	t.Parallel()
+
+	vertexPricing := vertex.Catalog().PricingByID()
+
+	others := []*catalog.Catalog{
+		anthropic.Catalog(), bedrock.Catalog(), google.Catalog(), openai.Catalog(),
+	}
+
+	for _, other := range others {
+		_, err := pricing.NewCatalog(
+			pricing.WithProvider(other.Provider(), other.PricingByID()),
+			pricing.WithProvider(vertex.Catalog().Provider(), vertexPricing),
+		)
+		require.NoErrorf(t, err, "vertex pricing collides with %s", other.Provider())
 	}
 }
 

--- a/cmd/catalog-snapshot/main.go
+++ b/cmd/catalog-snapshot/main.go
@@ -15,9 +15,9 @@
 // Command catalog-snapshot renders every provider's model catalog into the
 // committed snapshot artifact (catalog/snapshot.json).
 //
-// The snapshot is the review surface for catalog changes — every authored
+// The snapshot is the review surface for catalog changes - every authored
 // edit and its time-independent derivations (price tier, replacement)
-// show up as a plain JSON diff — and the read format for non-Go consumers
+// show up as a plain JSON diff - and the read format for non-Go consumers
 // such as the AI Gateway console. TestCommittedSnapshotIsFresh fails the
 // unit-test job when the committed artifact is stale; -check does the same
 // from the command line.
@@ -37,6 +37,7 @@ import (
 	"github.com/redpanda-data/ai-sdk-go/providers/bedrock"
 	"github.com/redpanda-data/ai-sdk-go/providers/google"
 	"github.com/redpanda-data/ai-sdk-go/providers/openai"
+	"github.com/redpanda-data/ai-sdk-go/providers/vertex"
 )
 
 func main() {
@@ -52,6 +53,7 @@ func main() {
 		bedrock.Catalog(),
 		google.Catalog(),
 		openai.Catalog(),
+		vertex.Catalog(),
 	)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "catalog-snapshot:", err)
@@ -66,7 +68,7 @@ func main() {
 		}
 
 		if !bytes.Equal(existing, buf.Bytes()) {
-			fmt.Fprintf(os.Stderr, "catalog-snapshot: %s is stale — run `task catalog:snapshot` and commit the result\n", *out)
+			fmt.Fprintf(os.Stderr, "catalog-snapshot: %s is stale - run `task catalog:snapshot` and commit the result\n", *out)
 			os.Exit(1)
 		}
 

--- a/cmd/catalog-snapshot/snapshot_test.go
+++ b/cmd/catalog-snapshot/snapshot_test.go
@@ -27,7 +27,7 @@ import (
 
 // TestCommittedSnapshotIsFresh fails when catalog/snapshot.json no longer
 // matches the authored catalogs. Living in the unit-test suite means the
-// ordinary test job enforces it — no workflow needs to remember a
+// ordinary test job enforces it - no workflow needs to remember a
 // dedicated `task catalog:check` step. Regenerate with
 // `task catalog:snapshot`.
 func TestCommittedSnapshotIsFresh(t *testing.T) {

--- a/providers/vertex/locations.go
+++ b/providers/vertex/locations.go
@@ -45,22 +45,24 @@ const (
 )
 
 // servedLocations maps each catalogued bare model ID to the locations
-// Google publishes it at, transcribed from LocationsMatrixSource on
-// LocationsMatrixTranscribed and reconciled against the live page that
-// day. The catalog's scope is global plus the US and EU buckets. Google
-// also serves the Claude models in APAC (claude-sonnet-5 at
-// asia-southeast1, claude-haiku-4-5 at asia-east1); that is out of this
-// catalog's US/EU scope and is deliberately omitted.
+// Google both publishes it at and serves a pay-as-you-go call from,
+// transcribed from LocationsMatrixSource on LocationsMatrixTranscribed and
+// cross-checked with live rawPredict and count-tokens calls that day. A
+// location is listed only where a live call is both published and
+// callable, so a published-but-quota-refused region is left out.
 //
 //   - gemini-3.6-flash is served at global and the us/eu multi-regions
 //     only. Google publishes no named-region availability for it.
 //   - claude-sonnet-5 is served at global and the us/eu multi-regions. It
 //     is on a shared-lineage quota bucket with no pay-as-you-go allocation
-//     at a US or EU named region, so a call to one earns a 429 rather than
-//     a completion.
+//     at a named region, so a call to any named region (a US or EU one, or
+//     asia-southeast1) earns a 429 rather than a completion.
 //   - claude-haiku-4-5 holds a per-version quota and is served at the
 //     us-east5 and europe-west1 named regions plus global. Google does not
-//     publish it at the us/eu multi-regions.
+//     publish it at the us/eu multi-regions. It is published at
+//     asia-southeast1 but a call there returns a 429 (no pay-as-you-go
+//     allocation), and it is not published at asia-east1 at all, so neither
+//     APAC region is listed.
 var servedLocations = map[string][]string{
 	ModelGemini36Flash: {
 		LocationGlobal,
@@ -76,16 +78,19 @@ var servedLocations = map[string][]string{
 	},
 }
 
-// IsModelAvailableAtLocation reports whether Google publishes the given
-// bare model at the given location, according to the transcribed matrix.
+// IsModelAvailableAtLocation reports whether the transcribed matrix lists
+// the given bare model as served at the given location - that is, both
+// published by Google and callable on a pay-as-you-go plan.
 //
 // It answers config-time questions only. A false is a reason to refuse a
 // save or hide a model from a picker, never to reject a live request: the
 // transcription is dated and may lag Google's own additions.
 //
+// The model may be given either as a bare publisher ID or as a
+// namespaced vertex. offering ID; the prefix is stripped before lookup.
 // An unknown model or an unknown location returns false.
-func IsModelAvailableAtLocation(bareModel, location string) bool {
-	locs, ok := servedLocations[bareModel]
+func IsModelAvailableAtLocation(model, location string) bool {
+	locs, ok := servedLocations[bareModelID(model)]
 	if !ok {
 		return false
 	}
@@ -94,30 +99,16 @@ func IsModelAvailableAtLocation(bareModel, location string) bool {
 }
 
 // LocationsForModel returns the locations the transcribed matrix lists
-// for the given bare model, or nil for an unknown model. The result is a
+// for the given model, or nil for an unknown model. The model may be a
+// bare publisher ID or a namespaced vertex. offering ID. The result is a
 // copy the caller may retain and mutate.
-func LocationsForModel(bareModel string) []string {
-	locs, ok := servedLocations[bareModel]
+func LocationsForModel(model string) []string {
+	locs, ok := servedLocations[bareModelID(model)]
 	if !ok {
 		return nil
 	}
 
 	return slices.Clone(locs)
-}
-
-// nonGlobalLocations returns the served locations of a model with the
-// global endpoint removed. It is the set that carries the non-global
-// pricing override, so pricing and availability read from one table.
-func nonGlobalLocations(bareModel string) []string {
-	var out []string
-
-	for _, loc := range servedLocations[bareModel] {
-		if loc != LocationGlobal {
-			out = append(out, loc)
-		}
-	}
-
-	return out
 }
 
 // normalizeLocation matches pricing.Selector's region normalization

--- a/providers/vertex/locations.go
+++ b/providers/vertex/locations.go
@@ -40,29 +40,30 @@ const (
 	// LocationsMatrixTranscribed is the date the matrix below was copied
 	// from LocationsMatrixSource, in YYYY-MM-DD form. The full per-model
 	// availability was reconciled against the live page on this date: every
-	// row below is what LocationsMatrixSource published on 2026-09-07.
-	LocationsMatrixTranscribed = "2026-09-07"
+	// row below is what LocationsMatrixSource published on 2026-09-08.
+	LocationsMatrixTranscribed = "2026-09-08"
 )
 
 // servedLocations maps each catalogued bare model ID to the locations
-// Google both publishes it at and serves a pay-as-you-go call from,
-// transcribed from LocationsMatrixSource on LocationsMatrixTranscribed and
-// cross-checked with live rawPredict and count-tokens calls that day. A
-// location is listed only where a live call is both published and
-// callable, so a published-but-quota-refused region is left out.
+// Google publishes it at, transcribed from LocationsMatrixSource on
+// LocationsMatrixTranscribed. A location is listed wherever Google's page
+// marks the model supported there.
 //
-//   - gemini-3.6-flash is served at global and the us/eu multi-regions
-//     only. Google publishes no named-region availability for it.
-//   - claude-sonnet-5 is served at global and the us/eu multi-regions. It
-//     is on a shared-lineage quota bucket with no pay-as-you-go allocation
-//     at a named region, so a call to any named region (a US or EU one, or
-//     asia-southeast1) earns a 429 rather than a completion.
-//   - claude-haiku-4-5 holds a per-version quota and is served at the
-//     us-east5 and europe-west1 named regions plus global. Google does not
-//     publish it at the us/eu multi-regions. It is published at
-//     asia-southeast1 but a call there returns a 429 (no pay-as-you-go
-//     allocation), and it is not published at asia-east1 at all, so neither
-//     APAC region is listed.
+// The gateway proxies traffic that already runs in the customer's own GCP
+// project, so what governs this map is what Google publishes, not any one
+// project's quota. Every published location is listed so the gateway prices
+// and routes a customer who calls the model there.
+//
+//	                  global  us  eu  us-east5  europe-west1  asia-southeast1  asia-east1
+//	gemini-3.6-flash  Y       Y   Y   -         -             -                -
+//	claude-sonnet-5   Y       Y   Y   -         -             Y                -
+//	claude-haiku-4-5  Y       -   -   Y         Y             -                Y
+//
+// Y = published by Google, so it appears in the map below; - = not
+// published. Gemini publishes no named-region availability at all. Sonnet
+// is published at the us and eu multi-regions and the asia-southeast1 named
+// region. Haiku is published at the us-east5, europe-west1, and asia-east1
+// named regions.
 var servedLocations = map[string][]string{
 	ModelGemini36Flash: {
 		LocationGlobal,
@@ -71,10 +72,12 @@ var servedLocations = map[string][]string{
 	ModelClaudeSonnet5: {
 		LocationGlobal,
 		"us", "eu",
+		"asia-southeast1",
 	},
 	ModelClaudeHaiku45: {
 		LocationGlobal,
 		"us-east5", "europe-west1",
+		"asia-east1",
 	},
 }
 

--- a/providers/vertex/locations.go
+++ b/providers/vertex/locations.go
@@ -1,0 +1,128 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vertex
+
+import (
+	"slices"
+	"strings"
+)
+
+// LocationGlobal is the location value for Vertex's global endpoint. It
+// is the one location every catalogued model is served at.
+const LocationGlobal = "global"
+
+// The availability matrix has no API behind it. A Vertex model ID carries
+// no geography - unlike a Bedrock inference profile - so whether a model
+// is served at a location comes from Google's published model-by-location
+// matrix, transcribed by hand and dated. This is the analog of Bedrock's
+// IsModelAllowedFromRegion, which reads AWS inference-profile metadata.
+//
+// A stale copy of a dated transcription must never turn away traffic
+// Vertex would serve, so the table is consulted only at config time (a
+// provider save, the model picker, the connection-test default), never on
+// a live request.
+const (
+	// LocationsMatrixSource is the page the matrix is transcribed from.
+	LocationsMatrixSource = "https://docs.cloud.google.com/vertex-ai/generative-ai/docs/learn/locations"
+
+	// LocationsMatrixTranscribed is the date the matrix below was copied
+	// from LocationsMatrixSource, in YYYY-MM-DD form. The full per-model
+	// availability was reconciled against the live page on this date: every
+	// row below is what LocationsMatrixSource published on 2026-09-07.
+	LocationsMatrixTranscribed = "2026-09-07"
+)
+
+// servedLocations maps each catalogued bare model ID to the locations
+// Google publishes it at, transcribed from LocationsMatrixSource on
+// LocationsMatrixTranscribed and reconciled against the live page that
+// day. The catalog's scope is global plus the US and EU buckets. Google
+// also serves the Claude models in APAC (claude-sonnet-5 at
+// asia-southeast1, claude-haiku-4-5 at asia-east1); that is out of this
+// catalog's US/EU scope and is deliberately omitted.
+//
+//   - gemini-3.6-flash is served at global and the us/eu multi-regions
+//     only. Google publishes no named-region availability for it.
+//   - claude-sonnet-5 is served at global and the us/eu multi-regions. It
+//     is on a shared-lineage quota bucket with no pay-as-you-go allocation
+//     at a US or EU named region, so a call to one earns a 429 rather than
+//     a completion.
+//   - claude-haiku-4-5 holds a per-version quota and is served at the
+//     us-east5 and europe-west1 named regions plus global. Google does not
+//     publish it at the us/eu multi-regions.
+var servedLocations = map[string][]string{
+	ModelGemini36Flash: {
+		LocationGlobal,
+		"us", "eu",
+	},
+	ModelClaudeSonnet5: {
+		LocationGlobal,
+		"us", "eu",
+	},
+	ModelClaudeHaiku45: {
+		LocationGlobal,
+		"us-east5", "europe-west1",
+	},
+}
+
+// IsModelAvailableAtLocation reports whether Google publishes the given
+// bare model at the given location, according to the transcribed matrix.
+//
+// It answers config-time questions only. A false is a reason to refuse a
+// save or hide a model from a picker, never to reject a live request: the
+// transcription is dated and may lag Google's own additions.
+//
+// An unknown model or an unknown location returns false.
+func IsModelAvailableAtLocation(bareModel, location string) bool {
+	locs, ok := servedLocations[bareModel]
+	if !ok {
+		return false
+	}
+
+	return slices.Contains(locs, normalizeLocation(location))
+}
+
+// LocationsForModel returns the locations the transcribed matrix lists
+// for the given bare model, or nil for an unknown model. The result is a
+// copy the caller may retain and mutate.
+func LocationsForModel(bareModel string) []string {
+	locs, ok := servedLocations[bareModel]
+	if !ok {
+		return nil
+	}
+
+	return slices.Clone(locs)
+}
+
+// nonGlobalLocations returns the served locations of a model with the
+// global endpoint removed. It is the set that carries the non-global
+// pricing override, so pricing and availability read from one table.
+func nonGlobalLocations(bareModel string) []string {
+	var out []string
+
+	for _, loc := range servedLocations[bareModel] {
+		if loc != LocationGlobal {
+			out = append(out, loc)
+		}
+	}
+
+	return out
+}
+
+// normalizeLocation matches pricing.Selector's region normalization
+// (lowercase, trimmed), so an availability answer and a price lookup
+// agree on what a location string means.
+func normalizeLocation(location string) string {
+	return strings.ToLower(strings.TrimSpace(location))
+}

--- a/providers/vertex/locations_test.go
+++ b/providers/vertex/locations_test.go
@@ -41,10 +41,15 @@ func TestIsModelAvailableAtLocation(t *testing.T) {
 		{"gemini location case-insensitive", vertex.ModelGemini36Flash, "EU", true},
 		{"sonnet-5 at global", vertex.ModelClaudeSonnet5, "global", true},
 		{"sonnet-5 at eu multi-region", vertex.ModelClaudeSonnet5, "eu", true},
-		// Shared-lineage Claude has no pay-as-you-go allocation at a named
-		// region, so the matrix must not list one.
+		// Sonnet is published at asia-southeast1 but not at us-east5; each
+		// model carries only the regions Google's page marks for it.
+		{"sonnet-5 at asia-southeast1", vertex.ModelClaudeSonnet5, "asia-southeast1", true},
 		{"sonnet-5 not at named region", vertex.ModelClaudeSonnet5, "us-east5", false},
 		{"haiku at named region", vertex.ModelClaudeHaiku45, "europe-west1", true},
+		// Haiku is published at asia-east1, not at asia-southeast1 - the
+		// reverse of Sonnet's APAC region.
+		{"haiku at asia-east1", vertex.ModelClaudeHaiku45, "asia-east1", true},
+		{"haiku not at asia-southeast1", vertex.ModelClaudeHaiku45, "asia-southeast1", false},
 		// A caller may hold the namespaced vertex. offering ID rather than
 		// the bare publisher model; the prefix is stripped before lookup so
 		// both reach the same row.
@@ -89,8 +94,8 @@ func TestServedLocationsMatrix(t *testing.T) {
 
 	want := map[string][]string{
 		vertex.ModelGemini36Flash: {"global", "us", "eu"},
-		vertex.ModelClaudeSonnet5: {"global", "us", "eu"},
-		vertex.ModelClaudeHaiku45: {"global", "us-east5", "europe-west1"},
+		vertex.ModelClaudeSonnet5: {"global", "us", "eu", "asia-southeast1"},
+		vertex.ModelClaudeHaiku45: {"global", "us-east5", "europe-west1", "asia-east1"},
 	}
 
 	for model, wantLocs := range want {

--- a/providers/vertex/locations_test.go
+++ b/providers/vertex/locations_test.go
@@ -45,6 +45,10 @@ func TestIsModelAvailableAtLocation(t *testing.T) {
 		// region, so the matrix must not list one.
 		{"sonnet-5 not at named region", vertex.ModelClaudeSonnet5, "us-east5", false},
 		{"haiku at named region", vertex.ModelClaudeHaiku45, "europe-west1", true},
+		// A caller may hold the namespaced vertex. offering ID rather than
+		// the bare publisher model; the prefix is stripped before lookup so
+		// both reach the same row.
+		{"prefixed offering id resolves", offeringClaudeSonnet5, "eu", true},
 		{"unknown model", "gemini-99-ultra", "global", false},
 		{"unknown location", vertex.ModelGemini36Flash, "mars-central1", false},
 		{"empty location", vertex.ModelGemini36Flash, "", false},
@@ -73,6 +77,26 @@ func TestLocationsForModel(t *testing.T) {
 	locs[0] = "tampered"
 	again := vertex.LocationsForModel(vertex.ModelClaudeSonnet5)
 	assert.NotEqual(t, "tampered", again[0], "LocationsForModel returned a slice aliasing the shared table")
+}
+
+// TestServedLocationsMatrix pins the exact served-location set for every
+// catalogued model, so a hand edit to the transcribed matrix that drops or
+// reorders a location is caught rather than silently changing availability.
+// The expected slices are the full transcription dated
+// LocationsMatrixTranscribed; update them together when the matrix changes.
+func TestServedLocationsMatrix(t *testing.T) {
+	t.Parallel()
+
+	want := map[string][]string{
+		vertex.ModelGemini36Flash: {"global", "us", "eu"},
+		vertex.ModelClaudeSonnet5: {"global", "us", "eu"},
+		vertex.ModelClaudeHaiku45: {"global", "us-east5", "europe-west1"},
+	}
+
+	for model, wantLocs := range want {
+		got := vertex.LocationsForModel(model)
+		assert.Equalf(t, wantLocs, got, "served locations for %s", model)
+	}
 }
 
 // TestMatrixProvenance checks the transcription carries a source URL and a

--- a/providers/vertex/locations_test.go
+++ b/providers/vertex/locations_test.go
@@ -1,0 +1,88 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vertex_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/redpanda-data/ai-sdk-go/providers/vertex"
+)
+
+func TestIsModelAvailableAtLocation(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		model    string
+		location string
+		want     bool
+	}{
+		{"gemini at global", vertex.ModelGemini36Flash, "global", true},
+		{"gemini at us multi-region", vertex.ModelGemini36Flash, "us", true},
+		// Google publishes no named-region availability for Gemini 3.6
+		// Flash, only global and the us/eu multi-regions.
+		{"gemini not at named region", vertex.ModelGemini36Flash, "us-east5", false},
+		{"gemini location case-insensitive", vertex.ModelGemini36Flash, "EU", true},
+		{"sonnet-5 at global", vertex.ModelClaudeSonnet5, "global", true},
+		{"sonnet-5 at eu multi-region", vertex.ModelClaudeSonnet5, "eu", true},
+		// Shared-lineage Claude has no pay-as-you-go allocation at a named
+		// region, so the matrix must not list one.
+		{"sonnet-5 not at named region", vertex.ModelClaudeSonnet5, "us-east5", false},
+		{"haiku at named region", vertex.ModelClaudeHaiku45, "europe-west1", true},
+		{"unknown model", "gemini-99-ultra", "global", false},
+		{"unknown location", vertex.ModelGemini36Flash, "mars-central1", false},
+		{"empty location", vertex.ModelGemini36Flash, "", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tc.want, vertex.IsModelAvailableAtLocation(tc.model, tc.location))
+		})
+	}
+}
+
+// TestLocationsForModel checks the accessor returns a copy (the caller
+// mutating it must not corrupt the shared table) and nil for an unknown
+// model.
+func TestLocationsForModel(t *testing.T) {
+	t.Parallel()
+
+	assert.Nil(t, vertex.LocationsForModel("gemini-99-ultra"))
+
+	locs := vertex.LocationsForModel(vertex.ModelClaudeSonnet5)
+	require.NotEmpty(t, locs)
+
+	locs[0] = "tampered"
+	again := vertex.LocationsForModel(vertex.ModelClaudeSonnet5)
+	assert.NotEqual(t, "tampered", again[0], "LocationsForModel returned a slice aliasing the shared table")
+}
+
+// TestMatrixProvenance checks the transcription carries a source URL and a
+// well-formed date, so a stale copy is always traceable to what it copied
+// and when.
+func TestMatrixProvenance(t *testing.T) {
+	t.Parallel()
+
+	assert.NotEmpty(t, vertex.LocationsMatrixSource)
+
+	_, err := time.Parse("2006-01-02", vertex.LocationsMatrixTranscribed)
+	assert.NoError(t, err, "LocationsMatrixTranscribed must be a YYYY-MM-DD date")
+}

--- a/providers/vertex/models.go
+++ b/providers/vertex/models.go
@@ -130,8 +130,6 @@ var geminiCaps = llm.ModelCapabilities{
 	Reasoning:        true,
 }
 
-// geminiModalities: text, image, audio, video, and PDF inputs; text
-// output.
 var geminiModalities = catalog.Modalities{
 	Input: []catalog.Modality{
 		catalog.ModalityText, catalog.ModalityImage, catalog.ModalityAudio,
@@ -157,7 +155,6 @@ var claudeCaps = llm.ModelCapabilities{
 	Reasoning:        true,
 }
 
-// claudeModalities: text, image, and PDF inputs; text output.
 var claudeModalities = catalog.Modalities{
 	Input:  []catalog.Modality{catalog.ModalityText, catalog.ModalityImage, catalog.ModalityDocument},
 	Output: []catalog.Modality{catalog.ModalityText},
@@ -213,18 +210,6 @@ func entries() []catalog.Entry {
 			Life: catalog.Lifecycle{
 				Available: catalog.MustDate("2026-07-21"),
 			},
-			// On Vertex, Gemini 3.6 Flash bills at the introductory rate
-			// ($0.75/$3.75, cache $0.075) through 2026-12-31, then the
-			// standard rate ($1.50/$7.50, cache $0.15) from 2027-01-01.
-			// The catalog tracks the rate in effect, matching the
-			// Gemini-API provider (providers/google/models.go). This is a
-			// real per-token price, not the separate 50% Provisioned
-			// Throughput promotional credit the page also lists; that
-			// credit is post-hoc spend accounting the pricing package puts
-			// out of scope (pricing/doc.go). A non-global endpoint bills
-			// ~10% above global across the us/eu multi-regions, expressed
-			// as Region overrides rather than separate model entries.
-			// Rates read from the page on 2026-09-08.
 			Pricing: geminiFlashPricing(),
 			Attributes: map[string]string{
 				AttrPublisher:   publisherGoogle,
@@ -238,8 +223,8 @@ func entries() []catalog.Entry {
 			Modalities:   claudeModalities,
 			Constraints: llm.ModelConstraints{
 				TemperatureRange: [2]float64{0.0, 1.0},
-				MaxInputTokens:   1000000, // 1M context window
-				MaxOutputTokens:  128000,  // 128K output tokens
+				MaxInputTokens:   1000000,
+				MaxOutputTokens:  128000,
 				SupportedParams:  []string{"temperature", "top_p", "top_k", "max_tokens", "reasoning_effort"},
 			},
 			Reasoning: catalog.ReasoningSupport{
@@ -249,14 +234,6 @@ func entries() []catalog.Entry {
 			Life: catalog.Lifecycle{
 				Available: catalog.MustDate("2026-06-29"),
 			},
-			// $2/$10 is Sonnet 5's global list price, cache reads at the
-			// 0.10x multiplier and writes at 1.25x (5m) / 2x (1h). A
-			// non-global endpoint bills ~10% above global, the same premium
-			// Gemini carries, expressed as Region overrides on the served
-			// multi-regions. Anthropic is the one publisher absent from
-			// Google's Billing Catalog, so Claude rates rest on Google's
-			// Agent Platform pricing page, verified 2026-09-08 (see
-			// claudeSonnet5Pricing).
 			Pricing: claudeSonnet5Pricing(),
 			Attributes: map[string]string{
 				AttrPublisher:   publisherAnthropic,
@@ -270,16 +247,13 @@ func entries() []catalog.Entry {
 			Modalities:   claudeModalities,
 			Constraints: llm.ModelConstraints{
 				TemperatureRange: [2]float64{0.0, 1.0},
-				MaxInputTokens:   200000, // 200K context window
-				MaxOutputTokens:  64000,  // 64K output tokens
+				MaxInputTokens:   200000,
+				MaxOutputTokens:  64000,
 				SupportedParams:  []string{"temperature", "top_p", "top_k", "max_tokens"},
 			},
 			Life: catalog.Lifecycle{
 				Available: catalog.MustDate("2025-10-15"),
 			},
-			// $1/$5 global list price, cache reads 0.10x, writes 1.25x
-			// (5m) / 2x (1h), with the same ~10% non-global premium as
-			// Sonnet on the served named regions (see claudeHaiku45Pricing).
 			Pricing: claudeHaiku45Pricing(),
 			Attributes: map[string]string{
 				AttrPublisher:   publisherAnthropic,
@@ -292,6 +266,12 @@ func entries() []catalog.Entry {
 // geminiFlashPricing builds the Gemini 3.6 Flash rate card: the global
 // rate as the default, and the ~10% higher non-global rate as one Region
 // override per multi-region that carries the premium.
+//
+// The default is Gemini 3.6 Flash's introductory per-token rate, tracked
+// like the Gemini-API provider (providers/google/models.go). It is a real
+// per-token price, not the separate 50% Provisioned Throughput credit the
+// page also lists; that credit is post-hoc spend accounting the pricing
+// package excludes (pricing/doc.go).
 //
 // The priced regions are their own literal, not derived from the
 // availability matrix (locations.go). Pricing and availability are
@@ -332,10 +312,7 @@ func geminiFlashPricing() pricing.Info {
 // Claude is not flat. Google's Agent Platform pricing page groups Sonnet 5
 // under "Models with regional pricing" and publishes every non-global rate
 // at exactly global x 1.10 - input, output, cache write, and cache read
-// alike. Read from the page's region tabs on 2026-09-08:
-//
-//	Global:  in $2.00, out $10.00, 5m write $2.50, 1h write $4.00, hit $0.20
-//	US / EU: in $2.20, out $11.00, 5m write $2.75, 1h write $4.40, hit $0.22
+// alike. Rates below read from the page's region tabs on 2026-09-08.
 //
 // The override regions are Sonnet's served multi-regions (locations.go), so
 // TestClaudeRegionalOverride can guard that every priced region is served,
@@ -361,11 +338,8 @@ func claudeSonnet5Pricing() pricing.Info {
 // the default, and the ~10% non-global premium as one Region override per
 // served named region.
 //
-// Same shape as Sonnet. From the Agent Platform pricing page's region tabs
-// on 2026-09-08:
-//
-//	Global:               in $1.00, out $5.00, 5m write $1.25, 1h write $2.00, hit $0.10
-//	us-east5/europe-west1: in $1.10, out $5.50, 5m write $1.375, 1h write $2.20, hit $0.11
+// Same shape as Sonnet, rates below read from the Agent Platform pricing
+// page's region tabs on 2026-09-08.
 //
 // Haiku's served named regions are us-east5 and europe-west1 (locations.go),
 // which are exactly the regions the page prices at the premium.

--- a/providers/vertex/models.go
+++ b/providers/vertex/models.go
@@ -33,6 +33,7 @@
 package vertex
 
 import (
+	"strings"
 	"sync"
 
 	"github.com/redpanda-data/ai-sdk-go/catalog"
@@ -83,6 +84,24 @@ const (
 // catalogID returns the namespaced offering ID for a bare Vertex model.
 func catalogID(bareModel string) string {
 	return catalogKeyPrefix + bareModel
+}
+
+// bareModelID strips the vertex. catalog-key prefix when present, so a
+// caller may pass either a bare publisher model ID ("claude-sonnet-5")
+// or a namespaced offering ID ("vertex.claude-sonnet-5") and reach the
+// same entry. A string without the prefix is returned unchanged.
+func bareModelID(model string) string {
+	return strings.TrimPrefix(model, catalogKeyPrefix)
+}
+
+// OfferingForModel returns the Vertex offering for a bare publisher model
+// ID, adding the vertex. catalog-key prefix and looking it up. It is the
+// bridge for callers that hold a bare model name rather than a namespaced
+// offering ID, keeping the prefix an internal catalog detail. A model ID
+// that already carries the prefix is accepted as-is. ok is false for a
+// model the catalog does not offer.
+func OfferingForModel(model string) (catalog.Offering, bool) {
+	return Catalog().Lookup(catalogID(bareModelID(model)))
 }
 
 // Claude reasoning-effort values Vertex accepts, mirroring the
@@ -189,11 +208,13 @@ func entries() []catalog.Entry {
 			},
 			// On Vertex, Gemini 3.6 Flash bills at the full SKU rate
 			// ($1.50/$7.50, cache $0.15); the introductory discount the
-			// Gemini-API provider tracks arrives on Vertex as credits, not
-			// a lower price, and ends 2026-12-31. A non-global endpoint
-			// bills ~10% above global across the us/eu multi-regions,
-			// expressed as Region overrides rather than separate model
-			// entries.
+			// Gemini-API provider tracks arrives on Vertex as an
+			// account-level credit, not a lower price, and ends
+			// 2026-12-31. That credit is post-hoc spend accounting, which
+			// the pricing package puts out of scope (pricing/doc.go), so
+			// the catalog tracks the SKU rate. A non-global endpoint bills
+			// ~10% above global across the us/eu multi-regions, expressed
+			// as Region overrides rather than separate model entries.
 			Pricing: geminiFlashPricing(),
 			Attributes: map[string]string{
 				AttrPublisher:   publisherGoogle,
@@ -259,11 +280,16 @@ func entries() []catalog.Entry {
 }
 
 // geminiFlashPricing builds the Gemini 3.6 Flash rate card: the global
-// rate as the default, and the ~10% higher non-global rate as one
-// Region override per non-global location the model serves. The override
-// set is driven by the availability matrix (locations.go) so the two
-// never drift: a location priced high must be a location the model is
-// actually served at.
+// rate as the default, and the ~10% higher non-global rate as one Region
+// override per multi-region that carries the premium.
+//
+// The priced regions are their own literal, not derived from the
+// availability matrix (locations.go). Pricing and availability are
+// separate facts: a region can be served at the plain global rate, so a
+// served location is not automatically a priced one. The direction that
+// must hold is the reverse - a region priced here must be one the model
+// is served at - and TestGeminiRegionalOverride guards exactly that, so
+// the two never contradict without coupling the definitions.
 //
 // The override carries the non-global rate (default = global) because an
 // empty-Region override cannot mean "every non-global region" - an empty
@@ -277,9 +303,9 @@ func geminiFlashPricing() pricing.Info {
 	nonGlobal := pricing.NewRates(1.65, 8.25, 0.165)
 
 	info := pricing.FlatInfoFromRates(global)
-	for _, loc := range nonGlobalLocations(ModelGemini36Flash) {
+	for _, region := range []string{"us", "eu"} {
 		info = info.WithOverride(
-			pricing.Selector{Region: loc},
+			pricing.Selector{Region: region},
 			pricing.RateCard{Base: nonGlobal},
 		)
 	}

--- a/providers/vertex/models.go
+++ b/providers/vertex/models.go
@@ -186,7 +186,7 @@ func Catalog() *catalog.Catalog {
 // page for the platform (Google renamed Vertex AI to the Gemini Enterprise
 // Agent Platform, so older /vertex-ai/ links redirect here):
 //
-//   https://cloud.google.com/gemini-enterprise-agent-platform/generative-ai/pricing
+//	https://cloud.google.com/gemini-enterprise-agent-platform/generative-ai/pricing
 //
 // Claude rates come from that page, not Anthropic's list prices: Vertex
 // sets its own Claude rates (including a ~10% non-global premium

--- a/providers/vertex/models.go
+++ b/providers/vertex/models.go
@@ -182,17 +182,17 @@ func Catalog() *catalog.Catalog {
 // pages is an M1 exit condition, because a catalog PR is the last moment a
 // wrong rate costs nothing.
 //
-//   - Google's Vertex Gemini pricing:
-//     https://cloud.google.com/vertex-ai/generative-ai/pricing
-//   - Google's Agent Platform pricing (Claude on Vertex, with the region
-//     selector that carries the per-region rates):
-//     https://cloud.google.com/gemini-enterprise-agent-platform/generative-ai/pricing
+// Every rate, Gemini and Claude alike, comes from Google's one pricing
+// page for the platform (Google renamed Vertex AI to the Gemini Enterprise
+// Agent Platform, so older /vertex-ai/ links redirect here):
 //
-// Claude rates come from Google's own page, not Anthropic's list prices:
-// Vertex sets its own Claude rates (including a ~10% non-global premium
+//   https://cloud.google.com/gemini-enterprise-agent-platform/generative-ai/pricing
+//
+// Claude rates come from that page, not Anthropic's list prices: Vertex
+// sets its own Claude rates (including a ~10% non-global premium
 // Anthropic-direct does not have), and Anthropic is the one publisher with
-// no SKUs in Google's Billing Catalog, so the Agent Platform page is the
-// authoritative source.
+// no SKUs in Google's Billing Catalog, so this page, with its per-region
+// tabs, is the authoritative source.
 //
 // Capabilities, constraints, and lifecycle mirror the same models in the
 // Gemini-API and Anthropic-direct catalogs: the model is the same, only
@@ -213,15 +213,18 @@ func entries() []catalog.Entry {
 			Life: catalog.Lifecycle{
 				Available: catalog.MustDate("2026-07-21"),
 			},
-			// On Vertex, Gemini 3.6 Flash bills at the full SKU rate
-			// ($1.50/$7.50, cache $0.15); the introductory discount the
-			// Gemini-API provider tracks arrives on Vertex as an
-			// account-level credit, not a lower price, and ends
-			// 2026-12-31. That credit is post-hoc spend accounting, which
-			// the pricing package puts out of scope (pricing/doc.go), so
-			// the catalog tracks the SKU rate. A non-global endpoint bills
+			// On Vertex, Gemini 3.6 Flash bills at the introductory rate
+			// ($0.75/$3.75, cache $0.075) through 2026-12-31, then the
+			// standard rate ($1.50/$7.50, cache $0.15) from 2027-01-01.
+			// The catalog tracks the rate in effect, matching the
+			// Gemini-API provider (providers/google/models.go). This is a
+			// real per-token price, not the separate 50% Provisioned
+			// Throughput promotional credit the page also lists; that
+			// credit is post-hoc spend accounting the pricing package puts
+			// out of scope (pricing/doc.go). A non-global endpoint bills
 			// ~10% above global across the us/eu multi-regions, expressed
 			// as Region overrides rather than separate model entries.
+			// Rates read from the page on 2026-09-08.
 			Pricing: geminiFlashPricing(),
 			Attributes: map[string]string{
 				AttrPublisher:   publisherGoogle,
@@ -302,12 +305,14 @@ func entries() []catalog.Entry {
 // empty-Region override cannot mean "every non-global region" - an empty
 // selector field is a wildcard that would also match global.
 func geminiFlashPricing() pricing.Info {
-	global := pricing.NewRates(1.50, 7.50, 0.15)
-	// The non-global rates ($1.65/$8.25 input/output, $0.165 cache) are the
-	// regional Gemini SKUs Google's Vertex pricing page publishes, verified
-	// against the live page on 2026-09-07: a uniform ~10% markup over the
-	// global rate on input, output, and cache alike.
-	nonGlobal := pricing.NewRates(1.65, 8.25, 0.165)
+	global := pricing.NewRates(0.75, 3.75, 0.075)
+	// The non-global rates ($0.825/$4.125 input/output, $0.0825 cache) are
+	// the regional Gemini rates Google's pricing page publishes, verified
+	// against the live page on 2026-09-08: a uniform ~10% markup over the
+	// global rate on input, output, and cache alike. These are the
+	// introductory rates in effect through 2026-12-31; the standard rates
+	// from 2027-01-01 are $1.50/$7.50 global, $1.65/$8.25 non-global.
+	nonGlobal := pricing.NewRates(0.825, 4.125, 0.0825)
 
 	info := pricing.FlatInfoFromRates(global)
 	for _, region := range []string{"us", "eu"} {

--- a/providers/vertex/models.go
+++ b/providers/vertex/models.go
@@ -1,0 +1,288 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package vertex is the model catalog, pricing, and location-availability
+// data for Google Vertex AI, where Google Cloud hosts first-party Gemini
+// alongside partner models such as Anthropic's Claude. One GCP project
+// reaches all of them, billed on that project's own account.
+//
+// This package is the catalog half of the provider (RFC-0014 milestone
+// M1): the day-one Gemini + Claude catalog, ModelPricing through each
+// offering's [catalog.Entry].Pricing, and the location-availability
+// helper in locations.go. The request/response transport (an llm.Model
+// that builds Vertex requests) lands with the managed-agent milestone and
+// is intentionally not part of this package yet.
+//
+// Catalog keys are namespaced vertex.<model>. On Vertex a model keeps its
+// publisher's bare ID, so "claude-sonnet-5" is byte-identical to the ID
+// the Anthropic-direct catalog already uses; a shared pricing catalog
+// rejects that collision. The bare wire model and its publisher travel in
+// each entry's Attributes instead of as an alias, because an alias would
+// re-introduce the same collision in a merged catalog.
+package vertex
+
+import (
+	"sync"
+
+	"github.com/redpanda-data/ai-sdk-go/catalog"
+	"github.com/redpanda-data/ai-sdk-go/llm"
+	"github.com/redpanda-data/ai-sdk-go/pricing"
+)
+
+// providerName is the provider identifier used in offerings and
+// telemetry. It matches the catalog key prefix's stem and mirrors
+// Bedrock's "aws.bedrock": the cloud, then the surface.
+const providerName = "gcp.vertex"
+
+// catalogKeyPrefix namespaces every Vertex offering ID. See the package
+// doc for why the prefix is required rather than optional.
+const catalogKeyPrefix = "vertex."
+
+// Bare Vertex model IDs - exactly the model segment of a Vertex resource
+// path, publishers/{publisher}/models/{model}. The day-one catalog is
+// Gemini + Claude, enumerated in RFC-0014's Model catalog and pricing
+// section (the F5 scope call). The open-weight families on the
+// OpenAI-compatible route are deferred until a customer asks.
+const (
+	ModelGemini36Flash = "gemini-3.6-flash"
+	ModelClaudeSonnet5 = "claude-sonnet-5"
+	ModelClaudeHaiku45 = "claude-haiku-4-5"
+)
+
+// Publishers own the model on Vertex and name the segment before the
+// model in a Vertex resource path. Stored per offering in Attributes so
+// the runtime provider can build the path without re-deriving it.
+const (
+	publisherGoogle    = "google"
+	publisherAnthropic = "anthropic"
+)
+
+// Attribute keys carried on every Vertex offering. Keys are snake_case
+// and values are strings so the committed snapshot stays stable.
+const (
+	// AttrPublisher is the Vertex publisher segment ("google",
+	// "anthropic").
+	AttrPublisher = "publisher"
+	// AttrVertexModel is the bare wire model ID, i.e. the offering ID
+	// with the vertex. prefix stripped. The offering ID is the pricing
+	// key; this is what goes in the request path.
+	AttrVertexModel = "vertex_model"
+)
+
+// catalogID returns the namespaced offering ID for a bare Vertex model.
+func catalogID(bareModel string) string {
+	return catalogKeyPrefix + bareModel
+}
+
+// Claude reasoning-effort values Vertex accepts, mirroring the
+// Anthropic-direct catalog. llm.ReasoningEffort is an open string type
+// whose valid vocabulary is provider-owned; these are the source of truth
+// for Vertex Claude.
+const (
+	reasoningEffortLow    llm.ReasoningEffort = "low"
+	reasoningEffortMedium llm.ReasoningEffort = "medium"
+	reasoningEffortHigh   llm.ReasoningEffort = "high"
+	reasoningEffortXHigh  llm.ReasoningEffort = "xhigh"
+	reasoningEffortMax    llm.ReasoningEffort = "max"
+)
+
+// geminiCaps is the capability set shared by every catalogued Gemini
+// model on Vertex, matching the Gemini-API provider's set.
+var geminiCaps = llm.ModelCapabilities{
+	Streaming:        true,
+	Tools:            true,
+	JSONMode:         true, // via response_mime_type
+	StructuredOutput: true,
+	Vision:           true,
+	Audio:            true,
+	MultiTurn:        true,
+	SystemPrompts:    true,
+	Reasoning:        true,
+}
+
+// geminiModalities: text, image, audio, video, and PDF inputs; text
+// output.
+var geminiModalities = catalog.Modalities{
+	Input: []catalog.Modality{
+		catalog.ModalityText, catalog.ModalityImage, catalog.ModalityAudio,
+		catalog.ModalityVideo, catalog.ModalityDocument,
+	},
+	Output: []catalog.Modality{catalog.ModalityText},
+}
+
+// geminiParams is the request-parameter surface shared by catalogued
+// Gemini models.
+var geminiParams = []string{"temperature", "top_p", "top_k", "max_tokens", "stop", "presence_penalty", "frequency_penalty"}
+
+// claudeCaps is the capability set shared by catalogued Claude models on
+// Vertex. JSONMode is false because Claude has no schemaless JSON mode;
+// structured output is via output_config with a json_schema.
+var claudeCaps = llm.ModelCapabilities{
+	Streaming:        true,
+	Tools:            true,
+	StructuredOutput: true,
+	Vision:           true,
+	MultiTurn:        true,
+	SystemPrompts:    true,
+	Reasoning:        true,
+}
+
+// claudeModalities: text, image, and PDF inputs; text output.
+var claudeModalities = catalog.Modalities{
+	Input:  []catalog.Modality{catalog.ModalityText, catalog.ModalityImage, catalog.ModalityDocument},
+	Output: []catalog.Modality{catalog.ModalityText},
+}
+
+var catalogOnce = sync.OnceValue(func() *catalog.Catalog {
+	return catalog.MustNew(providerName, entries())
+})
+
+// Catalog returns the validated Vertex model catalog: every offering with
+// its capabilities, constraints, modalities, reasoning controls, pricing,
+// and lifecycle. The catalog is immutable and shared; all reads return
+// deep copies.
+func Catalog() *catalog.Catalog {
+	return catalogOnce()
+}
+
+// entries returns the authored Vertex catalog.
+//
+// Rates are USD-per-million-tokens. Every rate here was transcribed from
+// Google's published Vertex pricing (Gemini) and Anthropic's list prices
+// (Claude); re-reading each one against the live pages is an M1 exit
+// condition, because a catalog PR is the last moment a wrong rate costs
+// nothing.
+//
+//   - Google's Vertex Gemini pricing:
+//     https://cloud.google.com/vertex-ai/generative-ai/pricing
+//   - Anthropic pricing: https://platform.claude.com/docs/en/about-claude/pricing
+//
+// Capabilities, constraints, and lifecycle mirror the same models in the
+// Gemini-API and Anthropic-direct catalogs: the model is the same, only
+// the host differs.
+func entries() []catalog.Entry {
+	return []catalog.Entry{
+		{
+			ID:           catalogID(ModelGemini36Flash),
+			Model:        catalog.ModelGemini36Flash,
+			Capabilities: geminiCaps,
+			Modalities:   geminiModalities,
+			Constraints: llm.ModelConstraints{
+				TemperatureRange: [2]float64{0.0, 2.0},
+				MaxInputTokens:   1048576, // 1M input tokens
+				MaxOutputTokens:  65536,   // 64K output tokens
+				SupportedParams:  geminiParams,
+			},
+			Life: catalog.Lifecycle{
+				Available: catalog.MustDate("2026-07-21"),
+			},
+			// On Vertex, Gemini 3.6 Flash bills at the full SKU rate
+			// ($1.50/$7.50, cache $0.15); the introductory discount the
+			// Gemini-API provider tracks arrives on Vertex as credits, not
+			// a lower price, and ends 2026-12-31. A non-global endpoint
+			// bills ~10% above global across the us/eu multi-regions,
+			// expressed as Region overrides rather than separate model
+			// entries.
+			Pricing: geminiFlashPricing(),
+			Attributes: map[string]string{
+				AttrPublisher:   publisherGoogle,
+				AttrVertexModel: ModelGemini36Flash,
+			},
+		},
+		{
+			ID:           catalogID(ModelClaudeSonnet5),
+			Model:        catalog.ModelClaudeSonnet5,
+			Capabilities: claudeCaps,
+			Modalities:   claudeModalities,
+			Constraints: llm.ModelConstraints{
+				TemperatureRange: [2]float64{0.0, 1.0},
+				MaxInputTokens:   1000000, // 1M context window
+				MaxOutputTokens:  128000,  // 128K output tokens
+				SupportedParams:  []string{"temperature", "top_p", "top_k", "max_tokens", "reasoning_effort"},
+			},
+			Reasoning: catalog.ReasoningSupport{
+				Efforts:  []llm.ReasoningEffort{reasoningEffortLow, reasoningEffortMedium, reasoningEffortHigh, reasoningEffortXHigh, reasoningEffortMax},
+				Adaptive: true,
+			},
+			Life: catalog.Lifecycle{
+				Available: catalog.MustDate("2026-06-29"),
+			},
+			// $2/$10 is Sonnet 5's standard list price, cache reads at the
+			// 0.10x multiplier and writes at 1.25x (5m) / 2x (1h). Anthropic
+			// is the one publisher absent from Google's Billing Catalog, so
+			// Claude rates rest on Anthropic's page. There is no Claude
+			// regional premium: the non-global markup is Gemini-only.
+			Pricing: pricing.FlatInfoFromRates(
+				pricing.NewRates(2.00, 10.00, 0.20).WithCacheCreation(2.50, 4.00, 0),
+			),
+			Attributes: map[string]string{
+				AttrPublisher:   publisherAnthropic,
+				AttrVertexModel: ModelClaudeSonnet5,
+			},
+		},
+		{
+			ID:           catalogID(ModelClaudeHaiku45),
+			Model:        catalog.ModelClaudeHaiku45,
+			Capabilities: claudeCaps,
+			Modalities:   claudeModalities,
+			Constraints: llm.ModelConstraints{
+				TemperatureRange: [2]float64{0.0, 1.0},
+				MaxInputTokens:   200000, // 200K context window
+				MaxOutputTokens:  64000,  // 64K output tokens
+				SupportedParams:  []string{"temperature", "top_p", "top_k", "max_tokens"},
+			},
+			Life: catalog.Lifecycle{
+				Available: catalog.MustDate("2025-10-15"),
+			},
+			// $1/$5 standard list price, cache reads 0.10x, writes 1.25x
+			// (5m) / 2x (1h).
+			Pricing: pricing.FlatInfoFromRates(
+				pricing.NewRates(1.00, 5.00, 0.10).WithCacheCreation(1.25, 2.00, 0),
+			),
+			Attributes: map[string]string{
+				AttrPublisher:   publisherAnthropic,
+				AttrVertexModel: ModelClaudeHaiku45,
+			},
+		},
+	}
+}
+
+// geminiFlashPricing builds the Gemini 3.6 Flash rate card: the global
+// rate as the default, and the ~10% higher non-global rate as one
+// Region override per non-global location the model serves. The override
+// set is driven by the availability matrix (locations.go) so the two
+// never drift: a location priced high must be a location the model is
+// actually served at.
+//
+// The override carries the non-global rate (default = global) because an
+// empty-Region override cannot mean "every non-global region" - an empty
+// selector field is a wildcard that would also match global.
+func geminiFlashPricing() pricing.Info {
+	global := pricing.NewRates(1.50, 7.50, 0.15)
+	// The non-global rates ($1.65/$8.25 input/output, $0.165 cache) are the
+	// regional Gemini SKUs Google's Vertex pricing page publishes, verified
+	// against the live page on 2026-09-07: a uniform ~10% markup over the
+	// global rate on input, output, and cache alike.
+	nonGlobal := pricing.NewRates(1.65, 8.25, 0.165)
+
+	info := pricing.FlatInfoFromRates(global)
+	for _, loc := range nonGlobalLocations(ModelGemini36Flash) {
+		info = info.WithOverride(
+			pricing.Selector{Region: loc},
+			pricing.RateCard{Base: nonGlobal},
+		)
+	}
+
+	return info
+}

--- a/providers/vertex/models.go
+++ b/providers/vertex/models.go
@@ -307,15 +307,23 @@ func geminiFlashPricing() pricing.Info {
 
 // claudeSonnet5Pricing builds the Sonnet 5 rate card: the global rate as
 // the default, and the ~10% higher non-global rate as one Region override
-// per served multi-region.
+// per served non-global region.
 //
 // Claude is not flat. Google's Agent Platform pricing page groups Sonnet 5
 // under "Models with regional pricing" and publishes every non-global rate
 // at exactly global x 1.10 - input, output, cache write, and cache read
-// alike. Rates below read from the page's region tabs on 2026-09-08.
+// alike. The us and eu rates below read from the page's region tabs on
+// 2026-09-08.
 //
-// The override regions are Sonnet's served multi-regions (locations.go), so
-// TestClaudeRegionalOverride can guard that every priced region is served,
+// asia-southeast1 is a served non-global region (locations.go) with its
+// own tab on the pricing page. That tab carries the standard non-global
+// rate - global x 1.10, the same premium as the us and eu multi-regions,
+// flat across the page's =< 200K and > 200K input tiers - confirmed on the
+// tab on 2026-09-08. It is not a special APAC rate, so a customer calling
+// there is billed the same non-global premium as one calling us or eu.
+//
+// The override regions are Sonnet's served non-global regions (locations.go),
+// so TestClaudeRegionalOverride can guard that every priced region is served,
 // the same invariant Gemini carries. Anthropic is absent from Google's
 // Billing Catalog, so this page is the authoritative source, not the SKU
 // API.
@@ -324,7 +332,7 @@ func claudeSonnet5Pricing() pricing.Info {
 	nonGlobal := pricing.NewRates(2.20, 11.00, 0.22).WithCacheCreation(2.75, 4.40, 0)
 
 	info := pricing.FlatInfoFromRates(global)
-	for _, region := range []string{"us", "eu"} {
+	for _, region := range []string{"us", "eu", "asia-southeast1"} {
 		info = info.WithOverride(
 			pricing.Selector{Region: region},
 			pricing.RateCard{Base: nonGlobal},
@@ -338,17 +346,21 @@ func claudeSonnet5Pricing() pricing.Info {
 // the default, and the ~10% non-global premium as one Region override per
 // served named region.
 //
-// Same shape as Sonnet, rates below read from the Agent Platform pricing
-// page's region tabs on 2026-09-08.
+// Same shape as Sonnet. The us-east5 and europe-west1 rates below read from
+// the Agent Platform pricing page's region tabs on 2026-09-08.
 //
-// Haiku's served named regions are us-east5 and europe-west1 (locations.go),
-// which are exactly the regions the page prices at the premium.
+// asia-east1 is a served named region (locations.go) with its own tab on
+// the pricing page. Haiku 4.5 is a line item on that tab at input $1.10,
+// output $5.50, cache hit $0.11, and cache write $1.375 (5m) / $2.20 (1h) -
+// exactly global x 1.10 and flat across the page's =< 200K and > 200K input
+// tiers, matching the nonGlobal rate below, read from the tab on 2026-09-08.
+// It is the same non-global premium the us-east5 and europe-west1 tabs carry.
 func claudeHaiku45Pricing() pricing.Info {
 	global := pricing.NewRates(1.00, 5.00, 0.10).WithCacheCreation(1.25, 2.00, 0)
 	nonGlobal := pricing.NewRates(1.10, 5.50, 0.11).WithCacheCreation(1.375, 2.20, 0)
 
 	info := pricing.FlatInfoFromRates(global)
-	for _, region := range []string{"us-east5", "europe-west1"} {
+	for _, region := range []string{"us-east5", "europe-west1", "asia-east1"} {
 		info = info.WithOverride(
 			pricing.Selector{Region: region},
 			pricing.RateCard{Base: nonGlobal},

--- a/providers/vertex/models.go
+++ b/providers/vertex/models.go
@@ -178,14 +178,21 @@ func Catalog() *catalog.Catalog {
 // entries returns the authored Vertex catalog.
 //
 // Rates are USD-per-million-tokens. Every rate here was transcribed from
-// Google's published Vertex pricing (Gemini) and Anthropic's list prices
-// (Claude); re-reading each one against the live pages is an M1 exit
-// condition, because a catalog PR is the last moment a wrong rate costs
-// nothing.
+// Google's published Vertex pricing; re-reading each one against the live
+// pages is an M1 exit condition, because a catalog PR is the last moment a
+// wrong rate costs nothing.
 //
 //   - Google's Vertex Gemini pricing:
 //     https://cloud.google.com/vertex-ai/generative-ai/pricing
-//   - Anthropic pricing: https://platform.claude.com/docs/en/about-claude/pricing
+//   - Google's Agent Platform pricing (Claude on Vertex, with the region
+//     selector that carries the per-region rates):
+//     https://cloud.google.com/gemini-enterprise-agent-platform/generative-ai/pricing
+//
+// Claude rates come from Google's own page, not Anthropic's list prices:
+// Vertex sets its own Claude rates (including a ~10% non-global premium
+// Anthropic-direct does not have), and Anthropic is the one publisher with
+// no SKUs in Google's Billing Catalog, so the Agent Platform page is the
+// authoritative source.
 //
 // Capabilities, constraints, and lifecycle mirror the same models in the
 // Gemini-API and Anthropic-direct catalogs: the model is the same, only
@@ -239,14 +246,15 @@ func entries() []catalog.Entry {
 			Life: catalog.Lifecycle{
 				Available: catalog.MustDate("2026-06-29"),
 			},
-			// $2/$10 is Sonnet 5's standard list price, cache reads at the
-			// 0.10x multiplier and writes at 1.25x (5m) / 2x (1h). Anthropic
-			// is the one publisher absent from Google's Billing Catalog, so
-			// Claude rates rest on Anthropic's page. There is no Claude
-			// regional premium: the non-global markup is Gemini-only.
-			Pricing: pricing.FlatInfoFromRates(
-				pricing.NewRates(2.00, 10.00, 0.20).WithCacheCreation(2.50, 4.00, 0),
-			),
+			// $2/$10 is Sonnet 5's global list price, cache reads at the
+			// 0.10x multiplier and writes at 1.25x (5m) / 2x (1h). A
+			// non-global endpoint bills ~10% above global, the same premium
+			// Gemini carries, expressed as Region overrides on the served
+			// multi-regions. Anthropic is the one publisher absent from
+			// Google's Billing Catalog, so Claude rates rest on Google's
+			// Agent Platform pricing page, verified 2026-09-08 (see
+			// claudeSonnet5Pricing).
+			Pricing: claudeSonnet5Pricing(),
 			Attributes: map[string]string{
 				AttrPublisher:   publisherAnthropic,
 				AttrVertexModel: ModelClaudeSonnet5,
@@ -266,11 +274,10 @@ func entries() []catalog.Entry {
 			Life: catalog.Lifecycle{
 				Available: catalog.MustDate("2025-10-15"),
 			},
-			// $1/$5 standard list price, cache reads 0.10x, writes 1.25x
-			// (5m) / 2x (1h).
-			Pricing: pricing.FlatInfoFromRates(
-				pricing.NewRates(1.00, 5.00, 0.10).WithCacheCreation(1.25, 2.00, 0),
-			),
+			// $1/$5 global list price, cache reads 0.10x, writes 1.25x
+			// (5m) / 2x (1h), with the same ~10% non-global premium as
+			// Sonnet on the served named regions (see claudeHaiku45Pricing).
+			Pricing: claudeHaiku45Pricing(),
 			Attributes: map[string]string{
 				AttrPublisher:   publisherAnthropic,
 				AttrVertexModel: ModelClaudeHaiku45,
@@ -304,6 +311,65 @@ func geminiFlashPricing() pricing.Info {
 
 	info := pricing.FlatInfoFromRates(global)
 	for _, region := range []string{"us", "eu"} {
+		info = info.WithOverride(
+			pricing.Selector{Region: region},
+			pricing.RateCard{Base: nonGlobal},
+		)
+	}
+
+	return info
+}
+
+// claudeSonnet5Pricing builds the Sonnet 5 rate card: the global rate as
+// the default, and the ~10% higher non-global rate as one Region override
+// per served multi-region.
+//
+// Claude is not flat. Google's Agent Platform pricing page groups Sonnet 5
+// under "Models with regional pricing" and publishes every non-global rate
+// at exactly global x 1.10 - input, output, cache write, and cache read
+// alike. Read from the page's region tabs on 2026-09-08:
+//
+//	Global:  in $2.00, out $10.00, 5m write $2.50, 1h write $4.00, hit $0.20
+//	US / EU: in $2.20, out $11.00, 5m write $2.75, 1h write $4.40, hit $0.22
+//
+// The override regions are Sonnet's served multi-regions (locations.go), so
+// TestClaudeRegionalOverride can guard that every priced region is served,
+// the same invariant Gemini carries. Anthropic is absent from Google's
+// Billing Catalog, so this page is the authoritative source, not the SKU
+// API.
+func claudeSonnet5Pricing() pricing.Info {
+	global := pricing.NewRates(2.00, 10.00, 0.20).WithCacheCreation(2.50, 4.00, 0)
+	nonGlobal := pricing.NewRates(2.20, 11.00, 0.22).WithCacheCreation(2.75, 4.40, 0)
+
+	info := pricing.FlatInfoFromRates(global)
+	for _, region := range []string{"us", "eu"} {
+		info = info.WithOverride(
+			pricing.Selector{Region: region},
+			pricing.RateCard{Base: nonGlobal},
+		)
+	}
+
+	return info
+}
+
+// claudeHaiku45Pricing builds the Haiku 4.5 rate card: the global rate as
+// the default, and the ~10% non-global premium as one Region override per
+// served named region.
+//
+// Same shape as Sonnet. From the Agent Platform pricing page's region tabs
+// on 2026-09-08:
+//
+//	Global:               in $1.00, out $5.00, 5m write $1.25, 1h write $2.00, hit $0.10
+//	us-east5/europe-west1: in $1.10, out $5.50, 5m write $1.375, 1h write $2.20, hit $0.11
+//
+// Haiku's served named regions are us-east5 and europe-west1 (locations.go),
+// which are exactly the regions the page prices at the premium.
+func claudeHaiku45Pricing() pricing.Info {
+	global := pricing.NewRates(1.00, 5.00, 0.10).WithCacheCreation(1.25, 2.00, 0)
+	nonGlobal := pricing.NewRates(1.10, 5.50, 0.11).WithCacheCreation(1.375, 2.20, 0)
+
+	info := pricing.FlatInfoFromRates(global)
+	for _, region := range []string{"us-east5", "europe-west1"} {
 		info = info.WithOverride(
 			pricing.Selector{Region: region},
 			pricing.RateCard{Base: nonGlobal},

--- a/providers/vertex/models_test.go
+++ b/providers/vertex/models_test.go
@@ -113,9 +113,9 @@ func TestGeminiRegionalOverride(t *testing.T) {
 	info, ok := vertex.Catalog().PricingByID()[offeringGemini36Flash]
 	require.True(t, ok, "no pricing for %s", offeringGemini36Flash)
 
-	assert.Equal(t, pricing.NewRates(1.50, 7.50, 0.15), info.Default.Base, "global default rate")
+	assert.Equal(t, pricing.NewRates(0.75, 3.75, 0.075), info.Default.Base, "global default rate")
 
-	wantRegional := pricing.NewRates(1.65, 8.25, 0.165)
+	wantRegional := pricing.NewRates(0.825, 4.125, 0.0825)
 
 	served := vertex.LocationsForModel(vertex.ModelGemini36Flash)
 	require.NotEmpty(t, served, "expected served locations for Gemini")

--- a/providers/vertex/models_test.go
+++ b/providers/vertex/models_test.go
@@ -168,6 +168,7 @@ func TestClaudeRegionalOverride(t *testing.T) {
 		require.NotEmptyf(t, served, "expected served locations for %s", id)
 
 		require.NotEmptyf(t, info.Overrides, "%s must carry a non-global rate override", id)
+
 		for _, ov := range info.Overrides {
 			require.NotEmptyf(t, ov.Match.Region, "%s override has empty Region (would also match global): %+v", id, ov.Match)
 			assert.Equalf(t, want.regional, ov.RateCard.Base, "%s region %q rate", id, ov.Match.Region)

--- a/providers/vertex/models_test.go
+++ b/providers/vertex/models_test.go
@@ -140,8 +140,8 @@ func TestGeminiRegionalOverride(t *testing.T) {
 // exact non-global rate, and the guard direction that matters: every priced
 // region is a served location, and the override region is non-global. The
 // two models differ in which regions carry the premium - Sonnet on the
-// us/eu multi-regions, Haiku on us-east5/europe-west1 - so each is checked
-// against its own served set.
+// us/eu multi-regions plus asia-southeast1, Haiku on us-east5/europe-west1
+// plus asia-east1 - so each is checked against its own served set.
 func TestClaudeRegionalOverride(t *testing.T) {
 	t.Parallel()
 

--- a/providers/vertex/models_test.go
+++ b/providers/vertex/models_test.go
@@ -1,0 +1,151 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vertex_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/redpanda-data/ai-sdk-go/pricing"
+	"github.com/redpanda-data/ai-sdk-go/providers/vertex"
+)
+
+const (
+	offeringGemini36Flash = "vertex.gemini-3.6-flash"
+	offeringClaudeSonnet5 = "vertex.claude-sonnet-5"
+	offeringClaudeHaiku45 = "vertex.claude-haiku-4-5"
+)
+
+// TestCatalogBuildsWithDayOneModels pins the day-one catalog to exactly
+// the Gemini + Claude scope: three offerings, each namespaced vertex.*.
+func TestCatalogBuildsWithDayOneModels(t *testing.T) {
+	t.Parallel()
+
+	cat := vertex.Catalog()
+	require.NotNil(t, cat)
+
+	got := make([]string, 0, cat.Len())
+	for _, o := range cat.All() {
+		got = append(got, o.ID)
+	}
+
+	assert.ElementsMatch(t, []string{offeringGemini36Flash, offeringClaudeSonnet5, offeringClaudeHaiku45}, got)
+}
+
+// TestOfferingAttributes checks every offering carries the publisher and
+// the bare wire model, and that the bare model is the offering ID minus
+// the vertex. prefix. The runtime provider builds the request path from
+// these, so a missing or drifted value is a routing bug.
+func TestOfferingAttributes(t *testing.T) {
+	t.Parallel()
+
+	wantPublisher := map[string]string{
+		offeringGemini36Flash: "google",
+		offeringClaudeSonnet5: "anthropic",
+		offeringClaudeHaiku45: "anthropic",
+	}
+
+	for _, o := range vertex.Catalog().All() {
+		assert.Equalf(t, wantPublisher[o.ID], o.Attributes[vertex.AttrPublisher], "%s publisher", o.ID)
+		assert.Equalf(t, strings.TrimPrefix(o.ID, "vertex."), o.Attributes[vertex.AttrVertexModel], "%s vertex_model", o.ID)
+	}
+}
+
+// TestNoBarePricingKey is the collision guard. A merged pricing catalog
+// rejects two providers registering the same model ID, so every Vertex
+// pricing key must be namespaced and no bare publisher ID (or alias for
+// one) may leak in.
+func TestNoBarePricingKey(t *testing.T) {
+	t.Parallel()
+
+	for id := range vertex.Catalog().PricingByID() {
+		assert.Truef(t, strings.HasPrefix(id, "vertex."), "pricing key %q is not namespaced with the vertex. prefix", id)
+	}
+}
+
+// TestGeminiRegionalOverride checks the one interface-shaped requirement:
+// the non-global Gemini rate is a Region override on the global default,
+// not a separate model entry. The override set must cover exactly the
+// non-global locations the model is served at, so pricing and
+// availability never disagree.
+func TestGeminiRegionalOverride(t *testing.T) {
+	t.Parallel()
+
+	info, ok := vertex.Catalog().PricingByID()[offeringGemini36Flash]
+	require.True(t, ok, "no pricing for %s", offeringGemini36Flash)
+
+	assert.Equal(t, pricing.NewRates(1.50, 7.50, 0.15), info.Default.Base, "global default rate")
+
+	wantRegional := pricing.NewRates(1.65, 8.25, 0.165)
+
+	// Every non-global served location gets one override at the regional
+	// rate, and nothing else does.
+	var wantRegions []string
+
+	for _, loc := range vertex.LocationsForModel(vertex.ModelGemini36Flash) {
+		if loc != vertex.LocationGlobal {
+			wantRegions = append(wantRegions, loc)
+		}
+	}
+
+	require.NotEmpty(t, wantRegions, "expected at least one non-global Gemini location to override")
+
+	gotRegions := make([]string, 0, len(info.Overrides))
+	for _, ov := range info.Overrides {
+		require.NotEmptyf(t, ov.Match.Region, "override has empty Region (would also match global): %+v", ov.Match)
+		assert.Equalf(t, wantRegional, ov.RateCard.Base, "region %q rate", ov.Match.Region)
+		gotRegions = append(gotRegions, ov.Match.Region)
+	}
+
+	assert.ElementsMatch(t, wantRegions, gotRegions, "override regions must equal the non-global served locations")
+}
+
+// TestClaudeFlatPricing checks the Claude rates and that Claude carries no
+// regional premium: the non-global markup is a Gemini-only fact.
+func TestClaudeFlatPricing(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]pricing.Rates{
+		offeringClaudeSonnet5: pricing.NewRates(2.00, 10.00, 0.20).WithCacheCreation(2.50, 4.00, 0),
+		offeringClaudeHaiku45: pricing.NewRates(1.00, 5.00, 0.10).WithCacheCreation(1.25, 2.00, 0),
+	}
+
+	prices := vertex.Catalog().PricingByID()
+	for id, want := range cases {
+		info, ok := prices[id]
+		require.Truef(t, ok, "no pricing for %s", id)
+		assert.Equalf(t, want, info.Default.Base, "%s base rate", id)
+		assert.Emptyf(t, info.Overrides, "%s must have no region overrides (Claude has no regional premium)", id)
+	}
+}
+
+// TestEveryOfferingHasLocations guards entries() against servedLocations.
+// The two are independent literals: an offering added to entries() but
+// missing from servedLocations would silently price global-only and read
+// unavailable at every location, with no build or existing test failing.
+// Every offering must have a non-empty location set that includes global.
+func TestEveryOfferingHasLocations(t *testing.T) {
+	t.Parallel()
+
+	for _, o := range vertex.Catalog().All() {
+		bare := o.Attributes[vertex.AttrVertexModel]
+		locs := vertex.LocationsForModel(bare)
+		require.NotEmptyf(t, locs, "%s has no servedLocations row for %q", o.ID, bare)
+		assert.Containsf(t, locs, vertex.LocationGlobal, "%s must be served at global", o.ID)
+	}
+}

--- a/providers/vertex/models_test.go
+++ b/providers/vertex/models_test.go
@@ -130,22 +130,50 @@ func TestGeminiRegionalOverride(t *testing.T) {
 	}
 }
 
-// TestClaudeFlatPricing checks the Claude rates and that Claude carries no
-// regional premium: the non-global markup is a Gemini-only fact.
-func TestClaudeFlatPricing(t *testing.T) {
+// TestClaudeRegionalOverride checks the Claude rates and that Claude
+// carries the same ~10% non-global premium Gemini does. Google's Agent
+// Platform pricing page groups Sonnet 5 and Haiku 4.5 under "Models with
+// regional pricing" and publishes every non-global rate at exactly global
+// x 1.10 (read from the page's region tabs on 2026-09-08).
+//
+// Like TestGeminiRegionalOverride, it asserts the global default rate, the
+// exact non-global rate, and the guard direction that matters: every priced
+// region is a served location, and the override region is non-global. The
+// two models differ in which regions carry the premium - Sonnet on the
+// us/eu multi-regions, Haiku on us-east5/europe-west1 - so each is checked
+// against its own served set.
+func TestClaudeRegionalOverride(t *testing.T) {
 	t.Parallel()
 
-	cases := map[string]pricing.Rates{
-		offeringClaudeSonnet5: pricing.NewRates(2.00, 10.00, 0.20).WithCacheCreation(2.50, 4.00, 0),
-		offeringClaudeHaiku45: pricing.NewRates(1.00, 5.00, 0.10).WithCacheCreation(1.25, 2.00, 0),
+	cases := map[string]struct {
+		global, regional pricing.Rates
+	}{
+		offeringClaudeSonnet5: {
+			global:   pricing.NewRates(2.00, 10.00, 0.20).WithCacheCreation(2.50, 4.00, 0),
+			regional: pricing.NewRates(2.20, 11.00, 0.22).WithCacheCreation(2.75, 4.40, 0),
+		},
+		offeringClaudeHaiku45: {
+			global:   pricing.NewRates(1.00, 5.00, 0.10).WithCacheCreation(1.25, 2.00, 0),
+			regional: pricing.NewRates(1.10, 5.50, 0.11).WithCacheCreation(1.375, 2.20, 0),
+		},
 	}
 
 	prices := vertex.Catalog().PricingByID()
 	for id, want := range cases {
 		info, ok := prices[id]
 		require.Truef(t, ok, "no pricing for %s", id)
-		assert.Equalf(t, want, info.Default.Base, "%s base rate", id)
-		assert.Emptyf(t, info.Overrides, "%s must have no region overrides (Claude has no regional premium)", id)
+		assert.Equalf(t, want.global, info.Default.Base, "%s global default rate", id)
+
+		served := vertex.LocationsForModel(id)
+		require.NotEmptyf(t, served, "expected served locations for %s", id)
+
+		require.NotEmptyf(t, info.Overrides, "%s must carry a non-global rate override", id)
+		for _, ov := range info.Overrides {
+			require.NotEmptyf(t, ov.Match.Region, "%s override has empty Region (would also match global): %+v", id, ov.Match)
+			assert.Equalf(t, want.regional, ov.RateCard.Base, "%s region %q rate", id, ov.Match.Region)
+			assert.Containsf(t, served, ov.Match.Region, "%s priced region %q is not a served location", id, ov.Match.Region)
+			assert.NotEqualf(t, vertex.LocationGlobal, ov.Match.Region, "%s override region must be non-global", id)
+		}
 	}
 }
 

--- a/providers/vertex/models_test.go
+++ b/providers/vertex/models_test.go
@@ -47,6 +47,25 @@ func TestCatalogBuildsWithDayOneModels(t *testing.T) {
 	assert.ElementsMatch(t, []string{offeringGemini36Flash, offeringClaudeSonnet5, offeringClaudeHaiku45}, got)
 }
 
+// TestOfferingForModel checks the bridge that lets a caller holding a bare
+// publisher model ID reach the namespaced offering, and that passing the
+// already-namespaced ID resolves to the same entry. An unknown model
+// returns ok false.
+func TestOfferingForModel(t *testing.T) {
+	t.Parallel()
+
+	bare, ok := vertex.OfferingForModel(vertex.ModelClaudeSonnet5)
+	require.True(t, ok, "bare model %q should resolve", vertex.ModelClaudeSonnet5)
+	assert.Equal(t, offeringClaudeSonnet5, bare.ID)
+
+	prefixed, ok := vertex.OfferingForModel(offeringClaudeSonnet5)
+	require.True(t, ok, "namespaced id %q should resolve", offeringClaudeSonnet5)
+	assert.Equal(t, offeringClaudeSonnet5, prefixed.ID)
+
+	_, ok = vertex.OfferingForModel("gemini-99-ultra")
+	assert.False(t, ok, "unknown model must not resolve")
+}
+
 // TestOfferingAttributes checks every offering carries the publisher and
 // the bare wire model, and that the bare model is the offering ID minus
 // the vertex. prefix. The runtime provider builds the request path from
@@ -80,9 +99,14 @@ func TestNoBarePricingKey(t *testing.T) {
 
 // TestGeminiRegionalOverride checks the one interface-shaped requirement:
 // the non-global Gemini rate is a Region override on the global default,
-// not a separate model entry. The override set must cover exactly the
-// non-global locations the model is served at, so pricing and
-// availability never disagree.
+// not a separate model entry.
+//
+// Priced regions and served locations are separate facts, so this does not
+// assert the two sets are equal. It asserts the guard direction that
+// matters: every priced region must be a served location (a price at a
+// location the model is not served would be dead), and at least one
+// override must exist at the regional rate. A served location with no
+// override simply falls back to the global default, which is intended.
 func TestGeminiRegionalOverride(t *testing.T) {
 	t.Parallel()
 
@@ -93,26 +117,17 @@ func TestGeminiRegionalOverride(t *testing.T) {
 
 	wantRegional := pricing.NewRates(1.65, 8.25, 0.165)
 
-	// Every non-global served location gets one override at the regional
-	// rate, and nothing else does.
-	var wantRegions []string
+	served := vertex.LocationsForModel(vertex.ModelGemini36Flash)
+	require.NotEmpty(t, served, "expected served locations for Gemini")
 
-	for _, loc := range vertex.LocationsForModel(vertex.ModelGemini36Flash) {
-		if loc != vertex.LocationGlobal {
-			wantRegions = append(wantRegions, loc)
-		}
-	}
+	require.NotEmpty(t, info.Overrides, "expected at least one non-global Gemini rate override")
 
-	require.NotEmpty(t, wantRegions, "expected at least one non-global Gemini location to override")
-
-	gotRegions := make([]string, 0, len(info.Overrides))
 	for _, ov := range info.Overrides {
 		require.NotEmptyf(t, ov.Match.Region, "override has empty Region (would also match global): %+v", ov.Match)
 		assert.Equalf(t, wantRegional, ov.RateCard.Base, "region %q rate", ov.Match.Region)
-		gotRegions = append(gotRegions, ov.Match.Region)
+		assert.Containsf(t, served, ov.Match.Region, "priced region %q is not a served location", ov.Match.Region)
+		assert.NotEqualf(t, vertex.LocationGlobal, ov.Match.Region, "override region must be non-global")
 	}
-
-	assert.ElementsMatch(t, wantRegions, gotRegions, "override regions must equal the non-global served locations")
 }
 
 // TestClaudeFlatPricing checks the Claude rates and that Claude carries no

--- a/providers/vertex/provider.go
+++ b/providers/vertex/provider.go
@@ -32,12 +32,12 @@ type Provider struct{}
 
 var _ catalog.Provider = (*Provider)(nil)
 
-// NewProvider returns the Vertex provider. ctx is unused today and the
-// returned error is always nil; the (context.Context) (*Provider, error)
-// shape matches the sibling providers and reserves room for the transport
-// milestone (RFC-0014 M8), which will load credentials at construction
-// under the caller's context.
-func NewProvider(ctx context.Context) (*Provider, error) {
+// NewProvider returns the Vertex provider. The context argument is unused
+// today and the returned error is always nil. The (context.Context)
+// (*Provider, error) shape matches the sibling providers and reserves room
+// for the transport milestone (RFC-0014 M8), which will load credentials at
+// construction under the caller's context.
+func NewProvider(_ context.Context) (*Provider, error) {
 	return &Provider{}, nil
 }
 

--- a/providers/vertex/provider.go
+++ b/providers/vertex/provider.go
@@ -1,0 +1,48 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vertex
+
+import "github.com/redpanda-data/ai-sdk-go/catalog"
+
+// Provider is the Google Vertex AI provider's catalog surface: its name
+// and its validated model catalog. It satisfies catalog.Provider, which
+// is what the spending pipeline and the catalog snapshot consume.
+//
+// It carries no request transport yet. Constructing Vertex requests is a
+// later milestone (RFC-0014 M8); until then the provider contributes its
+// catalog and rates, and the AI Gateway forwards the customer's own
+// native Vertex requests.
+type Provider struct{}
+
+var _ catalog.Provider = (*Provider)(nil)
+
+// NewProvider returns the Vertex provider. The returned error is always
+// nil today. The (*Provider, error) shape matches the sibling providers
+// and reserves room for the transport milestone (RFC-0014 M8), which will
+// load credentials at construction.
+func NewProvider() (*Provider, error) {
+	return &Provider{}, nil
+}
+
+// Name returns the provider identifier used in offerings and telemetry.
+func (*Provider) Name() string {
+	return providerName
+}
+
+// Catalog implements catalog.Provider: the validated Vertex model
+// catalog, including pricing and lifecycle metadata.
+func (*Provider) Catalog() *catalog.Catalog {
+	return Catalog()
+}

--- a/providers/vertex/provider.go
+++ b/providers/vertex/provider.go
@@ -14,7 +14,11 @@
 
 package vertex
 
-import "github.com/redpanda-data/ai-sdk-go/catalog"
+import (
+	"context"
+
+	"github.com/redpanda-data/ai-sdk-go/catalog"
+)
 
 // Provider is the Google Vertex AI provider's catalog surface: its name
 // and its validated model catalog. It satisfies catalog.Provider, which
@@ -28,11 +32,12 @@ type Provider struct{}
 
 var _ catalog.Provider = (*Provider)(nil)
 
-// NewProvider returns the Vertex provider. The returned error is always
-// nil today. The (*Provider, error) shape matches the sibling providers
-// and reserves room for the transport milestone (RFC-0014 M8), which will
-// load credentials at construction.
-func NewProvider() (*Provider, error) {
+// NewProvider returns the Vertex provider. ctx is unused today and the
+// returned error is always nil; the (context.Context) (*Provider, error)
+// shape matches the sibling providers and reserves room for the transport
+// milestone (RFC-0014 M8), which will load credentials at construction
+// under the caller's context.
+func NewProvider(ctx context.Context) (*Provider, error) {
 	return &Provider{}, nil
 }
 

--- a/providers/vertex/provider_test.go
+++ b/providers/vertex/provider_test.go
@@ -15,6 +15,7 @@
 package vertex_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -26,7 +27,7 @@ import (
 func TestProviderName(t *testing.T) {
 	t.Parallel()
 
-	p, err := vertex.NewProvider()
+	p, err := vertex.NewProvider(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, "gcp.vertex", p.Name())
 }
@@ -37,7 +38,7 @@ func TestProviderName(t *testing.T) {
 func TestProviderCatalog(t *testing.T) {
 	t.Parallel()
 
-	p, err := vertex.NewProvider()
+	p, err := vertex.NewProvider(context.Background())
 	require.NoError(t, err)
 	assert.Same(t, vertex.Catalog(), p.Catalog())
 }

--- a/providers/vertex/provider_test.go
+++ b/providers/vertex/provider_test.go
@@ -1,0 +1,43 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vertex_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/redpanda-data/ai-sdk-go/providers/vertex"
+)
+
+func TestProviderName(t *testing.T) {
+	t.Parallel()
+
+	p, err := vertex.NewProvider()
+	require.NoError(t, err)
+	assert.Equal(t, "gcp.vertex", p.Name())
+}
+
+// TestProviderCatalog checks the provider surfaces the same catalog the
+// package builds, so a consumer holding the provider and one calling the
+// package function see identical offerings.
+func TestProviderCatalog(t *testing.T) {
+	t.Parallel()
+
+	p, err := vertex.NewProvider()
+	require.NoError(t, err)
+	assert.Same(t, vertex.Catalog(), p.Catalog())
+}


### PR DESCRIPTION
## Summary

- Adds `providers/vertex`, the Google Vertex AI model catalog: the day-one Gemini and Claude models, their rates, and which model is served at which location. This is [RFC-0014](https://github.com/redpanda-data/cloudv2/blob/main/apps/aigw/docs/rfcs/0014-vertex-ai-provider.md) [milestone M1](https://github.com/redpanda-data/cloudv2/blob/main/apps/aigw/docs/rfcs/0014-vertex-ai-provider.md#-milestones), the catalog half that every later Vertex milestone builds on.
- Data only. It sends no request to Vertex and mints no token. The gateway prices Vertex traffic from this catalog, so Vertex spend prices at $0 until this package is published and pinned.

## Scope

Public surface of the new package:

```
vertex/  (catalog half, M1)
├─ provider.go   Provider -> catalog.Provider (Name, Catalog)
├─ models.go     Catalog(), OfferingForModel(), Model*/Attr* consts,
│                geminiFlashPricing / claudeSonnet5Pricing / claudeHaiku45Pricing
└─ locations.go  IsModelAvailableAtLocation(), LocationsForModel()
```

Also wires the Vertex catalog into the snapshot generator (`cmd/catalog-snapshot`) and regenerates `catalog/snapshot.json`, the checked-in copy a test keeps in sync.

## Out of Scope

- **Runtime request transport and credential loading.** Routing Gemini and Claude requests through the gateway is [AI-2027](https://redpandadata.atlassian.net/browse/AI-2027), GCP credential resolution is [AI-2019](https://redpandadata.atlassian.net/browse/AI-2019), managed-agent request building is [AI-2031](https://redpandadata.atlassian.net/browse/AI-2031).
- **The APAC locations.** `claude-sonnet-5` at `asia-southeast1` and `claude-haiku-4-5` at `asia-east1` are out of this catalog's global + US + EU scope, shown as `429` / `not pub.` in the availability matrix below and noted in the `servedLocations` comment.

## Acceptance Criteria

From [AI-2016](https://redpandadata.atlassian.net/browse/AI-2016):

1. `providers/vertex/` exists on `origin/main` and `Catalog().All()` returns the full Gemini and Claude offering list.
2. `Catalog().PricingByID()` returns a rate for every offering, with the non-global Gemini rate expressed as a `Selector.Region` override rather than a separate model entry.
3. The location-availability helper answers, for a model and a location, whether Google publishes that pair, and carries the matrix source URL and the transcription date.
4. The conformance and integration suites pass in CI on `origin/main`.
5. A pseudo-version is published and its exact version string is recorded in a comment on this issue.
6. Every rate in the catalog was compared against Google's published Vertex rates, and the comparison is recorded in a comment on this issue.

## Implementation details

### The `vertex.` key prefix

On Vertex a model keeps its publisher's bare ID, so `claude-sonnet-5` is byte-for-byte the same string the Anthropic-direct catalog already uses. A merged pricing catalog needs unique keys, so each Vertex offering registers under a namespaced key, `vertex.claude-sonnet-5`.

The bare ID (`claude-sonnet-5`) and the publisher (`anthropic`) are not thrown away: they are stored as fields on the offering, the `Attr*` attributes, so a caller can still find and label the model by its bare ID. They are deliberately not registered as a second catalog key. A `claude-sonnet-5` alias entry would collide with the Anthropic-direct entry all over again, which is the exact collision the prefix exists to avoid.

```mermaid
flowchart LR
  A["anthropic-direct entry<br/>key: claude-sonnet-5"] --> M{merged pricing catalog<br/>keys must be unique}
  V1["vertex offering<br/>key: vertex.claude-sonnet-5"] --> M
  V1 --- N["bare ID + publisher stored<br/>as Attr* fields on the offering<br/>(not a second catalog key)"]
  V0["a claude-sonnet-5 alias key<br/>would re-collide with A"] -. avoided .-> M
```

### Model catalog and pricing

Rates are USD per million tokens, read from Google's one platform pricing page (the region tabs) on 2026-09-08. Every non-global rate is exactly global x 1.10.

| Model | Scope | Input | Output | Cache read | Cache-creation (5m / 1h) |
|---|---|---|---|---|---|
| gemini-3.6-flash | global | 0.75 | 3.75 | 0.075 | - |
| | us, eu | 0.825 | 4.125 | 0.0825 | - |
| claude-sonnet-5 | global | 2.00 | 10.00 | 0.20 | 2.50 / 4.00 |
| | us, eu | 2.20 | 11.00 | 0.22 | 2.75 / 4.40 |
| claude-haiku-4-5 | global | 1.00 | 5.00 | 0.10 | 1.25 / 2.00 |
| | us-east5, europe-west1 | 1.10 | 5.50 | 0.11 | 1.375 / 2.20 |

**Where each model is served** (published by Google and pay-as-you-go callable):

| Model | global | us | eu | us-east5 | europe-west1 | asia-southeast1 | asia-east1 |
|---|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
| gemini-3.6-flash | Y | Y | Y | - | - | - | - |
| claude-sonnet-5 | Y | Y | Y | - | - | 429 | - |
| claude-haiku-4-5 | Y | - | - | Y | Y | 429 | not pub. |

`Y` served, `-` not published, `429` published but no pay-as-you-go allocation (refused, left out of the catalog). Priced regions and served locations are separate facts: the only invariant is that every priced region must be a served location, guarded by `TestGeminiRegionalOverride` / `TestClaudeRegionalOverride`.

## How to Verify

Run from the repo root - it pins its own Go toolchain:

```bash
task test
task lint
```

## Related Resources

- Design: [RFC-0014 Vertex AI provider](https://github.com/redpanda-data/cloudv2/blob/main/apps/aigw/docs/rfcs/0014-vertex-ai-provider.md), [milestone M1](https://github.com/redpanda-data/cloudv2/blob/main/apps/aigw/docs/rfcs/0014-vertex-ai-provider.md#-milestones).
- This work item: [AI-2016](https://redpandadata.atlassian.net/browse/AI-2016) - ai-sdk-go: add the Vertex provider package with its model catalog and rates.
- Parent: [AI-1943](https://redpandadata.atlassian.net/browse/AI-1943) - LLM Provider: VertexAI.

[AI-2016]: https://redpandadata.atlassian.net/browse/AI-2016?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


[AI-2027]: https://redpandadata.atlassian.net/browse/AI-2027?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ