### PR TITLE
fix: low-cardinality error.type on spans, no doubled "API call failed" prefix

### DIFF
--- a/llm/errors.go
+++ b/llm/errors.go
@@ -106,6 +106,20 @@ type ProviderError struct {
 	Retryable bool
 }
 
+// WrapAPICall marks err as an API-call failure so errors.Is(err, ErrAPICall)
+// holds for callers that only check the category, while keeping the specific
+// classification (rate limit, context overflow, ...) reachable with errors.Is
+// too. A classified error whose category already is ErrAPICall — a
+// *ProviderError for a 401/403 — is returned as is: wrapping it again would
+// repeat the "API call failed" prefix in the message.
+func WrapAPICall(err error) error {
+	if err == nil || errors.Is(err, ErrAPICall) {
+		return err
+	}
+
+	return fmt.Errorf("%w: %w", ErrAPICall, err)
+}
+
 // IsRetryable checks if an error represents a transient condition that may
 // succeed on retry. It works through error wrapping chains.
 //

--- a/llm/errors_wrap_test.go
+++ b/llm/errors_wrap_test.go
@@ -1,0 +1,66 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package llm
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWrapAPICall(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		err     error
+		wantMsg string
+	}{
+		{
+			name:    "already an API-call failure is not wrapped again",
+			err:     &ProviderError{Base: ErrAPICall, Code: "guardrail_intervened", Message: "blocked"},
+			wantMsg: "API call failed: [guardrail_intervened] blocked",
+		},
+		{
+			name:    "other classifications gain the category prefix once",
+			err:     &ProviderError{Base: ErrRateLimitExceeded, Code: "rate_limit_exceeded", Message: "slow down"},
+			wantMsg: "API call failed: rate limit exceeded: [rate_limit_exceeded] slow down",
+		},
+		{
+			name:    "plain error gains the prefix",
+			err:     errors.New("boom"),
+			wantMsg: "API call failed: boom",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := WrapAPICall(tc.err)
+			require.Error(t, got)
+			assert.Equal(t, tc.wantMsg, got.Error())
+			require.ErrorIs(t, got, ErrAPICall, "the category must stay matchable")
+
+			var perr *ProviderError
+			if errors.As(tc.err, &perr) {
+				require.ErrorIs(t, got, perr.Base, "the specific classification must stay matchable")
+			}
+		})
+	}
+
+	assert.NoError(t, WrapAPICall(nil))
+}

--- a/plugins/otel/utils.go
+++ b/plugins/otel/utils.go
@@ -16,6 +16,7 @@ package otel
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 
 	"go.opentelemetry.io/otel/attribute"
@@ -61,8 +62,31 @@ func setSpanError(span trace.Span, err error) {
 
 	span.RecordError(err)
 	span.SetStatus(codes.Error, err.Error())
-	// Use concrete error type for better debugging (e.g., "*errors.errorString")
-	span.SetAttributes(errorType(fmt.Sprintf("%T", err)))
+
+	if t, ok := spanErrorType(err); ok {
+		span.SetAttributes(errorType(t))
+	}
+}
+
+// spanErrorType picks the error.type value for err: a low-cardinality class,
+// as the semantic conventions ask for. A *llm.ProviderError anywhere in the
+// chain contributes its provider code ("rate_limit_exceeded",
+// "guardrail_intervened"); other concrete types are named as before. The
+// stdlib wrapper types (fmt.Errorf with %w, errors.New, errors.Join) name
+// nothing about the failure — a wrapped error is always one of them — so they
+// yield no attribute rather than "*fmt.wrapErrors".
+func spanErrorType(err error) (string, bool) {
+	var perr *llm.ProviderError
+	if errors.As(err, &perr) && perr.Code != "" {
+		return perr.Code, true
+	}
+
+	switch t := fmt.Sprintf("%T", err); t {
+	case "*fmt.wrapError", "*fmt.wrapErrors", "*errors.errorString", "*errors.joinError":
+		return "", false
+	default:
+		return t, true
+	}
 }
 
 // setToolError records a tool-level error on a span.

--- a/plugins/otel/utils_errortype_test.go
+++ b/plugins/otel/utils_errortype_test.go
@@ -1,0 +1,60 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package otel
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/redpanda-data/ai-sdk-go/llm"
+)
+
+type customError struct{}
+
+func (customError) Error() string { return "custom" }
+
+func TestSpanErrorType(t *testing.T) {
+	t.Parallel()
+
+	perr := &llm.ProviderError{Base: llm.ErrAPICall, Code: "guardrail_intervened", Message: "blocked"}
+
+	tests := []struct {
+		name   string
+		err    error
+		want   string
+		wantOK bool
+	}{
+		{"provider error contributes its code", perr, "guardrail_intervened", true},
+		{"provider code survives wrapping", fmt.Errorf("agent: model generation failed: %w", llm.WrapAPICall(perr)), "guardrail_intervened", true},
+		{"provider error without a code falls through to its type", &llm.ProviderError{Base: llm.ErrServerError, Message: "x"}, "*llm.ProviderError", true},
+		{"fmt wrap of a plain error names nothing", fmt.Errorf("ctx: %w", errors.New("boom")), "", false},
+		{"multi-wrap names nothing", fmt.Errorf("%w: %w", llm.ErrAPICall, errors.New("boom")), "", false},
+		{"errors.New names nothing", errors.New("boom"), "", false},
+		{"errors.Join names nothing", errors.Join(errors.New("a"), errors.New("b")), "", false},
+		{"concrete custom type keeps its name", customError{}, "otel.customError", true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, ok := spanErrorType(tc.err)
+			assert.Equal(t, tc.wantOK, ok)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/providers/anthropic/model.go
+++ b/providers/anthropic/model.go
@@ -80,7 +80,7 @@ func (m *Model) Generate(ctx context.Context, req *llm.Request) (*llm.Response, 
 	if err != nil {
 		// Double-wrap: ErrAPICall (for backward compat) + classified error (e.g.
 		// ErrRateLimitExceeded) so both errors.Is checks work on the same error.
-		return nil, fmt.Errorf("%w: %w", llm.ErrAPICall, classifyError(err))
+		return nil, llm.WrapAPICall(classifyError(err))
 	}
 
 	// Convert Beta Messages API response back to our format
@@ -244,7 +244,7 @@ func (m *Model) GenerateEvents(ctx context.Context, req *llm.Request) iter.Seq2[
 		// Check for transport/cancellation errors
 		if err := stream.Err(); err != nil {
 			// See Generate for ErrAPICall double-wrap rationale.
-			yield(nil, fmt.Errorf("%w: %w", llm.ErrAPICall, classifyError(err)))
+			yield(nil, llm.WrapAPICall(classifyError(err)))
 			return
 		}
 

--- a/providers/bedrock/model.go
+++ b/providers/bedrock/model.go
@@ -88,7 +88,7 @@ func (m *Model) Generate(ctx context.Context, req *llm.Request) (*llm.Response, 
 
 	output, err := m.client.Converse(ctx, input)
 	if err != nil {
-		return nil, fmt.Errorf("%w: %w", llm.ErrAPICall, classifyError(err))
+		return nil, llm.WrapAPICall(classifyError(err))
 	}
 
 	return m.responseMapper.FromConverseOutput(
@@ -113,7 +113,7 @@ func (m *Model) GenerateEvents(ctx context.Context, req *llm.Request) iter.Seq2[
 
 		output, err := m.client.ConverseStream(ctx, input)
 		if err != nil {
-			yield(nil, fmt.Errorf("%w: %w", llm.ErrAPICall, classifyError(err)))
+			yield(nil, llm.WrapAPICall(classifyError(err)))
 			return
 		}
 
@@ -212,7 +212,7 @@ func (m *Model) GenerateEvents(ctx context.Context, req *llm.Request) iter.Seq2[
 
 		// Check for stream errors
 		if err := stream.Err(); err != nil {
-			yield(nil, fmt.Errorf("%w: %w", llm.ErrAPICall, classifyError(err)))
+			yield(nil, llm.WrapAPICall(classifyError(err)))
 			return
 		}
 

--- a/providers/google/model.go
+++ b/providers/google/model.go
@@ -89,7 +89,7 @@ func (m *Model) Generate(ctx context.Context, req *llm.Request) (*llm.Response, 
 	response, err := m.client.Models.GenerateContent(ctx, modelName, contents, config)
 	if err != nil {
 		// Double-wrap: see anthropic/model.go Generate for rationale.
-		return nil, fmt.Errorf("%w: %w", llm.ErrAPICall, classifyError(err))
+		return nil, llm.WrapAPICall(classifyError(err))
 	}
 
 	// Convert Gemini response back to our format
@@ -124,7 +124,7 @@ func (m *Model) GenerateEvents(ctx context.Context, req *llm.Request) iter.Seq2[
 		for response, err := range stream {
 			if err != nil {
 				// Double-wrap: see anthropic/model.go Generate for rationale.
-				yield(nil, fmt.Errorf("%w: %w", llm.ErrAPICall, classifyError(err)))
+				yield(nil, llm.WrapAPICall(classifyError(err)))
 				return
 			}
 

--- a/providers/openai/model.go
+++ b/providers/openai/model.go
@@ -79,7 +79,7 @@ func (m *Model) Generate(ctx context.Context, req *llm.Request) (*llm.Response, 
 	response, err := m.client.Responses.New(ctx, apiReq)
 	if err != nil {
 		// Double-wrap: see anthropic/model.go Generate for rationale.
-		return nil, fmt.Errorf("%w: %w", llm.ErrAPICall, classifyError(err))
+		return nil, llm.WrapAPICall(classifyError(err))
 	}
 
 	// Convert Responses API response back to our format
@@ -177,7 +177,7 @@ func (m *Model) GenerateEvents(ctx context.Context, req *llm.Request) iter.Seq2[
 		// Check for transport/cancellation errors
 		if err := stream.Err(); err != nil {
 			// Double-wrap: see anthropic/model.go Generate for rationale.
-			yield(nil, fmt.Errorf("%w: %w", llm.ErrAPICall, classifyError(err)))
+			yield(nil, llm.WrapAPICall(classifyError(err)))
 			return
 		}
 

--- a/providers/openaicompat/model.go
+++ b/providers/openaicompat/model.go
@@ -71,7 +71,7 @@ func (m *Model) Generate(ctx context.Context, req *llm.Request) (*llm.Response, 
 	response, err := m.client.Chat.Completions.New(ctx, apiReq, m.requestOptions()...)
 	if err != nil {
 		// Double-wrap: see anthropic/model.go Generate for rationale.
-		return nil, fmt.Errorf("%w: %w", llm.ErrAPICall, classifyError(err))
+		return nil, llm.WrapAPICall(classifyError(err))
 	}
 
 	// Convert Chat Completion API response back to our format
@@ -214,7 +214,7 @@ func (m *Model) GenerateEvents(ctx context.Context, req *llm.Request) iter.Seq2[
 		// Check for stream errors
 		if err := stream.Err(); err != nil {
 			// Double-wrap: see anthropic/model.go Generate for rationale.
-			yield(nil, fmt.Errorf("%w: %w", llm.ErrAPICall, classifyError(err)))
+			yield(nil, llm.WrapAPICall(classifyError(err)))
 
 			return
 		}


### PR DESCRIPTION
## What a failed model call looked like downstream

An agent whose LLM call was refused by the gateway (a guardrail block, HTTP 403) produced this turn in Redpanda's transcripts UI:

```
Turn failed · *fmt.wrapErrors
agent: model generation failed: API call failed: API call failed: [guardrail_intervened] Blocked by the demo guardrail: this topic is off limits.
```

Two defects in that line come from this SDK.

## 1. `error.type` = Go type of the error

`plugins/otel` `setSpanError` set `error.type` to `fmt.Sprintf("%T", err)`. Any wrapped error is one of the stdlib wrapper types, so the attribute was `*fmt.wrapErrors` / `*fmt.wrapError` / `*errors.errorString` — no information, and shown verbatim as the error code in transcripts.

Now `spanErrorType`:
- a `*llm.ProviderError` anywhere in the chain contributes its provider **code** (`rate_limit_exceeded`, `guardrail_intervened`) — the low-cardinality class the semantic conventions ask for;
- other concrete types keep their type name as before;
- the stdlib wrappers (`*fmt.wrapError`, `*fmt.wrapErrors`, `*errors.errorString`, `*errors.joinError`) record **no** `error.type`.

`tool_error` for tool-payload errors is untouched.

## 2. "API call failed: API call failed:"

Every provider wrapped the classified error with `ErrAPICall` a second time ("so both `errors.Is` checks work"). `classifyStatusCode` maps 401/403 to `ErrAPICall` itself, so the `*ProviderError` already rendered `API call failed: [code] message` and the outer wrap doubled the prefix.

`llm.WrapAPICall(err)` adds the category only when `errors.Is(err, ErrAPICall)` does not already hold. All eleven call sites (`anthropic`, `bedrock`, `google`, `openai`, `openaicompat`; `Generate` + `GenerateEvents`) use it. `errors.Is(err, ErrAPICall)` and `errors.Is(err, <specific>)` both still hold — pinned by the test.

## Tests

`llm/errors_wrap_test.go`, `plugins/otel/utils_errortype_test.go`. `task lint:new`, `task license:check`, unit tests for `llm`, `providers`, `plugins`, `agent`, `adapter` green.

Consumer-side follow-up (cloudv2): the transcripts assembler will prefer the step's error when the run's error merely wraps it, dropping the `agent: model generation failed:` prefix; then a go.mod bump to this change.
